### PR TITLE
docs: OpenAPI仕様に未定義レスポンスコードを追加し実装と一致させる

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -64,6 +64,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー（サインアップ後処理の失敗等）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/login:
     post:
@@ -238,6 +244,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/watchlist/{code}:
     delete:
@@ -263,6 +275,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/watchlist/order:
     put:
@@ -283,6 +301,12 @@ paths:
           description: 並び替え成功
         "400":
           description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
           content:
             application/json:
               schema:
@@ -320,6 +344,18 @@ paths:
                   $ref: "#/components/schemas/DetectedLogoResponse"
         "400":
           description: バリデーションエラー（画像未指定等）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "413":
+          description: 画像サイズが上限（10MB）を超えている
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー（ファイル操作失敗等）
           content:
             application/json:
               schema:


### PR DESCRIPTION
## 概要
各ハンドラーが実際に返すHTTPステータスコードの一部がOpenAPI仕様に未定義だった。
クライアント開発者が仕様を参照した際に実際の挙動と乖離しないよう、不足していたレスポンスコードを追加する。

## 変更内容
- `POST /v1/signup`: `500` を追加（post-signupフック失敗時）
- `POST /v1/watchlist`: `500` を追加（予期しないエラー時）
- `DELETE /v1/watchlist/{code}`: `500` を追加（予期しないエラー時）
- `PUT /v1/watchlist/order`: `500` を追加（予期しないエラー時）
- `POST /v1/logo/detect`: `413` を追加（画像サイズ > 10MB 時）
- `POST /v1/logo/detect`: `500` を追加（ファイル操作失敗時）

## テスト
- `go generate ./internal/api/...` で型定義の再生成を確認
- `go test ./... -race -cover` で全テスト通過を確認
- `go build ./...` でビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメンテーション**
  * API エラーレスポンスのドキュメントを拡充しました。複数のエンドポイント（登録、ウォッチリスト操作）でサーバーエラーの詳細な応答仕様を追加し、ロゴ検出エンドポイントではエラーハンドリングを強化しました。API利用時のエラー対応がより明確になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->