### PR TITLE
feat: add /v1 prefix to API routes

### DIFF
--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -14,23 +14,23 @@ func NewRouter(authHandler *authhandler.AuthHandler, candles *candleshandler.Can
 	symbol *symbollisthandler.SymbolHandler) *gin.Engine {
 	r := gin.Default()
 
-	// Public routes (no authentication required)
-	// Health check endpoint
+	// Health check endpoint (unversioned)
 	r.GET("/healthz", handler.Health)
-	// New user registration
-	r.POST("/signup", authHandler.Signup)
-	// Login (JWT issuance)
-	r.POST("/login", authHandler.Login)
 
-	// Protected routes (authentication required)
-	// Create route group with r.Group("/")
-	auth := r.Group("/")
-	// Apply jwtmw.AuthRequired() middleware
-	// This requires JWT in the request header
-	auth.Use(jwtmw.AuthRequired())
+	// API v1 routes
+	v1 := r.Group("/v1")
 	{
-		auth.GET("/candles/:code", candles.GetCandlesHandler)
-		auth.GET("/symbols", symbol.List)
+		// Public routes (no authentication required)
+		v1.POST("/signup", authHandler.Signup)
+		v1.POST("/login", authHandler.Login)
+
+		// Protected routes (authentication required)
+		auth := v1.Group("/")
+		auth.Use(jwtmw.AuthRequired())
+		{
+			auth.GET("/candles/:code", candles.GetCandlesHandler)
+			auth.GET("/symbols", symbol.List)
+		}
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- Add `/v1` prefix to all API routes for versioning support
- Keep `/healthz` endpoint unversioned (infrastructure endpoint)

## Changes
| Before | After |
|--------|-------|
| `POST /signup` | `POST /v1/signup` |
| `POST /login` | `POST /v1/login` |
| `GET /candles/:code` | `GET /v1/candles/:code` |
| `GET /symbols` | `GET /v1/symbols` |
| `GET /healthz` | `GET /healthz` (unchanged) |

## Testing
- All existing tests pass (`go test ./... -race`)
- Linter passes (`golangci-lint run`)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * API endpoint paths have been reorganized under API versioning. Public authentication endpoints (signup/login) are now accessible at /v1 instead of the root path. Protected endpoints requiring authentication (candles and symbols) are located under /v1 with mandatory authentication enforcement. Health check endpoint remains at the unversioned /healthz path.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->