### PR TITLE
ci: skip CI workflow for documentation-only changes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,13 @@ name: CI
 on:
     pull_request:
         branches: [main]
+        paths-ignore:
+            - "**.md"
+            - "docs/**"
+            - ".github/PULL_REQUEST_TEMPLATE.md"
+            - "CLAUDE.md"
+            - "README.md"
+            - "LICENSE"
 
 jobs:
     build-test:


### PR DESCRIPTION
Add paths-ignore to CI workflow to prevent running tests and builds when only documentation files are modified. This saves CI resources and speeds up documentation PRs.

Ignored paths:
- All markdown files (**.md)
- docs/ directory
- PR template
- License file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
