### PR TITLE
docs: fix incorrect .docker.env references to .env.docker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ go build ./...
 ```
 
 ### Environment Setup
-- Copy `example.env.docker` to `.docker.env` and configure:
+- Copy `example.env.docker` to `.env.docker` and configure:
   - `TWELVE_DATA_API_KEY`: Get from https://twelvedata.com/ (free tier: 8 req/min)
   - `JWT_SECRET`: Set a strong secret for production
   - DB and Redis configurations for local development

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ REST API として、ユーザー認証、株価データ提供、キャッシ�
 | DB            | MySQL / Cloud SQL                                                  |
 | Cache         | Redis                                                              |
 | Auth          | JWT / bcrypt                                                       |
-| Config        | **.docker.env（ローカル） / Secret Manager（本番） + os.Getenv()** |
+| Config        | **.env.docker（ローカル） / Secret Manager（本番） + os.Getenv()** |
 | Container     | Docker / Docker Compose                                            |
 | Cloud         | Google Cloud Run / Cloud SQL / Secret Manager / Artifact Registry  |
 | CI/CD         | GitHub Actions                                                     |
@@ -109,7 +109,7 @@ REST API として、ユーザー認証、株価データ提供、キャッシ�
 │   ├── docker-compose.dev.yml  # ローカル開発用オーバーライド構成
 │   └── mysql/                  # MySQL初期化スクリプト
 │
-├── .docker.env                 # ローカル環境変数（gitignore推奨）
+├── .env.docker                 # ローカル環境変数（gitignore推奨）
 ├── go.mod
 ├── go.sum
 └── .github/
@@ -179,7 +179,7 @@ REST API として、ユーザー認証、株価データ提供、キャッシ�
 - **Redis（Cloud Memorystore）**：キャッシュ管理
 - **Secret Manager**：API キー・DB パスワード・JWT 秘密鍵を安全に管理
 - 起動時に `os.Getenv()` + Secret Manager API でロード
-- **ローカル開発時は `.docker.env` から読み込み**
+- **ローカル開発時は `.env.docker` から読み込み**
 
 ## 🧪 CI/CD
 
@@ -194,7 +194,7 @@ REST API として、ユーザー認証、株価データ提供、キャッシ�
 
 - Docker / Docker Compose がインストール済み
 - Go は不要（すべて Docker で起動）
-- `.docker.env` にローカル環境変数を設定
+- `.env.docker` にローカル環境変数を設定
 
 ---
 
@@ -216,7 +216,7 @@ cp example.env.docker .env.docker
 
 1. Twelve Data の公式サイトでアカウントを作成
 2. 「Dashboard > API Keys」からキーを発行
-3. .docker.env の TWELVE_DATA_API_KEY にコピーして設定  
+3. .env.docker の TWELVE_DATA_API_KEY にコピーして設定
    例: `TWELVE_DATA_API_KEY=your_api_key_here`
 
 ### ⚠️ Twelve Data 無料プランの制約

--- a/internal/feature/auth/README.md
+++ b/internal/feature/auth/README.md
@@ -313,7 +313,7 @@ go test ./internal/feature/auth/... -v -race -cover
 |----------|-------------|----------|
 | `JWT_SECRET` | Secret key for signing JWT tokens | ✅ |
 
-**Configuration Example** (`.docker.env`):
+**Configuration Example** (`.env.docker`):
 ```
 JWT_SECRET=your-super-secret-key-change-this-in-production
 ```


### PR DESCRIPTION
## Summary
Fixes documentation inconsistency where the environment file was incorrectly referenced as `.docker.env` instead of the actual filename `.env.docker` used throughout the codebase.

## Problem

Multiple documentation files referenced the environment file as `.docker.env`, which **does not exist**. The actual file is `.env.docker`.

**Affected Documentation:**
- ❌ CLAUDE.md - "Copy `example.env.docker` to `.docker.env`"
- ❌ README.md - Multiple references (5 locations)
- ❌ internal/feature/auth/README.md - Configuration example

**Actual Codebase:**
```bash
# What actually exists
.env.docker           # ✅ Real environment file (gitignored)
example.env.docker    # ✅ Template (version controlled)

# What docker-compose uses
env_file:
  - ../.env.docker    # ✅ Correctly references .env.docker
```

## Solution

### Files Updated

1. **[CLAUDE.md](CLAUDE.md#L38)**
   - Environment Setup section
   - Fixed: `.docker.env` → `.env.docker`

2. **[README.md](README.md)** (5 locations)
   - Line 45: Tech stack table
   - Line 112: Directory structure
   - Line 182: Configuration description
   - Line 197: Setup prerequisites
   - Line 219: API key setup instructions

3. **[internal/feature/auth/README.md](internal/feature/auth/README.md#L316)**
   - Configuration example section

### Changes

| Before (Incorrect) | After (Correct) |
|-------------------|-----------------|
| `.docker.env` | `.env.docker` |

## Why `.env.docker` is Correct

### Industry Standard Pattern
- Follows `.env.<environment>` naming convention
- Examples: `.env.local`, `.env.production`, `.env.test`
- Consistent with [12 Factor App](https://12factor.net/) principles

### Tool Compatibility
- ✅ Works with dotenv libraries
- ✅ Recognized by docker-compose
- ✅ Matches `.gitignore` pattern `.env*`

### File Grouping
```bash
.env*         # All environment files grouped together
├── .env.docker
├── example.env.docker
└── .env.production  # Future environments follow same pattern
```

## Impact

### User Experience
- **Before**: Developers copy `example.env.docker` to `.docker.env` (wrong filename)
- **After**: Developers copy `example.env.docker` to `.env.docker` (correct filename)

### Consistency
- Documentation now matches codebase structure
- No confusion about which file docker-compose reads

### No Breaking Changes
- This is purely a documentation fix
- No code changes required
- Existing `.env.docker` files continue working

## Verification

```bash
# Verify docker-compose uses .env.docker
grep -r "env_file" docker/
# Output: docker/docker-compose.yml:      - ../.env.docker

# Verify no .docker.env references in code
find . -name "*.go" -o -name "*.yml" | xargs grep "\.docker\.env"
# Output: (none)
```

## Testing

- ✅ Documentation reviewed for consistency
- ✅ All references updated
- ✅ No code changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment configuration file naming conventions from `.docker.env` to `.env.docker` across documentation.
  * Revised setup instructions and guidance materials to reflect the updated configuration file reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->