### PR TITLE
feat: XSS/CSRF対策としてJWTをhttpOnly Cookieに移行し、セキュリティヘッダーを追加

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,6 +39,8 @@ linters:
               desc: "domain/usecase must not depend on transport"
             - pkg: "stock_backend/internal/api"
               desc: "domain/usecase must not depend on API types (transport layer only)"
+            - pkg: "stock_backend/internal/platform/csrf"
+              desc: "domain/usecase must not depend on csrf middleware"
 
         # feature同士の依存禁止
         auth-isolation:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -40,7 +40,19 @@ linters:
             - pkg: "stock_backend/internal/api"
               desc: "domain/usecase must not depend on API types (transport layer only)"
             - pkg: "stock_backend/internal/platform/csrf"
-              desc: "domain/usecase must not depend on csrf middleware"
+              desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/cache"
+              desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/db"
+              desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/http"
+              desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/jwt"
+              desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/redis"
+              desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/ratelimit"
+              desc: "domain/usecase must not depend on platform packages"
 
         # feature同士の依存禁止
         auth-isolation:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -224,6 +224,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+          csrfHeader: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -240,6 +241,12 @@ paths:
                 $ref: "#/components/schemas/MessageResponse"
         "400":
           description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: CSRFトークン不一致
           content:
             application/json:
               schema:
@@ -265,6 +272,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+          csrfHeader: []
         - bearerAuth: []
       parameters:
         - name: code
@@ -276,6 +284,12 @@ paths:
       responses:
         "204":
           description: 削除成功
+        "403":
+          description: CSRFトークン不一致
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: ウォッチリストに存在しない
           content:
@@ -291,6 +305,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+          csrfHeader: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -307,6 +322,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: CSRFトークン不一致
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/logo/detect:
     post:
@@ -316,6 +337,7 @@ paths:
         - logo
       security:
         - cookieAuth: []
+          csrfHeader: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -345,6 +367,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: CSRFトークン不一致
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "502":
           description: 外部API通信エラー
           content:
@@ -360,6 +388,7 @@ paths:
         - logo
       security:
         - cookieAuth: []
+          csrfHeader: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -376,6 +405,12 @@ paths:
                 $ref: "#/components/schemas/CompanyAnalysisResponse"
         "400":
           description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: CSRFトークン不一致
           content:
             application/json:
               schema:
@@ -397,6 +432,11 @@ components:
       type: apiKey
       in: cookie
       name: auth_token
+    csrfHeader:
+      type: apiKey
+      in: header
+      name: X-CSRF-Token
+      description: Cookie認証使用時に必須。csrf_token CookieをJavaScriptで読み取り、このヘッダーにセットする（Double Submit Cookieパターン）
 
   schemas:
     SignupRequest:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -79,11 +79,11 @@ paths:
               $ref: "#/components/schemas/LoginRequest"
       responses:
         "200":
-          description: 認証成功
+          description: 認証成功（auth_token・csrf_token CookieをSet-Cookieで発行）
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TokenResponse"
+                $ref: "#/components/schemas/MessageResponse"
         "400":
           description: バリデーションエラー
           content:
@@ -108,6 +108,20 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
 
+  /v1/logout:
+    delete:
+      summary: ログアウト
+      operationId: logout
+      tags:
+        - auth
+      responses:
+        "200":
+          description: ログアウト成功（auth_token・csrf_token Cookieを削除）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageResponse"
+
   /v1/candles/{code}:
     get:
       summary: ローソク足データ取得
@@ -115,6 +129,7 @@ paths:
       tags:
         - candles
       security:
+        - cookieAuth: []
         - bearerAuth: []
       parameters:
         - name: code
@@ -160,6 +175,7 @@ paths:
       tags:
         - symbols
       security:
+        - cookieAuth: []
         - bearerAuth: []
       responses:
         "200":
@@ -184,6 +200,7 @@ paths:
       tags:
         - watchlist
       security:
+        - cookieAuth: []
         - bearerAuth: []
       responses:
         "200":
@@ -206,6 +223,7 @@ paths:
       tags:
         - watchlist
       security:
+        - cookieAuth: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -246,6 +264,7 @@ paths:
       tags:
         - watchlist
       security:
+        - cookieAuth: []
         - bearerAuth: []
       parameters:
         - name: code
@@ -271,6 +290,7 @@ paths:
       tags:
         - watchlist
       security:
+        - cookieAuth: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -295,6 +315,7 @@ paths:
       tags:
         - logo
       security:
+        - cookieAuth: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -338,6 +359,7 @@ paths:
       tags:
         - logo
       security:
+        - cookieAuth: []
         - bearerAuth: []
       requestBody:
         required: true
@@ -371,6 +393,10 @@ components:
       type: http
       scheme: bearer
       bearerFormat: JWT
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: auth_token
 
   schemas:
     SignupRequest:

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -136,8 +137,15 @@ func main() {
 	logoUC := logousecase.NewLogoDetectionUsecase(visionDetector, geminiAnalyzer)
 	watchlistUC := watchlistusecase.NewWatchlistUsecase(watchlistRepo, symbolRepo)
 
-	// APP_ENV=production の場合のみ Secure Cookie を有効化
+	// COOKIE_SECURE を優先し、未設定なら APP_ENV=production をフォールバックとして使用
 	secureCookie := os.Getenv("APP_ENV") == "production"
+	if raw := os.Getenv("COOKIE_SECURE"); raw != "" {
+		if parsed, err := strconv.ParseBool(raw); err == nil {
+			secureCookie = parsed
+		} else {
+			slog.Warn("invalid COOKIE_SECURE value, falling back to default", "value", raw, "default", secureCookie)
+		}
+	}
 
 	// ハンドラー
 	authH := authhandler.NewAuthHandler(authUC, rateLimiter, secureCookie, watchlistUC)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -136,8 +136,11 @@ func main() {
 	logoUC := logousecase.NewLogoDetectionUsecase(visionDetector, geminiAnalyzer)
 	watchlistUC := watchlistusecase.NewWatchlistUsecase(watchlistRepo, symbolRepo)
 
+	// APP_ENV=production の場合のみ Secure Cookie を有効化
+	secureCookie := os.Getenv("APP_ENV") == "production"
+
 	// ハンドラー
-	authH := authhandler.NewAuthHandler(authUC, rateLimiter, watchlistUC)
+	authH := authhandler.NewAuthHandler(authUC, rateLimiter, secureCookie, watchlistUC)
 	symbolH := symbollisthandler.NewSymbolHandler(symbolUC)
 	candlesH := candleshandler.NewCandlesHandler(candlesUC)
 	logoH := logohandler.NewLogoDetectionHandler(logoUC)

--- a/example.env.docker
+++ b/example.env.docker
@@ -17,6 +17,11 @@ CORS_ALLOWED_ORIGINS=http://localhost:3000
 # JWT
 JWT_SECRET=your_jwt_secret_here
 
+# Cookie Secure フラグ（本番環境では true に変更すること）
+# true: HTTPS のみで Cookie を送信（本番必須）
+# false: HTTP でも Cookie を送信（ローカル開発用）
+COOKIE_SECURE=false
+
 # Password Pepper（パスワードハッシュ用ペッパー）
 PASSWORD_PEPPER=your_password_pepper_here
 

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	BearerAuthScopes = "bearerAuth.Scopes"
+	CookieAuthScopes = "cookieAuth.Scopes"
 )
 
 // AddWatchlistRequest defines model for AddWatchlistRequest.
@@ -110,12 +111,6 @@ type SymbolItem struct {
 
 	// Name 企業名
 	Name string `json:"name"`
-}
-
-// TokenResponse defines model for TokenResponse.
-type TokenResponse struct {
-	// Token JWTトークン
-	Token string `json:"token"`
 }
 
 // WatchlistItem defines model for WatchlistItem.

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -12,7 +12,9 @@ import (
 	logohandler "stock_backend/internal/feature/logodetection/transport/handler"
 	symbollisthandler "stock_backend/internal/feature/symbollist/transport/handler"
 	watchlisthandler "stock_backend/internal/feature/watchlist/transport/handler"
+	csrfmw "stock_backend/internal/platform/csrf"
 	handler "stock_backend/internal/platform/http/handler"
+	httpmw "stock_backend/internal/platform/http/middleware"
 	jwtmw "stock_backend/internal/platform/jwt"
 	"stock_backend/internal/platform/ratelimit"
 )
@@ -34,10 +36,11 @@ func NewRouter(authHandler *authhandler.AuthHandler, candles *candleshandler.Can
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     allowedOrigins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
-		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization", "X-CSRF-Token"},
 		AllowCredentials: true,
 		MaxAge:           12 * time.Hour,
 	}))
+	r.Use(httpmw.SecurityHeaders())
 
 	// 画像アップロードのサイズ制限を設定（10MB）
 	r.MaxMultipartMemory = 10 << 20
@@ -65,10 +68,13 @@ func NewRouter(authHandler *authhandler.AuthHandler, candles *candleshandler.Can
 			}),
 			authHandler.Login,
 		)
+		// 期限切れトークンでもログアウトできるよう認証不要
+		v1.DELETE("/logout", authHandler.Logout)
 
-		// 保護ルート（認証必須）
+		// 保護ルート（認証必須・CSRF保護）
 		auth := v1.Group("/")
 		auth.Use(jwtmw.AuthRequired())
+		auth.Use(csrfmw.Protect())
 		{
 			auth.GET("/candles/:code", candles.GetCandlesHandler)
 			auth.GET("/symbols", symbol.List)

--- a/internal/feature/auth/transport/handler/auth_handler.go
+++ b/internal/feature/auth/transport/handler/auth_handler.go
@@ -119,17 +119,19 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	// auth_token: httpOnly Cookie（JavaScriptから読み取り不可 → XSS対策）
-	c.SetSameSite(http.SameSiteLaxMode)
-	c.SetCookie("auth_token", token, 3600, "/", "", h.secureCookie, true)
-
-	// csrf_token: 非httpOnly Cookie（JavaScriptが読み取りX-CSRF-Tokenヘッダーにセット → CSRF対策）
+	// CSRFトークンを先に生成（失敗した場合はCookieを設定しない → 部分ログイン状態を防止）
 	csrfToken, err := csrf.GenerateToken()
 	if err != nil {
 		slog.Error("failed to generate csrf token", "error", err)
 		c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: "internal error"})
 		return
 	}
+
+	// 両トークンが揃ってからCookieをセット（原子性保証）
+	// auth_token: httpOnly Cookie（JavaScriptから読み取り不可 → XSS対策）
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("auth_token", token, 3600, "/", "", h.secureCookie, true)
+	// csrf_token: 非httpOnly Cookie（JavaScriptが読み取りX-CSRF-Tokenヘッダーにセット → CSRF対策）
 	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie("csrf_token", csrfToken, 3600, "/", "", h.secureCookie, false)
 

--- a/internal/feature/auth/transport/handler/auth_handler.go
+++ b/internal/feature/auth/transport/handler/auth_handler.go
@@ -128,6 +128,8 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	}
 
 	// 両トークンが揃ってからCookieをセット（原子性保証）
+	// GinのSetSameSiteは直後のSetCookie1回にのみ適用されリセットされる仕様のため、
+	// Cookieごとに毎回SetSameSiteを呼ぶ必要がある。
 	// auth_token: httpOnly Cookie（JavaScriptから読み取り不可 → XSS対策）
 	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie("auth_token", token, 3600, "/", "", h.secureCookie, true)
@@ -142,6 +144,9 @@ func (h *AuthHandler) Login(c *gin.Context) {
 // Logout はauth_tokenとcsrf_tokenのCookieを削除してログアウトします。
 // 期限切れトークンでも動作するよう認証不要のルートに配置します。
 func (h *AuthHandler) Logout(c *gin.Context) {
+	// GinのSetSameSiteは直後のSetCookie1回にのみ適用されリセットされる仕様のため、
+	// Cookieごとに毎回SetSameSiteを呼ぶ必要がある。
+	// MaxAge=-1 はGinがMax-Age=0に変換し、ブラウザにCookieの即時削除を指示する。
 	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie("auth_token", "", -1, "/", "", h.secureCookie, true)
 

--- a/internal/feature/auth/transport/handler/auth_handler.go
+++ b/internal/feature/auth/transport/handler/auth_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"stock_backend/internal/api"
+	"stock_backend/internal/platform/csrf"
 	"stock_backend/internal/platform/ratelimit"
 )
 
@@ -39,16 +40,18 @@ const (
 // AuthHandler は認証操作のHTTPリクエストを処理します。
 // AuthUsecaseインターフェースに依存し、JSONリクエスト/レスポンスを処理します。
 type AuthHandler struct {
-	auth      AuthUsecase
-	limiter   *ratelimit.Limiter
-	postHooks []PostSignupHook
+	auth         AuthUsecase
+	limiter      *ratelimit.Limiter
+	secureCookie bool
+	postHooks    []PostSignupHook
 }
 
 // NewAuthHandler はAuthHandlerの新しいインスタンスを生成します。
 // 依存性注入用のコンストラクタで、外部からAuthUsecaseとレートリミッターを注入します。
+// secureCookie が true の場合、Secure属性付きのCookieを設定します（本番環境用）。
 // postHooks にはサインアップ後に実行するフックを任意で渡せます。
-func NewAuthHandler(auth AuthUsecase, limiter *ratelimit.Limiter, postHooks ...PostSignupHook) *AuthHandler {
-	return &AuthHandler{auth: auth, limiter: limiter, postHooks: postHooks}
+func NewAuthHandler(auth AuthUsecase, limiter *ratelimit.Limiter, secureCookie bool, postHooks ...PostSignupHook) *AuthHandler {
+	return &AuthHandler{auth: auth, limiter: limiter, secureCookie: secureCookie, postHooks: postHooks}
 }
 
 // Signup はユーザー登録APIエンドポイントを処理します。
@@ -115,6 +118,33 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, api.ErrorResponse{Error: "invalid email or password"})
 		return
 	}
+
+	// auth_token: httpOnly Cookie（JavaScriptから読み取り不可 → XSS対策）
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("auth_token", token, 3600, "/", "", h.secureCookie, true)
+
+	// csrf_token: 非httpOnly Cookie（JavaScriptが読み取りX-CSRF-Tokenヘッダーにセット → CSRF対策）
+	csrfToken, err := csrf.GenerateToken()
+	if err != nil {
+		slog.Error("failed to generate csrf token", "error", err)
+		c.JSON(http.StatusInternalServerError, api.ErrorResponse{Error: "internal error"})
+		return
+	}
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("csrf_token", csrfToken, 3600, "/", "", h.secureCookie, false)
+
 	slog.Info("user login successful", "email", req.Email, "remote_addr", c.ClientIP())
-	c.JSON(http.StatusOK, api.TokenResponse{Token: token})
+	c.JSON(http.StatusOK, api.MessageResponse{Message: "ok"})
+}
+
+// Logout はauth_tokenとcsrf_tokenのCookieを削除してログアウトします。
+// 期限切れトークンでも動作するよう認証不要のルートに配置します。
+func (h *AuthHandler) Logout(c *gin.Context) {
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("auth_token", "", -1, "/", "", h.secureCookie, true)
+
+	c.SetSameSite(http.SameSiteLaxMode)
+	c.SetCookie("csrf_token", "", -1, "/", "", h.secureCookie, false)
+
+	c.JSON(http.StatusOK, api.MessageResponse{Message: "ok"})
 }

--- a/internal/feature/auth/transport/handler/auth_handler_test.go
+++ b/internal/feature/auth/transport/handler/auth_handler_test.go
@@ -287,9 +287,9 @@ func TestAuthHandler_Logout(t *testing.T) {
 	h := handler.NewAuthHandler(&mockAuthUsecase{}, nil, false)
 
 	router := gin.New()
-	router.POST("/logout", h.Logout)
+	router.DELETE("/logout", h.Logout)
 
-	w := makeRequest(t, router, http.MethodPost, "/logout", gin.H{})
+	w := makeRequest(t, router, http.MethodDelete, "/logout", gin.H{})
 
 	assert.Equal(t, http.StatusOK, w.Code)
 

--- a/internal/feature/auth/transport/handler/auth_handler_test.go
+++ b/internal/feature/auth/transport/handler/auth_handler_test.go
@@ -124,7 +124,7 @@ func TestAuthHandler_Signup(t *testing.T) {
 			t.Parallel()
 
 			mockUC := &mockAuthUsecase{SignupFunc: tt.mockSignupFunc}
-			h := handler.NewAuthHandler(mockUC, nil)
+			h := handler.NewAuthHandler(mockUC, nil, false)
 
 			router := gin.New()
 			router.POST("/signup", h.Signup)
@@ -159,7 +159,7 @@ func TestAuthHandler_Login_RateLimited(t *testing.T) {
 			return "", errors.New("should not be called")
 		},
 	}
-	h := handler.NewAuthHandler(mockUC, limiter)
+	h := handler.NewAuthHandler(mockUC, limiter, false)
 
 	router := gin.New()
 	router.POST("/login", h.Login)
@@ -197,7 +197,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			requestBody:    gin.H{"email": "test@example.com", "password": "password123"},
 			mockLoginFunc:  func(ctx context.Context, email, password string) (string, error) { return "dummy-jwt-token", nil },
 			expectedStatus: http.StatusOK,
-			expectedBody:   gin.H{"token": "dummy-jwt-token"},
+			expectedBody:   gin.H{"message": "ok"},
 		},
 		{
 			name:           "failure: invalid email address",
@@ -238,7 +238,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			t.Parallel()
 
 			mockUC := &mockAuthUsecase{LoginFunc: tt.mockLoginFunc}
-			h := handler.NewAuthHandler(mockUC, nil)
+			h := handler.NewAuthHandler(mockUC, nil, false)
 
 			router := gin.New()
 			router.POST("/login", h.Login)

--- a/internal/feature/auth/transport/handler/auth_handler_test.go
+++ b/internal/feature/auth/transport/handler/auth_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -74,6 +75,31 @@ func assertJSONResponse(t *testing.T, w *httptest.ResponseRecorder, expectedStat
 	require.NoError(t, err)
 
 	assert.Equal(t, expectedBody, responseBody)
+}
+
+// assertLoginCookies はログイン成功時のSet-CookieヘッダーにCookieが正しく設定されていることを検証します。
+func assertLoginCookies(t *testing.T, w *httptest.ResponseRecorder) {
+	t.Helper()
+
+	var authTokenCookie, csrfTokenCookie string
+	for _, c := range w.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(c, "auth_token=") {
+			authTokenCookie = c
+		}
+		if strings.HasPrefix(c, "csrf_token=") {
+			csrfTokenCookie = c
+		}
+	}
+
+	// auth_token: HttpOnly かつ SameSite=Lax であること
+	assert.NotEmpty(t, authTokenCookie, "auth_token cookie should be set")
+	assert.Contains(t, authTokenCookie, "HttpOnly", "auth_token should be HttpOnly")
+	assert.Contains(t, authTokenCookie, "SameSite=Lax", "auth_token should have SameSite=Lax")
+
+	// csrf_token: 非HttpOnly（JavaScriptから読み取れる）かつ SameSite=Lax であること
+	assert.NotEmpty(t, csrfTokenCookie, "csrf_token cookie should be set")
+	assert.NotContains(t, csrfTokenCookie, "HttpOnly", "csrf_token must not be HttpOnly")
+	assert.Contains(t, csrfTokenCookie, "SameSite=Lax", "csrf_token should have SameSite=Lax")
 }
 
 // TestAuthHandler_Signup はサインアップハンドラーのHTTPリクエスト/レスポンス処理をテストします。
@@ -191,6 +217,7 @@ func TestAuthHandler_Login(t *testing.T) {
 		mockLoginFunc  func(ctx context.Context, email, password string) (string, error)
 		expectedStatus int
 		expectedBody   gin.H
+		checkCookies   bool
 	}{
 		{
 			name:           "success: user login",
@@ -198,6 +225,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			mockLoginFunc:  func(ctx context.Context, email, password string) (string, error) { return "dummy-jwt-token", nil },
 			expectedStatus: http.StatusOK,
 			expectedBody:   gin.H{"message": "ok"},
+			checkCookies:   true,
 		},
 		{
 			name:           "failure: invalid email address",
@@ -245,6 +273,40 @@ func TestAuthHandler_Login(t *testing.T) {
 
 			w := makeRequest(t, router, http.MethodPost, "/login", tt.requestBody)
 			assertJSONResponse(t, w, tt.expectedStatus, tt.expectedBody)
+			if tt.checkCookies {
+				assertLoginCookies(t, w)
+			}
 		})
 	}
+}
+
+// TestAuthHandler_Logout はログアウトハンドラーがCookieを削除することを検証します。
+func TestAuthHandler_Logout(t *testing.T) {
+	t.Parallel()
+
+	h := handler.NewAuthHandler(&mockAuthUsecase{}, nil, false)
+
+	router := gin.New()
+	router.POST("/logout", h.Logout)
+
+	w := makeRequest(t, router, http.MethodPost, "/logout", gin.H{})
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var authTokenCookie, csrfTokenCookie string
+	for _, c := range w.Header().Values("Set-Cookie") {
+		if strings.HasPrefix(c, "auth_token=") {
+			authTokenCookie = c
+		}
+		if strings.HasPrefix(c, "csrf_token=") {
+			csrfTokenCookie = c
+		}
+	}
+
+	// ログアウト時は Max-Age=0 でCookieを削除すること
+	assert.NotEmpty(t, authTokenCookie, "auth_token cookie should be present in response")
+	assert.Contains(t, authTokenCookie, "Max-Age=0", "auth_token cookie should be deleted (Max-Age=0)")
+
+	assert.NotEmpty(t, csrfTokenCookie, "csrf_token cookie should be present in response")
+	assert.Contains(t, csrfTokenCookie, "Max-Age=0", "csrf_token cookie should be deleted (Max-Age=0)")
 }

--- a/internal/feature/auth/transport/handler/auth_handler_test.go
+++ b/internal/feature/auth/transport/handler/auth_handler_test.go
@@ -78,7 +78,8 @@ func assertJSONResponse(t *testing.T, w *httptest.ResponseRecorder, expectedStat
 }
 
 // assertLoginCookies はログイン成功時のSet-CookieヘッダーにCookieが正しく設定されていることを検証します。
-func assertLoginCookies(t *testing.T, w *httptest.ResponseRecorder) {
+// secureCookie=true の場合は Secure 属性も検証します。
+func assertLoginCookies(t *testing.T, w *httptest.ResponseRecorder, secureCookie bool) {
 	t.Helper()
 
 	var authTokenCookie, csrfTokenCookie string
@@ -100,6 +101,12 @@ func assertLoginCookies(t *testing.T, w *httptest.ResponseRecorder) {
 	assert.NotEmpty(t, csrfTokenCookie, "csrf_token cookie should be set")
 	assert.NotContains(t, csrfTokenCookie, "HttpOnly", "csrf_token must not be HttpOnly")
 	assert.Contains(t, csrfTokenCookie, "SameSite=Lax", "csrf_token should have SameSite=Lax")
+
+	// secureCookie=true の場合: 両Cookieに Secure 属性が付くこと
+	if secureCookie {
+		assert.Contains(t, authTokenCookie, "Secure", "auth_token should have Secure attribute")
+		assert.Contains(t, csrfTokenCookie, "Secure", "csrf_token should have Secure attribute")
+	}
 }
 
 // TestAuthHandler_Signup はサインアップハンドラーのHTTPリクエスト/レスポンス処理をテストします。
@@ -218,6 +225,7 @@ func TestAuthHandler_Login(t *testing.T) {
 		expectedStatus int
 		expectedBody   gin.H
 		checkCookies   bool
+		secureCookie   bool
 	}{
 		{
 			name:           "success: user login",
@@ -226,6 +234,16 @@ func TestAuthHandler_Login(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedBody:   gin.H{"message": "ok"},
 			checkCookies:   true,
+			secureCookie:   false,
+		},
+		{
+			name:           "success: user login (secureCookie=true)",
+			requestBody:    gin.H{"email": "test@example.com", "password": "password123"},
+			mockLoginFunc:  func(ctx context.Context, email, password string) (string, error) { return "dummy-jwt-token", nil },
+			expectedStatus: http.StatusOK,
+			expectedBody:   gin.H{"message": "ok"},
+			checkCookies:   true,
+			secureCookie:   true,
 		},
 		{
 			name:           "failure: invalid email address",
@@ -266,7 +284,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			t.Parallel()
 
 			mockUC := &mockAuthUsecase{LoginFunc: tt.mockLoginFunc}
-			h := handler.NewAuthHandler(mockUC, nil, false)
+			h := handler.NewAuthHandler(mockUC, nil, tt.secureCookie)
 
 			router := gin.New()
 			router.POST("/login", h.Login)
@@ -274,7 +292,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			w := makeRequest(t, router, http.MethodPost, "/login", tt.requestBody)
 			assertJSONResponse(t, w, tt.expectedStatus, tt.expectedBody)
 			if tt.checkCookies {
-				assertLoginCookies(t, w)
+				assertLoginCookies(t, w, tt.secureCookie)
 			}
 		})
 	}
@@ -284,29 +302,49 @@ func TestAuthHandler_Login(t *testing.T) {
 func TestAuthHandler_Logout(t *testing.T) {
 	t.Parallel()
 
-	h := handler.NewAuthHandler(&mockAuthUsecase{}, nil, false)
-
-	router := gin.New()
-	router.DELETE("/logout", h.Logout)
-
-	w := makeRequest(t, router, http.MethodDelete, "/logout", gin.H{})
-
-	assert.Equal(t, http.StatusOK, w.Code)
-
-	var authTokenCookie, csrfTokenCookie string
-	for _, c := range w.Header().Values("Set-Cookie") {
-		if strings.HasPrefix(c, "auth_token=") {
-			authTokenCookie = c
-		}
-		if strings.HasPrefix(c, "csrf_token=") {
-			csrfTokenCookie = c
-		}
+	tests := []struct {
+		name         string
+		secureCookie bool
+	}{
+		{name: "secureCookie=false", secureCookie: false},
+		{name: "secureCookie=true", secureCookie: true},
 	}
 
-	// ログアウト時は Max-Age=0 でCookieを削除すること
-	assert.NotEmpty(t, authTokenCookie, "auth_token cookie should be present in response")
-	assert.Contains(t, authTokenCookie, "Max-Age=0", "auth_token cookie should be deleted (Max-Age=0)")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	assert.NotEmpty(t, csrfTokenCookie, "csrf_token cookie should be present in response")
-	assert.Contains(t, csrfTokenCookie, "Max-Age=0", "csrf_token cookie should be deleted (Max-Age=0)")
+			h := handler.NewAuthHandler(&mockAuthUsecase{}, nil, tt.secureCookie)
+
+			router := gin.New()
+			router.DELETE("/logout", h.Logout)
+
+			w := makeRequest(t, router, http.MethodDelete, "/logout", gin.H{})
+
+			assert.Equal(t, http.StatusOK, w.Code)
+
+			var authTokenCookie, csrfTokenCookie string
+			for _, c := range w.Header().Values("Set-Cookie") {
+				if strings.HasPrefix(c, "auth_token=") {
+					authTokenCookie = c
+				}
+				if strings.HasPrefix(c, "csrf_token=") {
+					csrfTokenCookie = c
+				}
+			}
+
+			// ログアウト時は Max-Age=0 でCookieを削除すること
+			assert.NotEmpty(t, authTokenCookie, "auth_token cookie should be present in response")
+			assert.Contains(t, authTokenCookie, "Max-Age=0", "auth_token cookie should be deleted (Max-Age=0)")
+
+			assert.NotEmpty(t, csrfTokenCookie, "csrf_token cookie should be present in response")
+			assert.Contains(t, csrfTokenCookie, "Max-Age=0", "csrf_token cookie should be deleted (Max-Age=0)")
+
+			// secureCookie=true の場合: 両Cookieに Secure 属性が付くこと
+			if tt.secureCookie {
+				assert.Contains(t, authTokenCookie, "Secure", "auth_token should have Secure attribute")
+				assert.Contains(t, csrfTokenCookie, "Secure", "csrf_token should have Secure attribute")
+			}
+		})
+	}
 }

--- a/internal/feature/auth/transport/handler/auth_handler_test.go
+++ b/internal/feature/auth/transport/handler/auth_handler_test.go
@@ -102,10 +102,13 @@ func assertLoginCookies(t *testing.T, w *httptest.ResponseRecorder, secureCookie
 	assert.NotContains(t, csrfTokenCookie, "HttpOnly", "csrf_token must not be HttpOnly")
 	assert.Contains(t, csrfTokenCookie, "SameSite=Lax", "csrf_token should have SameSite=Lax")
 
-	// secureCookie=true の場合: 両Cookieに Secure 属性が付くこと
+	// secureCookie=true の場合: 両Cookieに Secure 属性が付くこと / false の場合: 付かないこと
 	if secureCookie {
 		assert.Contains(t, authTokenCookie, "Secure", "auth_token should have Secure attribute")
 		assert.Contains(t, csrfTokenCookie, "Secure", "csrf_token should have Secure attribute")
+	} else {
+		assert.NotContains(t, authTokenCookie, "Secure", "auth_token must not have Secure attribute")
+		assert.NotContains(t, csrfTokenCookie, "Secure", "csrf_token must not have Secure attribute")
 	}
 }
 
@@ -340,10 +343,13 @@ func TestAuthHandler_Logout(t *testing.T) {
 			assert.NotEmpty(t, csrfTokenCookie, "csrf_token cookie should be present in response")
 			assert.Contains(t, csrfTokenCookie, "Max-Age=0", "csrf_token cookie should be deleted (Max-Age=0)")
 
-			// secureCookie=true の場合: 両Cookieに Secure 属性が付くこと
+			// secureCookie=true の場合: 両Cookieに Secure 属性が付くこと / false の場合: 付かないこと
 			if tt.secureCookie {
 				assert.Contains(t, authTokenCookie, "Secure", "auth_token should have Secure attribute")
 				assert.Contains(t, csrfTokenCookie, "Secure", "csrf_token should have Secure attribute")
+			} else {
+				assert.NotContains(t, authTokenCookie, "Secure", "auth_token must not have Secure attribute")
+				assert.NotContains(t, csrfTokenCookie, "Secure", "csrf_token must not have Secure attribute")
 			}
 		})
 	}

--- a/internal/platform/csrf/middleware.go
+++ b/internal/platform/csrf/middleware.go
@@ -3,6 +3,7 @@ package csrf
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"net/http"
 
@@ -58,7 +59,7 @@ func Protect() gin.HandlerFunc {
 		}
 
 		headerVal := c.GetHeader(HeaderName)
-		if headerVal == "" || headerVal != cookieVal {
+		if headerVal == "" || subtle.ConstantTimeCompare([]byte(headerVal), []byte(cookieVal)) != 1 {
 			c.AbortWithStatusJSON(http.StatusForbidden, api.ErrorResponse{Error: "csrf token mismatch"})
 			return
 		}

--- a/internal/platform/csrf/middleware.go
+++ b/internal/platform/csrf/middleware.go
@@ -1,0 +1,60 @@
+// Package csrf はDouble Submit CookieパターンによるCSRF保護を提供します。
+package csrf
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"stock_backend/internal/api"
+)
+
+const (
+	// CookieName はCSRFトークンを格納するCookie名です。
+	// このCookieはhttpOnly=falseのため、JavaScriptから読み取り可能です。
+	CookieName = "csrf_token"
+
+	// HeaderName はCSRFトークンを送信するリクエストヘッダー名です。
+	HeaderName = "X-CSRF-Token"
+
+	tokenBytes = 32
+)
+
+// GenerateToken は暗号学的に安全な64文字のhex文字列（CSRFトークン）を生成します。
+func GenerateToken() (string, error) {
+	b := make([]byte, tokenBytes)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// Protect はDouble Submit CookieパターンでCSRF攻撃を防ぐGinミドルウェアを返します。
+//   - GET / HEAD / OPTIONS などの安全なメソッドはスキップします
+//   - それ以外のメソッドでは X-CSRF-Token ヘッダーと csrf_token Cookie の値が
+//     一致しない場合に 403 を返します
+func Protect() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		switch c.Request.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			c.Next()
+			return
+		}
+
+		cookieVal, err := c.Cookie(CookieName)
+		if err != nil || cookieVal == "" {
+			c.AbortWithStatusJSON(http.StatusForbidden, api.ErrorResponse{Error: "missing csrf token"})
+			return
+		}
+
+		headerVal := c.GetHeader(HeaderName)
+		if headerVal == "" || headerVal != cookieVal {
+			c.AbortWithStatusJSON(http.StatusForbidden, api.ErrorResponse{Error: "csrf token mismatch"})
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/platform/csrf/middleware.go
+++ b/internal/platform/csrf/middleware.go
@@ -33,12 +33,20 @@ func GenerateToken() (string, error) {
 
 // Protect はDouble Submit CookieパターンでCSRF攻撃を防ぐGinミドルウェアを返します。
 //   - GET / HEAD / OPTIONS などの安全なメソッドはスキップします
+//   - Bearer認証（Authorization: Bearer）の場合はスキップします（CSRFはCookieベース認証にのみ必要）
 //   - それ以外のメソッドでは X-CSRF-Token ヘッダーと csrf_token Cookie の値が
 //     一致しない場合に 403 を返します
 func Protect() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		switch c.Request.Method {
 		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			c.Next()
+			return
+		}
+
+		// Bearer認証の場合はCSRFチェックをスキップ
+		// （CSRFはブラウザのCookie自動送信を悪用する攻撃のため、明示的なAuthorizationヘッダーを使う場合は不要）
+		if c.GetString("auth_source") == "bearer" {
 			c.Next()
 			return
 		}

--- a/internal/platform/http/middleware/security_headers.go
+++ b/internal/platform/http/middleware/security_headers.go
@@ -1,0 +1,16 @@
+// Package middleware はプラットフォーム共通のHTTPミドルウェアを提供します。
+package middleware
+
+import "github.com/gin-gonic/gin"
+
+// SecurityHeaders はセキュリティ関連のHTTPレスポンスヘッダーを設定するGinミドルウェアを返します。
+// このAPIサーバーはJSONのみを返すため、CSPは最も制限的な設定を使用します。
+func SecurityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+		c.Header("X-Frame-Options", "DENY")
+		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		c.Header("Content-Security-Policy", "default-src 'none'")
+		c.Next()
+	}
+}

--- a/internal/platform/jwt/middleware.go
+++ b/internal/platform/jwt/middleware.go
@@ -12,6 +12,10 @@ import (
 // ContextUserID はGinコンテキストに認証済みユーザーIDを格納するためのキーです。
 const ContextUserID = "userID"
 
+// ContextAuthSource はGinコンテキストに認証方式（"cookie" または "bearer"）を格納するためのキーです。
+// CSRFミドルウェアがBearer認証の場合にCSRFチェックをスキップするために使用します。
+const ContextAuthSource = "auth_source"
+
 // AuthRequired はJWTトークンを検証し、認証済みユーザーのみにアクセスを制限するGinミドルウェアを返します。
 // 認証はCookie（auth_token）を優先し、存在しない場合はAuthorizationヘッダーにフォールバックします。
 func AuthRequired() gin.HandlerFunc {
@@ -20,19 +24,21 @@ func AuthRequired() gin.HandlerFunc {
 		var tokenStr string
 		if cookie, err := c.Cookie("auth_token"); err == nil && cookie != "" {
 			tokenStr = cookie
+			c.Set(ContextAuthSource, "cookie")
 		} else {
 			// 2. Authorization: Bearer ヘッダーにフォールバック（APIクライアント・curl等）
 			auth := c.GetHeader("Authorization")
 			if strings.HasPrefix(auth, "Bearer ") {
 				tokenStr = strings.TrimPrefix(auth, "Bearer ")
+				c.Set(ContextAuthSource, "bearer")
 			}
 		}
 		if tokenStr == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing authentication token"})
 			return
 		}
 
-		// 2. 環境変数からシークレットキーを読み込み
+		// 3. 環境変数からシークレットキーを読み込み
 		secret := os.Getenv(EnvKeyJWTSecret)
 		if secret == "" {
 			// サーバー設定ミス（JWT_SECRETが未設定）
@@ -40,7 +46,7 @@ func AuthRequired() gin.HandlerFunc {
 			return
 		}
 
-		// 3. JWT署名をパースして検証
+		// 4. JWT署名をパースして検証
 		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
 			// 署名アルゴリズムを確認（HMACのみ許可）
 			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -54,13 +60,20 @@ func AuthRequired() gin.HandlerFunc {
 			return
 		}
 
-		// 4. クレーム（ペイロード）を抽出
-		if claims, ok := token.Claims.(jwt.MapClaims); ok {
-			if sub, ok := claims["sub"].(float64); ok { // JWTの数値はfloat64としてデコードされる
-				c.Set(ContextUserID, uint(sub))
-			}
+		// 5. クレーム（ペイロード）を抽出
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token claims"})
+			return
 		}
-		// 5. 次のハンドラーに制御を渡す
+		sub, ok := claims["sub"].(float64) // JWTの数値はfloat64としてデコードされる
+		if !ok {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid token: missing subject"})
+			return
+		}
+		c.Set(ContextUserID, uint(sub))
+
+		// 6. 次のハンドラーに制御を渡す
 		c.Next()
 	}
 }

--- a/internal/platform/jwt/middleware.go
+++ b/internal/platform/jwt/middleware.go
@@ -13,15 +13,24 @@ import (
 const ContextUserID = "userID"
 
 // AuthRequired はJWTトークンを検証し、認証済みユーザーのみにアクセスを制限するGinミドルウェアを返します。
+// 認証はCookie（auth_token）を優先し、存在しない場合はAuthorizationヘッダーにフォールバックします。
 func AuthRequired() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// 1. Authorizationヘッダーを取得
-		auth := c.GetHeader("Authorization")
-		if !strings.HasPrefix(auth, "Bearer ") {
+		// 1. auth_token Cookie を優先（Next.jsブラウザクライアント用）
+		var tokenStr string
+		if cookie, err := c.Cookie("auth_token"); err == nil && cookie != "" {
+			tokenStr = cookie
+		} else {
+			// 2. Authorization: Bearer ヘッダーにフォールバック（APIクライアント・curl等）
+			auth := c.GetHeader("Authorization")
+			if strings.HasPrefix(auth, "Bearer ") {
+				tokenStr = strings.TrimPrefix(auth, "Bearer ")
+			}
+		}
+		if tokenStr == "" {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing bearer token"})
 			return
 		}
-		tokenStr := strings.TrimPrefix(auth, "Bearer ")
 
 		// 2. 環境変数からシークレットキーを読み込み
 		secret := os.Getenv(EnvKeyJWTSecret)


### PR DESCRIPTION
## 概要
JWTトークンのlocalStorage保存によるXSSリスクに対処するため、
httpOnly Cookieへの移行とDouble Submit CookieパターンによるCSRF保護を実装した。
あわせてセキュリティヘッダーを全レスポンスに付与する。

## 変更内容
- **httpOnly Cookie移行**: ログイン時に `auth_token`（httpOnly・SameSite=Lax）をSet-Cookieで発行
- **CSRF保護**: `csrf_token`（非httpOnly）をセットし、変更系リクエストで `X-CSRF-Token` ヘッダーとの一致を検証（Double Submit Cookieパターン）
- **セキュリティヘッダー**: `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Content-Security-Policy` を全レスポンスに付与
- **ログアウトエンドポイント追加**: `DELETE /v1/logout`（認証不要・両Cookie削除）
- **JWT middleware更新**: `auth_token` Cookie 優先、`Authorization: Bearer` ヘッダーフォールバック（APIクライアント互換性維持）
- **本番環境のSecure Cookie**: `APP_ENV=production` の場合のみCookieにSecure属性を付与

## 破壊的変更
- `POST /v1/login` のレスポンスボディが `{"token": "..."}` から `{"message": "ok"}` に変更（JWTはSet-CookieのみでJSからアクセス不可）
- フロントエンド（Next.js）側の対応が必要:
  - 全リクエストに `credentials: 'include'` を追加
  - ログイン後に `csrf_token` Cookieを読み取り、変更系リクエストの `X-CSRF-Token` ヘッダーにセット
  - ローカルストレージへのトークン保存・読み取り処理を削除

## テスト
- `go test ./... -race -cover` — 全テストpass
- `golangci-lint run` — 0 issues
- 手動確認項目:
  - ログイン → `Set-Cookie: auth_token`（httpOnly）と `csrf_token` が返ること
  - 認証なしで保護ルートにアクセス → 401
  - CSRF ヘッダーなしで POST → 403
  - 正しいCookie + `X-CSRF-Token` ヘッダーで POST → 成功
  - ログアウト → 両Cookieが削除されること

## レビューポイント
- `SameSite=Lax` を選択（`Strict` はNext.jsの外部遷移時にCookieが送られないケースがあるため）
- ログアウトは認証不要のルートに配置（期限切れトークンでもCookieをクリアできる）
- `APP_ENV=production` 以外では `Secure` 属性を付与しない（ローカル開発はHTTPのため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ログアウト（DELETE /v1/logout）を追加しました。
  * ログイン成功時に認証トークン（auth_token）とCSRFトークン（csrf_token）をSet-Cookieで発行するようになりました。Secure属性は環境で制御可能です。

* **Security**
  * 全保護ルートにDouble Submit Cookie方式のCSRF保護を適用（変更系操作でX-CSRF-Tokenヘッダ必須）。
  * Cookie認証（cookieAuth）とCSRFヘッダ（X-CSRF-Token）をサポート。
  * レスポンスに追加のセキュリティヘッダーを設定。

* **API**
  * ログイン成功レスポンスはメッセージ形式に変更（トークンはCookieで提供）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->