### PR TITLE
fix: OpenAPI仕様と実装の差異を解消

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -64,6 +64,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/login:
     post:
@@ -107,6 +113,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/logout:
     delete:
@@ -114,6 +126,7 @@ paths:
       operationId: logout
       tags:
         - auth
+      security: []
       responses:
         "200":
           description: ログアウト成功（auth_token・csrf_token Cookieを削除）
@@ -130,7 +143,6 @@ paths:
         - candles
       security:
         - cookieAuth: []
-        - bearerAuth: []
       parameters:
         - name: code
           in: path
@@ -161,6 +173,12 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/CandleResponse"
+        "400":
+          description: バリデーションエラー（outputsizeに整数以外が指定された等）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "502":
           description: 外部API通信エラー
           content:
@@ -176,7 +194,6 @@ paths:
         - symbols
       security:
         - cookieAuth: []
-        - bearerAuth: []
       responses:
         "200":
           description: 銘柄一覧
@@ -201,7 +218,6 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
-        - bearerAuth: []
       responses:
         "200":
           description: ウォッチリスト一覧
@@ -224,8 +240,6 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
-          csrfHeader: []
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -245,20 +259,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: CSRFトークン不一致
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
         "404":
           description: 銘柄が存在しない
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "403":
+          description: CSRFトークン不一致
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "409":
           description: 既にウォッチリストに存在する
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
           content:
             application/json:
               schema:
@@ -272,8 +292,6 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
-          csrfHeader: []
-        - bearerAuth: []
       parameters:
         - name: code
           in: path
@@ -296,6 +314,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/watchlist/order:
     put:
@@ -305,8 +329,6 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
-          csrfHeader: []
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -328,6 +350,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/logo/detect:
     post:
@@ -337,8 +365,6 @@ paths:
         - logo
       security:
         - cookieAuth: []
-          csrfHeader: []
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -373,8 +399,20 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "413":
+          description: 画像サイズ超過（10MB超）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "502":
           description: 外部API通信エラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "500":
+          description: サーバーエラー
           content:
             application/json:
               schema:
@@ -388,8 +426,6 @@ paths:
         - logo
       security:
         - cookieAuth: []
-          csrfHeader: []
-        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -424,19 +460,10 @@ paths:
 
 components:
   securitySchemes:
-    bearerAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
     cookieAuth:
       type: apiKey
       in: cookie
       name: auth_token
-    csrfHeader:
-      type: apiKey
-      in: header
-      name: X-CSRF-Token
-      description: Cookie認証使用時に必須。csrf_token CookieをJavaScriptで読み取り、このヘッダーにセットする（Double Submit Cookieパターン）
 
   schemas:
     SignupRequest:
@@ -542,15 +569,6 @@ components:
       properties:
         message:
           type: string
-
-    TokenResponse:
-      type: object
-      required:
-        - token
-      properties:
-        token:
-          type: string
-          description: JWTトークン
 
     CompanyAnalysisRequest:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -405,14 +405,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "502":
-          description: 外部API通信エラー
+        "500":
+          description: サーバーエラー
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "500":
-          description: サーバーエラー
+        "502":
+          description: 外部API通信エラー
           content:
             application/json:
               schema:

--- a/internal/feature/candles/transport/handler/candle_handler.go
+++ b/internal/feature/candles/transport/handler/candle_handler.go
@@ -38,7 +38,11 @@ func (h *CandlesHandler) GetCandlesHandler(c *gin.Context) {
 	interval := c.DefaultQuery("interval", "1day")
 	outputsizeStr := c.DefaultQuery("outputsize", "200")
 	// 文字列を整数に変換
-	outputsize, _ := strconv.Atoi(outputsizeStr)
+	outputsize, err := strconv.Atoi(outputsizeStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "outputsize must be an integer"})
+		return
+	}
 
 	candles, err := h.uc.GetCandles(c.Request.Context(), code, interval, outputsize)
 	if err != nil {

--- a/internal/feature/candles/transport/handler/candle_handler_test.go
+++ b/internal/feature/candles/transport/handler/candle_handler_test.go
@@ -76,16 +76,11 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			expectedBody:   `{"error":"internal server error"}`,
 		},
 		{
-			name: "edge case: invalid outputsize string uses default value",
-			url:  "/candles/7203.T?outputsize=invalid",
-			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
-				// ハンドラーは0（strconv.Atoi("invalid")の結果）をusecaseに渡す。
-				// デフォルト値への変換はusecaseレイヤーで処理される。
-				assert.Equal(t, 0, outputsize)
-				return []entity.Candle{}, nil
-			},
-			expectedStatus: http.StatusOK,
-			expectedBody:   `[]`,
+			name:           "error: invalid outputsize string returns 400",
+			url:            "/candles/7203.T?outputsize=invalid",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"outputsize must be an integer"}`,
 		},
 	}
 

--- a/internal/feature/watchlist/transport/handler/watchlist_handler.go
+++ b/internal/feature/watchlist/transport/handler/watchlist_handler.go
@@ -85,10 +85,6 @@ func (h *WatchlistHandler) Add(c *gin.Context) {
 func (h *WatchlistHandler) Remove(c *gin.Context) {
 	userID := c.MustGet(jwtmw.ContextUserID).(uint)
 	code := c.Param("code")
-	if code == "" {
-		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "symbol code is required"})
-		return
-	}
 
 	if err := h.uc.RemoveSymbol(c.Request.Context(), userID, code); err != nil {
 		switch {


### PR DESCRIPTION
## 概要

`api/openapi.yaml` の仕様と実際のGoハンドラー実装を比較したところ、認証要件・レスポンスコード・未使用スキーマの複数の乖離が発見された。
この PR ではそれらをすべて解消し、仕様をコードの実態に合わせる。

## 変更内容

- `DELETE /v1/logout`: `security: [cookieAuth]` → `security: []`（実装が認証不要なため）
- `POST /v1/signup`, `POST /v1/login`, `POST /v1/logo/detect`: 500 レスポンスを追加
- `GET /v1/candles/{code}`: 400 レスポンスを追加し、`outputsize` に非整数を渡すと 400 を返すよう実装を修正
- `POST /v1/logo/detect`: 413 レスポンスを追加（既存実装との整合）
- `DELETE /v1/watchlist/{code}`: Ginのルーティング上到達不能な `code == ""` バリデーションを削除
- 未使用の `bearerAuth`・`csrfHeader` スキームおよび `TokenResponse` スキーマを削除
- `POST /v1/logo/detect` のレスポンスコード記述順序を昇順に統一

## テスト

- `go test ./... -race` 全パス
- `golangci-lint run` 0 issues
- `candle_handler_test.go`: `outputsize=invalid` のテストケースを 400 返却に更新

🤖 Generated with [Claude Code](https://claude.ai/claude-code)