### PR TITLE
refactor: separate JWT generation logic from auth usecase

### DIFF
--- a/internal/platform/jwt/generator.go
+++ b/internal/platform/jwt/generator.go
@@ -1,0 +1,46 @@
+package jwtmw
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Generator defines the interface for JWT token generation.
+type Generator interface {
+	// GenerateToken creates a signed JWT token for the given user.
+	GenerateToken(userID uint, email string) (string, error)
+}
+
+// generator implements the Generator interface.
+type generator struct {
+	secret     []byte
+	expiration time.Duration
+}
+
+// NewGenerator creates a new JWT generator with the provided secret and expiration duration.
+func NewGenerator(secret string, expiration time.Duration) Generator {
+	return &generator{
+		secret:     []byte(secret),
+		expiration: expiration,
+	}
+}
+
+// GenerateToken creates a signed JWT token with standard claims.
+func (g *generator) GenerateToken(userID uint, email string) (string, error) {
+	claims := jwt.MapClaims{
+		"sub":   userID,
+		"exp":   time.Now().Add(g.expiration).Unix(),
+		"iat":   time.Now().Unix(),
+		"email": email,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(g.secret)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	return signed, nil
+}


### PR DESCRIPTION
## Summary
Extracted JWT token generation from auth usecase to a dedicated generator in the platform/jwt package, improving testability and separation of concerns.

## Changes
- Added `platform/jwt/generator.go` with Generator interface and implementation
- Updated auth usecase to accept JWTGenerator via dependency injection
- Removed direct dependencies on `os.Getenv()`, `time`, and `jwt` packages from usecase
- Updated all auth usecase tests to use mock JWT generator
- Moved JWT_SECRET validation to application startup in main.go
- Added new test case for JWT generation failure

## Benefits
- **Improved testability**: No environment variable dependencies in tests
- **Better separation of concerns**: Usecase focuses on business logic only
- **Reusability**: JWT generation can be used across features
- **Earlier error detection**: JWT_SECRET validation at startup instead of runtime

## Test plan
- [x] All existing auth usecase tests pass
- [x] New test case for JWT generation failure added
- [x] Build succeeds (`go build ./...`)
- [x] No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)