### PR TITLE
feat:twelvedata API連携とロウソク足エンドポイントを追加

### DIFF
--- a/internal/domain/candle.go
+++ b/internal/domain/candle.go
@@ -1,0 +1,12 @@
+package domain
+
+import "time"
+
+type Candle struct {
+	Time   time.Time
+	Open   float64
+	High   float64
+	Low    float64
+	Close  float64
+	Volume int64
+}

--- a/internal/infrastructure/externalapi/twelvedata/config.go
+++ b/internal/infrastructure/externalapi/twelvedata/config.go
@@ -1,0 +1,27 @@
+package twelvedata
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"github.com/joho/godotenv"
+)
+
+type Config struct {
+	TwelveDataAPIKey string
+	BaseURL          string
+	Timeout          time.Duration
+}
+
+func LoadConfig() Config {
+	if err := godotenv.Load(); err != nil {
+		log.Println(".env ファイルが見つかりませんでした")
+	}
+
+	return Config{
+		TwelveDataAPIKey: os.Getenv("TWELVE_DATA_API_KEY"),
+		BaseURL:          os.Getenv("TWELVE_DATA_BASE_URL"),
+		Timeout:          10 * time.Second,
+	}
+}

--- a/internal/infrastructure/externalapi/twelvedata/market.go
+++ b/internal/infrastructure/externalapi/twelvedata/market.go
@@ -1,0 +1,112 @@
+package twelvedata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+	"todo_backend/internal/domain"
+	"todo_backend/internal/interface/dto"
+	"todo_backend/internal/interface/repository"
+)
+
+type TwelveDataMarket struct {
+	cfg    Config
+	client *http.Client
+}
+
+func NewTwelveDataMarket(cfg Config, client *http.Client) repository.MarketRepository {
+	return &TwelveDataMarket{cfg: cfg, client: client}
+}
+
+// GetTimeSeries は Twelve Data API から株価の時系列データを取得し、domain.Candle のスライスとして返します。
+func (t *TwelveDataMarket) GetTimeSeries(ctx context.Context, symbol, interval string, outputsize int) ([]domain.Candle, error) {
+	q := url.Values{}
+	// クエリの追加
+	q.Set("symbol", symbol)
+	q.Set("interval", interval)
+	q.Set("outputsize", strconv.Itoa(outputsize))
+	q.Set("apikey", t.cfg.TwelveDataAPIKey)
+
+	// URLの生成
+	u := fmt.Sprintf("%s/time_series?%s", t.cfg.BaseURL, q.Encode())
+
+	// リクエストオブジェクトの作成
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// リクエスト
+	res, err := t.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode >= 400 {
+		return nil, fmt.Errorf("twelvedata http %d", res.StatusCode)
+	}
+
+	// dto
+	var body dto.TimeSeriesResponse
+	// JSONを構造体にデコード
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+	if body.Status == "error" {
+		return nil, fmt.Errorf("twelvedata: %s", body.Message)
+	}
+
+	candles := make([]domain.Candle, 0, len(body.Values))
+	for _, v := range body.Values {
+
+		// 時間
+		tm, err := time.Parse("2006-01-02 15:04:05", v.Datetime)
+		if err != nil {
+			tm, err = time.Parse("2006-01-02", v.Datetime)
+			if err != nil {
+				return nil, fmt.Errorf("parse time %q: %w", v.Datetime, err)
+			}
+		}
+		//　始値
+		o, err := strconv.ParseFloat(v.Open, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse open %q: %w", v.Open, err)
+		}
+		// 高値
+		h, err := strconv.ParseFloat(v.High, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse high %q: %w", v.High, err)
+		}
+		// 安値
+		l, err := strconv.ParseFloat(v.Low, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse low %q: %w", v.Low, err)
+		}
+		// 現在値
+		c, err := strconv.ParseFloat(v.Close, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse close %q: %w", v.Close, err)
+		}
+		//出来高
+		vol64, err := strconv.ParseInt(v.Volume, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("parse volume %q: %w", v.Volume, err)
+		}
+
+		// domainに変換
+		candles = append(candles, domain.Candle{
+			Time:   tm,
+			Open:   o,
+			High:   h,
+			Low:    l,
+			Close:  c,
+			Volume: vol64,
+		})
+	}
+	return candles, nil
+}

--- a/internal/infrastructure/http/httpclient.go
+++ b/internal/infrastructure/http/httpclient.go
@@ -1,0 +1,35 @@
+package http
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// NewHTTPClient は外部API用の HTTP クライアントを生成します。
+//
+// 主な設定:
+//   - Proxy: 環境変数 (HTTP_PROXY など) があれば利用
+//   - Dialer.Timeout: TCP接続のタイムアウト (デフォルトより短めに設定)
+//   - Dialer.KeepAlive: 再利用可能なTCP接続を保持する時間
+//   - MaxIdleConns: 最大アイドル接続数 (大量リクエストでも枯渇しないように100)
+//   - IdleConnTimeout: アイドル状態の接続を保持する時間
+//   - TLSHandshakeTimeout: HTTPS ハンドシェイクの上限時間
+//   - Client.Timeout: リクエスト全体のタイムアウト (呼び出し元から渡す)
+//
+// ポイント:
+//   - http.DefaultClient はタイムアウトが無制限なので、必ずカスタムクライアントを使う
+//   - 外部APIとの通信安定性・リソース管理のため、Transport を明示的に設定している
+func NewHTTPClient(timeout time.Duration) *http.Client {
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:        100,
+		IdleConnTimeout:     90 * time.Second,
+		TLSHandshakeTimeout: 5 * time.Second,
+	}
+	return &http.Client{Timeout: timeout, Transport: t}
+}

--- a/internal/infrastructure/router.go
+++ b/internal/infrastructure/router.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func NewRouter(authHandler *handler.AuthHandler) *gin.Engine {
+func NewRouter(authHandler *handler.AuthHandler, candles *handler.CandlesHandler) *gin.Engine {
 	r := gin.Default()
 	// CORS のデフォルト設定を有効
 	r.Use(cors.Default())
@@ -26,7 +26,13 @@ func NewRouter(authHandler *handler.AuthHandler) *gin.Engine {
 	// → リクエストヘッダーに JWT が必要になる
 	auth.Use(jwtmw.AuthRequired())
 	{
+		auth.GET("/healthz", handler.Health)
+		auth.GET("/candles/:code", candles.GetCandlesHandler)
 	}
+
+	// TODO:開発用。不要になったら削除
+	// r.GET("/healthz", handler.Health)
+	// r.GET("/candles/:code", candles.GetCandlesHandler)
 
 	return r
 }

--- a/internal/interface/dto/candle_response.go
+++ b/internal/interface/dto/candle_response.go
@@ -1,0 +1,11 @@
+package dto
+
+// CandleResponse はロウソク足データのレスポンスDTOです。
+type CandleResponse struct {
+	Time   string  `json:"time"`   // 日付
+	Open   float64 `json:"open"`   // 始値
+	High   float64 `json:"high"`   // 高値
+	Low    float64 `json:"low"`    // 安値
+	Close  float64 `json:"close"`  // 終値
+	Volume int64   `json:"volume"` // 出来高
+}

--- a/internal/interface/dto/time_series_reponse.go
+++ b/internal/interface/dto/time_series_reponse.go
@@ -1,0 +1,16 @@
+package dto
+
+type TimeSeriesResponse struct {
+	Status   string `json:"status"`
+	Message  string `json:"message,omitempty"`
+	Symbol   string `json:"symbol"`
+	Interval string `json:"interval"`
+	Values   []struct {
+		Datetime string `json:"datetime"`
+		Open     string `json:"open"`
+		High     string `json:"high"`
+		Low      string `json:"low"`
+		Close    string `json:"close"`
+		Volume   string `json:"volume"`
+	} `json:"values"`
+}

--- a/internal/interface/handler/candles.go
+++ b/internal/interface/handler/candles.go
@@ -1,0 +1,54 @@
+// internal/handler/candles.go
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"todo_backend/internal/interface/dto"
+	"todo_backend/internal/usecase"
+
+	"github.com/gin-gonic/gin"
+)
+
+type CandlesHandler struct {
+	uc *usecase.CandlesUsecase
+}
+
+func NewCandlesHandler(uc *usecase.CandlesUsecase) *CandlesHandler {
+	return &CandlesHandler{uc: uc}
+}
+
+// GetCandles は銘柄コードと時間足を受け取り、ロウソク足データを JSON で返します。
+//
+// エンドポイント例
+// GET /candles/:code?interval=1day&outputsize=200
+func (h *CandlesHandler) GetCandlesHandler(c *gin.Context) {
+	code := c.Param("code")
+	// 指定されていない場合は以下を設定
+	interval := c.DefaultQuery("interval", "1day")
+	outputsizeStr := c.DefaultQuery("outputsize", "200")
+	// 文字列を数値に変換
+	outputsize, _ := strconv.Atoi(outputsizeStr)
+
+	candles, err := h.uc.GetCandles(c.Request.Context(), code, interval, outputsize)
+
+	if err != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
+		return
+	}
+
+	// データの整形
+	out := make([]dto.CandleResponse, 0, len(candles))
+	for _, x := range candles {
+		out = append(out, dto.CandleResponse{
+			Time:   x.Time.UTC().Format("2006-01-02"),
+			Open:   x.Open,
+			High:   x.High,
+			Low:    x.Low,
+			Close:  x.Close,
+			Volume: x.Volume,
+		})
+	}
+
+	c.JSON(http.StatusOK, out)
+}

--- a/internal/interface/handler/health.go
+++ b/internal/interface/handler/health.go
@@ -1,0 +1,7 @@
+package handler
+
+import "github.com/gin-gonic/gin"
+
+func Health(c *gin.Context) {
+	c.JSON(200, gin.H{"status": "ok"})
+}

--- a/internal/interface/repository/market_repository.go
+++ b/internal/interface/repository/market_repository.go
@@ -1,0 +1,12 @@
+package repository
+
+import (
+	"context"
+	"todo_backend/internal/domain"
+)
+
+// MarketRepository　は株価データを取得するリポジトリのインターフェイスです。
+// 外部 API の実装を抽象化します。
+type MarketRepository interface {
+	GetTimeSeries(ctx context.Context, symbol, interval string, outputsize int) ([]domain.Candle, error)
+}

--- a/internal/usecase/candles_usecase.go
+++ b/internal/usecase/candles_usecase.go
@@ -1,0 +1,27 @@
+package usecase
+
+import (
+	"context"
+	"todo_backend/internal/domain"
+	"todo_backend/internal/interface/repository"
+)
+
+type CandlesUsecase struct {
+	market repository.MarketRepository
+}
+
+func NewCandlesUsecase(market repository.MarketRepository) *CandlesUsecase {
+	return &CandlesUsecase{market: market}
+}
+
+// GetCandles は銘柄コードと時間足(interval)を指定してロウソク足データを取得します。
+func (cu *CandlesUsecase) GetCandles(ctx context.Context, symbol, interval string, outputsize int) ([]domain.Candle, error) {
+	if interval == "" {
+		interval = "1day"
+	}
+	if outputsize <= 0 || outputsize > 5000 {
+		outputsize = 200
+	}
+
+	return cu.market.GetTimeSeries(ctx, symbol, interval, outputsize)
+}


### PR DESCRIPTION
## 概要
twelvedata API連携とロウソク足エンドポイントを追加

## 変更内容
- twelvedata API連携
- ロウソク足のdomainを追加

## 背景・理由
株価のデータを外部APIから取得するため