### PR TITLE
ci: lintとtestを並列ジョブに分割してCI実行時間を短縮

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
       - name: Check if only docs changed (PR diff)
         id: docs_check
         shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -euo pipefail
-
-          BASE_REF="${{ github.base_ref }}"
-          HEAD_REF="${{ github.head_ref }}"
 
           git fetch --no-tags --prune origin \
             "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}" \
@@ -37,6 +37,11 @@ jobs:
           CHANGED_FILES="$(git diff --name-only "origin/${BASE_REF}...origin/${HEAD_REF}")"
           echo "Changed files:"
           echo "${CHANGED_FILES}"
+
+          if [ -z "${CHANGED_FILES}" ]; then
+            echo "code_changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if echo "${CHANGED_FILES}" | grep -qvE '\.(md|txt)$|^docs/|^LICENSE$|^\.github/PULL_REQUEST_TEMPLATE\.md$'; then
             echo "code_changed=true" >> "$GITHUB_OUTPUT"
@@ -96,8 +101,13 @@ jobs:
     steps:
       - name: Check CI results
         run: |
-          if [[ "${{ needs.lint.result }}" == "failure" || "${{ needs.build-test.result }}" == "failure" ]]; then
+          LINT="${{ needs.lint.result }}"
+          BUILD_TEST="${{ needs.build-test.result }}"
+          echo "lint=${LINT} build-test=${BUILD_TEST}"
+          if [[ "${LINT}" == "success" || "${LINT}" == "skipped" ]] && \
+             [[ "${BUILD_TEST}" == "success" || "${BUILD_TEST}" == "skipped" ]]; then
+            echo "CI passed"
+          else
             echo "CI failed"
             exit 1
           fi
-          echo "CI passed"


### PR DESCRIPTION
## 概要
CIワークフローのlintとbuild-testを並列ジョブに分割し、CI全体の実行時間を短縮する。

## 変更内容
- 1つのジョブで直列実行していたlint/build/testを、`lint`と`build-test`の2ジョブに分割して並列実行
- `docs-check`を独立ジョブ化し、結果を`outputs`で後続ジョブに共有
- `fetch-depth: 0` → `2` に変更し、不要な全履歴クローンを廃止
- `setup-go`のキャッシュ機能に任せるため、`go mod download`ステップを削除

## テスト
- [ ] PRを作成してCIが正常に動作することを確認
- [ ] ドキュメントのみの変更でCIがスキップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CIワークフローをマルチジョブ化し、ドキュメントのみの変更を検出してコード変更がある場合のみリント・ビルド・テストを実行するようにしました。
  * リントとビルド/テストを並列化してフィードバックを短縮、最終的なゲートジョブで結果を集約して失敗時に通知します。
  * PR差分に基づく判定とジョブ依存の明確化で処理の効率と信頼性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->