### PR TITLE
feat: バッチ取り込み後にキャッシュをウォームアップする戦略に変更

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -3,13 +3,16 @@ package main
 import (
 	"context"
 	"log"
+	"log/slog"
 	"time"
 
 	"stock_backend/internal/app/di"
 	candlesadapters "stock_backend/internal/feature/candles/adapters"
 	candlesusecase "stock_backend/internal/feature/candles/usecase"
 	symbollistadapters "stock_backend/internal/feature/symbollist/adapters"
+	"stock_backend/internal/platform/cache"
 	"stock_backend/internal/platform/db"
+	infraredis "stock_backend/internal/platform/redis"
 	"stock_backend/internal/shared/ratelimiter"
 )
 
@@ -24,7 +27,23 @@ func main() {
 	symbolRepo := symbollistadapters.NewSymbolRepository(db)
 	rateLimiter := ratelimiter.NewRateLimiter(rateLimitPerMinute, time.Minute)
 
-	uc := candlesusecase.NewIngestUsecase(marketRepo, candleRepo, symbolRepo, rateLimiter)
+	// Redis接続（ベストエフォート: 接続失敗時はキャッシュウォームアップなしで続行）
+	var rdb interface{ Close() error }
+	ttl := cache.TimeUntilNext8AM()
+	cachedCandleRepo := candlesadapters.NewCachingCandleRepository(nil, ttl, candleRepo, "candles")
+	if tmp, err := infraredis.NewRedisClient(); err != nil {
+		slog.Warn("Redis unavailable, cache warm-up disabled", "error", err)
+	} else {
+		rdb = tmp
+		defer func() {
+			if err := rdb.Close(); err != nil {
+				slog.Error("Failed to close Redis client", "error", err)
+			}
+		}()
+		cachedCandleRepo = candlesadapters.NewCachingCandleRepository(tmp, ttl, candleRepo, "candles")
+	}
+
+	uc := candlesusecase.NewIngestUsecase(marketRepo, cachedCandleRepo, symbolRepo, rateLimiter)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()

--- a/internal/feature/candles/adapters/caching_candle_repository.go
+++ b/internal/feature/candles/adapters/caching_candle_repository.go
@@ -12,6 +12,10 @@ import (
 	"stock_backend/internal/feature/candles/domain/entity"
 )
 
+// maxCacheOutputSize はキャッシュに保存する最大ローソク足件数です。
+// usecaseのMaxOutputSizeと合わせています（依存ルール上usecaseをimport不可のためここで定義）。
+const maxCacheOutputSize = 5000
+
 // candleRepository はCachingCandleRepositoryが内部で必要とする読み書きインターフェースです。
 type candleRepository interface {
 	Find(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error)
@@ -44,7 +48,7 @@ func NewCachingCandleRepository(rdb *redis.Client, ttl time.Duration, inner cand
 	}
 }
 
-// UpsertBatch はローソク足データを挿入または更新し、関連するキャッシュエントリを無効化します。
+// UpsertBatch はローソク足データを挿入または更新し、キャッシュを最新データで更新します。
 func (c *CachingCandleRepository) UpsertBatch(ctx context.Context, candles []entity.Candle) error {
 	// まず基盤リポジトリにUpsert
 	if err := c.inner.UpsertBatch(ctx, candles); err != nil {
@@ -55,95 +59,85 @@ func (c *CachingCandleRepository) UpsertBatch(ctx context.Context, candles []ent
 		return nil
 	}
 
-	// 影響を受けるキャッシュエントリを無効化（symbol+intervalごとのキー）
-	seen := map[string]struct{}{}
+	// 影響を受ける symbol+interval を収集
+	type symbolInterval struct {
+		symbol   string
+		interval string
+	}
+	seen := map[symbolInterval]struct{}{}
 	for _, cd := range candles {
-		prefix := c.cacheKeyPrefix(cd.Symbol, cd.Interval)
-		if _, ok := seen[prefix]; ok {
-			continue
+		seen[symbolInterval{cd.Symbol, cd.Interval}] = struct{}{}
+	}
+
+	// 各 symbol+interval のキャッシュを削除し、最新データで再生成（ウォームアップ）
+	for si := range seen {
+		key := c.cacheKey(si.symbol, si.interval)
+		_ = c.rdb.Del(ctx, key).Err() // ベストエフォート
+
+		data, err := c.inner.Find(ctx, si.symbol, si.interval, maxCacheOutputSize)
+		if err != nil {
+			continue // ベストエフォート: エラー時はウォームアップをスキップ
 		}
-		seen[prefix] = struct{}{}
-		_ = c.deleteByPattern(ctx, prefix+"*") // ベストエフォート: キャッシュ削除失敗時もエラーにしない
+		if b, err := json.Marshal(data); err == nil {
+			_ = c.rdb.Set(ctx, key, b, c.ttl).Err() // ベストエフォート
+		}
 	}
 	return nil
 }
 
 // Find はローソク足データを取得します。まずキャッシュを確認し、なければデータベースにフォールバックします。
+// キャッシュには全データ（最大maxCacheOutputSize件）を保存し、outputsize件にスライスして返します。
 func (c *CachingCandleRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
 	// Redisが未設定の場合はキャッシュをバイパス
 	if c.rdb == nil {
 		return c.inner.Find(ctx, symbol, interval, outputsize)
 	}
 
-	key := c.cacheKey(symbol, interval, outputsize)
+	key := c.cacheKey(symbol, interval)
 
 	// 1) キャッシュを確認
 	if b, err := c.rdb.Get(ctx, key).Bytes(); err == nil && len(b) > 0 {
-		var out []entity.Candle
-		if err := json.Unmarshal(b, &out); err == nil {
-			return out, nil
+		var all []entity.Candle
+		if err := json.Unmarshal(b, &all); err == nil {
+			return sliceCandles(all, outputsize), nil
 		}
 		// 破損したキャッシュエントリを削除
 		_ = c.rdb.Del(ctx, key).Err()
 	}
 
-	// 2) データベースにフォールバック
-	out, err := c.inner.Find(ctx, symbol, interval, outputsize)
+	// 2) データベースにフォールバック（全データ取得してキャッシュに保存）
+	all, err := c.inner.Find(ctx, symbol, interval, maxCacheOutputSize)
 	if err != nil {
 		return nil, err
 	}
 
 	// 3) キャッシュに保存（ベストエフォート）
-	if b, err := json.Marshal(out); err == nil {
+	if b, err := json.Marshal(all); err == nil {
 		_ = c.rdb.Set(ctx, key, b, c.ttl).Err()
 	}
 
-	return out, nil
+	return sliceCandles(all, outputsize), nil
 }
 
-// cacheKey は特定のクエリ用のキャッシュキーを生成します。
-func (c *CachingCandleRepository) cacheKey(symbol, interval string, outputsize int) string {
-	return fmt.Sprintf("%s:%s:%s:%d",
-		c.namespace,
-		safeCacheKey(symbol),
-		safeCacheKey(interval),
-		outputsize,
-	)
-}
-
-// cacheKeyPrefix は関連するキャッシュエントリの無効化用プレフィックスを生成します。
-func (c *CachingCandleRepository) cacheKeyPrefix(symbol, interval string) string {
-	return fmt.Sprintf("%s:%s:%s:",
-		c.namespace,
-		safeCacheKey(symbol),
-		safeCacheKey(interval),
-	)
-}
-
-// deleteByPattern はSCANを使用して指定パターンに一致するすべてのキャッシュキーを削除します。
-func (c *CachingCandleRepository) deleteByPattern(ctx context.Context, pattern string) error {
-	var cursor uint64
-	for {
-		keys, cur, err := c.rdb.Scan(ctx, cursor, pattern, 200).Result()
-		if err != nil {
-			return err
-		}
-		if len(keys) > 0 {
-			if err := c.rdb.Del(ctx, keys...).Err(); err != nil {
-				return err
-			}
-		}
-		cursor = cur
-		if cursor == 0 {
-			break
-		}
+// sliceCandles は全ローソク足データから先頭 outputsize 件を返します。
+func sliceCandles(all []entity.Candle, outputsize int) []entity.Candle {
+	if outputsize <= 0 || outputsize >= len(all) {
+		return all
 	}
-	return nil
+	return all[:outputsize]
+}
+
+// cacheKey はキャッシュキーを生成します。
+func (c *CachingCandleRepository) cacheKey(symbol, interval string) string {
+	return fmt.Sprintf("%s:%s:%s",
+		c.namespace,
+		safeCacheKey(symbol),
+		safeCacheKey(interval),
+	)
 }
 
 // safeCacheKey はRedisキーで問題となる文字をエスケープします。
 func safeCacheKey(s string) string {
-	// Redisキーで問題となる文字の簡易エスケープ
 	s = strings.ReplaceAll(s, " ", "_")
 	s = strings.ReplaceAll(s, ":", "_")
 	return s

--- a/internal/feature/candles/adapters/caching_candle_repository_test.go
+++ b/internal/feature/candles/adapters/caching_candle_repository_test.go
@@ -122,7 +122,8 @@ func TestCachingCandleRepository_Find_CacheHit(t *testing.T) {
 	}
 	cachedJSON, _ := json.Marshal(cachedCandles)
 
-	mock.ExpectGet("candles:AAPL:1day:100").SetVal(string(cachedJSON))
+	// キャッシュキーは outputsize を含まない
+	mock.ExpectGet("candles:AAPL:1day").SetVal(string(cachedJSON))
 
 	innerCalled := false
 	inner := &mockCandleRepo{
@@ -148,7 +149,42 @@ func TestCachingCandleRepository_Find_CacheHit(t *testing.T) {
 	}
 }
 
-// TestCachingCandleRepository_Find_CacheMiss はキャッシュミス時にDBからデータを取得し、キャッシュに保存することを検証します。
+// TestCachingCandleRepository_Find_CacheHit_Slices はキャッシュに複数件ある場合にoutputsize件にスライスして返すことを検証します。
+func TestCachingCandleRepository_Find_CacheHit_Slices(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	// キャッシュには5件保存されている
+	cachedCandles := []entity.Candle{
+		{Symbol: "AAPL", Interval: "1day", Open: 100.0},
+		{Symbol: "AAPL", Interval: "1day", Open: 101.0},
+		{Symbol: "AAPL", Interval: "1day", Open: 102.0},
+		{Symbol: "AAPL", Interval: "1day", Open: 103.0},
+		{Symbol: "AAPL", Interval: "1day", Open: 104.0},
+	}
+	cachedJSON, _ := json.Marshal(cachedCandles)
+
+	mock.ExpectGet("candles:AAPL:1day").SetVal(string(cachedJSON))
+
+	inner := &mockCandleRepo{}
+	repo := NewCachingCandleRepository(rdb, 5*time.Minute, inner, "candles")
+
+	// outputsize=3 を指定 → 先頭3件のみ返る
+	candles, err := repo.Find(context.Background(), "AAPL", "1day", 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candles) != 3 {
+		t.Errorf("expected 3 candles, got %d", len(candles))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestCachingCandleRepository_Find_CacheMiss はキャッシュミス時にDBから全データを取得し、キャッシュに保存してoutputsize件を返すことを検証します。
 func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 	t.Parallel()
 
@@ -161,12 +197,16 @@ func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 	expectedJSON, _ := json.Marshal(expectedCandles)
 
 	// Cache miss
-	mock.ExpectGet("candles:AAPL:1day:100").RedisNil()
-	// Set cache after fetching from inner
-	mock.ExpectSet("candles:AAPL:1day:100", expectedJSON, 5*time.Minute).SetVal("OK")
+	mock.ExpectGet("candles:AAPL:1day").RedisNil()
+	// Set cache after fetching from inner (全データで保存)
+	mock.ExpectSet("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal("OK")
 
 	inner := &mockCandleRepo{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
+			// maxCacheOutputSize(5000) で呼ばれることを検証
+			if outputsize != maxCacheOutputSize {
+				t.Errorf("expected outputsize %d, got %d", maxCacheOutputSize, outputsize)
+			}
 			return expectedCandles, nil
 		},
 	}
@@ -193,7 +233,7 @@ func TestCachingCandleRepository_Find_InnerError(t *testing.T) {
 
 	expectedErr := errors.New("database error")
 
-	mock.ExpectGet("candles:AAPL:1day:100").RedisNil()
+	mock.ExpectGet("candles:AAPL:1day").RedisNil()
 
 	inner := &mockCandleRepo{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
@@ -225,11 +265,11 @@ func TestCachingCandleRepository_Find_CorruptedCache(t *testing.T) {
 	expectedJSON, _ := json.Marshal(expectedCandles)
 
 	// Return invalid JSON from cache
-	mock.ExpectGet("candles:AAPL:1day:100").SetVal("invalid json")
+	mock.ExpectGet("candles:AAPL:1day").SetVal("invalid json")
 	// Delete corrupted cache
-	mock.ExpectDel("candles:AAPL:1day:100").SetVal(1)
+	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
 	// Set new cache after fetching from inner
-	mock.ExpectSet("candles:AAPL:1day:100", expectedJSON, 5*time.Minute).SetVal("OK")
+	mock.ExpectSet("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal("OK")
 
 	inner := &mockCandleRepo{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
@@ -315,22 +355,30 @@ func TestCachingCandleRepository_UpsertBatch_EmptyCandles(t *testing.T) {
 	}
 }
 
-// TestCachingCandleRepository_UpsertBatch_CacheInvalidation はUpsertBatch後に関連するキャッシュが無効化されることを検証します。
-func TestCachingCandleRepository_UpsertBatch_CacheInvalidation(t *testing.T) {
+// TestCachingCandleRepository_UpsertBatch_CacheWarmUp はUpsertBatch後にキャッシュが削除され最新データで再生成されることを検証します。
+func TestCachingCandleRepository_UpsertBatch_CacheWarmUp(t *testing.T) {
 	t.Parallel()
 
 	rdb, mock := redismock.NewClientMock()
 	defer func() { _ = rdb.Close() }()
 
+	warmCandles := []entity.Candle{
+		{Symbol: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+	}
+	warmJSON, _ := json.Marshal(warmCandles)
+
 	inner := &mockCandleRepo{
 		upsertBatchFn: func(ctx context.Context, candles []entity.Candle) error {
 			return nil
 		},
+		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
+			return warmCandles, nil
+		},
 	}
 
-	// Expect cache invalidation via SCAN and DEL
-	mock.ExpectScan(0, "candles:AAPL:1day:*", 200).SetVal([]string{"candles:AAPL:1day:100", "candles:AAPL:1day:200"}, 0)
-	mock.ExpectDel("candles:AAPL:1day:100", "candles:AAPL:1day:200").SetVal(2)
+	// 既存キャッシュを削除してから最新データで再生成
+	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
+	mock.ExpectSet("candles:AAPL:1day", warmJSON, 5*time.Minute).SetVal("OK")
 
 	repo := NewCachingCandleRepository(rdb, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []entity.Candle{
@@ -344,21 +392,32 @@ func TestCachingCandleRepository_UpsertBatch_CacheInvalidation(t *testing.T) {
 	}
 }
 
-// TestCachingCandleRepository_UpsertBatch_DeduplicatesInvalidation は同一symbol+intervalのキャッシュ無効化が重複せず1回のみ実行されることを検証します。
-func TestCachingCandleRepository_UpsertBatch_DeduplicatesInvalidation(t *testing.T) {
+// TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp は同一symbol+intervalのウォームアップが重複せず1回のみ実行されることを検証します。
+func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
 	t.Parallel()
 
 	rdb, mock := redismock.NewClientMock()
 	defer func() { _ = rdb.Close() }()
 
+	warmCandles := []entity.Candle{
+		{Symbol: "AAPL", Interval: "1day", Open: 150.0},
+	}
+	warmJSON, _ := json.Marshal(warmCandles)
+
+	findCallCount := 0
 	inner := &mockCandleRepo{
 		upsertBatchFn: func(ctx context.Context, candles []entity.Candle) error {
 			return nil
 		},
+		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
+			findCallCount++
+			return warmCandles, nil
+		},
 	}
 
-	// Only expect one SCAN call for AAPL:1day despite multiple candles
-	mock.ExpectScan(0, "candles:AAPL:1day:*", 200).SetVal([]string{}, 0)
+	// AAPL:1day が3件あっても DEL と SET は1回ずつのみ
+	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
+	mock.ExpectSet("candles:AAPL:1day", warmJSON, 5*time.Minute).SetVal("OK")
 
 	repo := NewCachingCandleRepository(rdb, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []entity.Candle{
@@ -368,6 +427,9 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesInvalidation(t *testing
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if findCallCount != 1 {
+		t.Errorf("expected inner.Find to be called once, got %d", findCallCount)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unfulfilled mock expectations: %v", err)


### PR DESCRIPTION
## 概要
バッチ取り込み（ingest）実行後、APIへの最初のリクエストが必ずDBを叩いていた問題を解消する。
UpsertBatch後にキャッシュを削除→最新データで再生成（ウォームアップ）することで、
バッチ直後のAPIリクエストもキャッシュヒットするようになる。

## 変更内容
- キャッシュキーから `outputsize` を除去（`candles:{symbol}:{interval}:{outputsize}` → `candles:{symbol}:{interval}`）
- キャッシュに全データ（最大5000件）を1エントリとして保存し、`Find()` 呼び出し時に `outputsize` 件にスライスして返す
- `UpsertBatch()` の動作を「キャッシュ削除のみ」から「削除→DBから再取得→キャッシュ再生成」に変更
- `cmd/ingest/main.go` にRedis接続を追加し、`CachingCandleRepository` でラップ（Redis未接続時はウォームアップなしで続行）

## レビューポイント
- Redisキーの形式変更により既存の旧フォーマットキー（`candles:AAPL:1day:200` 等）は自然にTTL期限切れとなる（移行済み）
- ウォームアップ処理は全てベストエフォート（失敗してもバッチ処理は続行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * キャンドルデータのRedisキャッシング機能を強化し、起動時の自動初期化に対応しました。接続失敗時は自動的にフォールバック処理を実行します。

* **改善**
  * キャッシュキー戦略を最適化し、キャッシュヒット時のデータ取得効率を向上させました。
  * キャッシュの自動ウォームアップ機能を実装し、パフォーマンスを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->