### PR TITLE
docs: README・CLAUDE.mdをCookie認証・CSRF保護・新機能に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,12 +59,18 @@ internal/
 ├── feature/          # フィーチャーモジュール（垂直スライス）
 │   ├── auth/
 │   ├── candles/
-│   └── symbollist/
+│   ├── logodetection/
+│   ├── symbollist/
+│   └── watchlist/
 ├── platform/         # インフラストラクチャ層（旧 "infrastructure"）
 │   ├── cache/        # キャッシュユーティリティ（TimeUntilNext8AM等）
+│   ├── csrf/         # CSRF保護（Double Submit Cookieパターン）
 │   ├── db/           # データベース初期化
 │   ├── http/         # HTTPクライアント設定 + ヘルスチェックハンドラー
+│   │   ├── handler/  # ヘルスチェックハンドラー
+│   │   └── middleware/ # セキュリティヘッダーミドルウェア
 │   ├── jwt/          # JWT生成・ミドルウェア
+│   ├── ratelimit/    # Redisベースのスライディングウィンドウレートリミッター
 │   └── redis/        # Redisクライアントセットアップ
 └── shared/           # 共有ユーティリティ（例: レートリミッター）
 ```

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
   - 画像からロゴを検出（Cloud Vision API）
   - 検出した企業の分析サマリーを生成（Gemini API / Vertex AI）
 
+- **セキュリティ強化**
+
+  - CSRF保護（Double Submit Cookieパターン、保護ルートに適用）
+  - IPベースのレートリミット（Redisスライディングウィンドウ方式）
+  - セキュリティヘッダー付与（X-Content-Type-Options等）
+  - SameSite Cookie設定によるクロスサイトリクエスト制御
+
 - **データベース永続化**
   - PostgreSQL / Cloud SQLによるデータ永続化
   - GORM ORMによるデータ管理
@@ -47,7 +54,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 | DB              | PostgreSQL / Cloud SQL                                              |
 | キャッシュ      | Redis                                                               |
 | AI / ML         | Cloud Vision API / Gemini API（Vertex AI）                          |
-| 認証            | JWT / bcrypt                                                        |
+| 認証・セキュリティ | JWT / bcrypt / CSRF（Double Submit Cookie）/ レートリミット       |
 | API仕様         | OpenAPI 3.0.3 / oapi-codegen（型生成）                              |
 | 設定管理        | **.env.docker（ローカル）/ Secret Manager（本番）+ os.Getenv()**    |
 | コンテナ        | Docker / Docker Compose                                             |
@@ -118,14 +125,17 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 │   │
 │   ├── platform/               # インフラストラクチャ層（外部依存）
 │   │   ├── cache/              # キャッシュユーティリティ（TimeUntilNext8AM等）
+│   │   ├── csrf/               # CSRF保護（Double Submit Cookieパターン）
 │   │   ├── db/                 # データベース接続初期化
 │   │   ├── http/               # HTTPクライアント設定
-│   │   │   └── handler/        # ヘルスチェックハンドラー
+│   │   │   ├── handler/        # ヘルスチェックハンドラー
+│   │   │   └── middleware/     # セキュリティヘッダーミドルウェア
 │   │   ├── jwt/                # JWT生成/検証/ミドルウェア
+│   │   ├── ratelimit/          # Redisベースのスライディングウィンドウレートリミッター
 │   │   └── redis/              # Redisクライアント実装
 │   │
 │   └── shared/                 # 共有ユーティリティ
-│       └── ratelimiter/        # レートリミット
+│       └── ratelimiter/        # レートリミット（旧実装・互換維持）
 │
 ├── docker/                     # Docker関連ファイル
 │   ├── Dockerfile.ingest       # ingest用Dockerfile（本番）
@@ -168,18 +178,20 @@ go generate ./internal/api/...
 
 生成されるファイル: `internal/api/types.gen.go`（手動編集不可）
 
-## 認証設計（JWT + リフレッシュトークン）
+## 認証・セキュリティ設計
 
 ### 現在の実装
 
-- JWTアクセストークンによる認証
-- `Authorization: Bearer <token>` ヘッダーによる検証
+- JWTアクセストークンによる認証（`Authorization: Bearer <token>` ヘッダー）
+- **CSRF保護**: Double Submit Cookieパターン（`csrf_token` Cookie + `X-CSRF-Token` ヘッダーの一致を検証）
+- **レートリミット**: Redisスライディングウィンドウ方式（signup: 5回/時、login: 10回/分）
+- **セキュリティヘッダー**: `X-Content-Type-Options`、`X-Frame-Options` 等を全レスポンスに付与
+- **SameSite Cookie**: `Lax` 設定でクロスサイトリクエストを制御
 
 ### 今後の計画（ハイブリッド認証）
 
 - **短期JWT（5〜10分）** + **サーバー管理リフレッシュトークン** 方式の実装
 - `/auth/refresh` によるアクセストークンの自動更新
-- `/auth/logout` によるデバイス単位の即時無効化
 - リフレッシュトークンをDBまたはRedisに保存し、**ローテーション管理**を実施
 
 ## データフロー（例: 株価取得）
@@ -205,10 +217,11 @@ go generate ./internal/api/...
 
 ### 認証
 
-| メソッド | パス         | 認証   | 説明                                  |
-| -------- | ------------ | ------ | ------------------------------------- |
-| POST     | `/v1/signup` | 不要   | 新規ユーザー登録                      |
-| POST     | `/v1/login`  | 不要   | ログイン（JWTアクセストークンを発行） |
+| メソッド | パス           | 認証   | 説明                                              |
+| -------- | -------------- | ------ | ------------------------------------------------- |
+| POST     | `/v1/signup`   | 不要   | 新規ユーザー登録（IPレートリミット: 5回/時）      |
+| POST     | `/v1/login`    | 不要   | ログイン（JWTアクセストークンを発行、10回/分）    |
+| DELETE   | `/v1/logout`   | 不要   | ログアウト（期限切れトークンでも実行可能）        |
 
 ---
 
@@ -241,8 +254,10 @@ go generate ./internal/api/...
 
 ### 補足
 
-- `/v1/candles`、`/v1/symbols`、`/v1/watchlist` は **JWT認証（`Authorization: Bearer <token>`）** が必要です。
-- 今後、リフレッシュトークン対応として `/auth/refresh` と `/auth/logout` を追加予定です。
+- `/v1/candles`、`/v1/symbols`、`/v1/watchlist`、`/v1/logo/*` は **JWT認証（`Authorization: Bearer <token>`）** が必要です。
+- 認証済みエンドポイントはすべて **CSRFトークン（`X-CSRF-Token` ヘッダー）** も必須です。
+- `/v1/signup` と `/v1/login` には **IPベースのレートリミット** が適用されています。
+- 今後、リフレッシュトークン対応として `/auth/refresh` を追加予定です。
 
 ## クラウドアーキテクチャ（Google Cloud）
 

--- a/internal/feature/auth/README.md
+++ b/internal/feature/auth/README.md
@@ -114,8 +114,26 @@ sequenceDiagram
     Usecase->>JWTGenerator: GenerateToken(userID, email)
     JWTGenerator-->>Usecase: JWT Token
     Usecase-->>Handler: JWT Token
-    Handler-->>Client: 200 OK<br/>{token: "eyJhbGc..."}
+    Handler->>Handler: GenerateCSRFToken()
+    Handler->>Handler: SetCookie("auth_token", token, httpOnly=true)
+    Handler->>Handler: SetCookie("csrf_token", csrfToken, httpOnly=false)
+    Handler-->>Client: 200 OK<br/>{"message":"ok"}<br/>Set-Cookie: auth_token=...; HttpOnly<br/>Set-Cookie: csrf_token=...
 ```
+
+### ログアウトフロー
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Handler as AuthHandler
+
+    Client->>Handler: DELETE /v1/logout
+    Handler->>Handler: SetCookie("auth_token", "", MaxAge=-1)
+    Handler->>Handler: SetCookie("csrf_token", "", MaxAge=-1)
+    Handler-->>Client: 200 OK {"message":"ok"}<br/>Set-Cookie: auth_token=; Max-Age=0<br/>Set-Cookie: csrf_token=; Max-Age=0
+```
+
+**注意**: ログアウトは期限切れトークンでも動作するよう、認証不要のルートに配置されています。
 
 ## API仕様
 
@@ -187,11 +205,15 @@ sequenceDiagram
 - **200 OK** - 認証成功
   ```json
   {
-    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+    "message": "ok"
   }
   ```
 
-  **JWTクレーム:**
+  **Set-Cookieヘッダー:**
+  - `auth_token`: JWTトークン（`HttpOnly; SameSite=Lax; Max-Age=3600`）— JavaScriptから読み取り不可（XSS対策）
+  - `csrf_token`: CSRFトークン（`SameSite=Lax; Max-Age=3600`）— JavaScriptが読み取り `X-CSRF-Token` ヘッダーにセット（CSRF対策）
+
+  **JWTクレーム（auth_token内）:**
   - `sub`: ユーザーID（uint）
   - `email`: ユーザーのメールアドレス
   - `iat`: 発行日時（Unixタイムスタンプ）
@@ -218,6 +240,25 @@ sequenceDiagram
   }
   ```
   ヘッダー: `Retry-After: <秒数>`
+
+### DELETE /v1/logout
+
+ログアウトします（`auth_token` と `csrf_token` のCookieを削除）。認証不要です。
+
+**レスポンス**
+
+- **200 OK** - ログアウト成功
+  ```json
+  {
+    "message": "ok"
+  }
+  ```
+
+  **Set-Cookieヘッダー:**
+  - `auth_token`: 空文字列、`Max-Age=0`（即時削除）
+  - `csrf_token`: 空文字列、`Max-Age=0`（即時削除）
+
+**注意**: 期限切れトークンを持つクライアントでも必ずログアウトできるよう、認証不要のエンドポイントに設定されています。
 
 ## レートリミット
 
@@ -353,7 +394,11 @@ graph TB
 1. **クリーンアーキテクチャ**: ドメイン層はインフラストラクチャ層から独立
 2. **依存性逆転**: Usecaseは具体的な実装ではなく、UserRepositoryインターフェースとJWTGeneratorインターフェースを定義・依存（Goの「インターフェースは利用者が定義する」原則に従う）
 3. **インターフェースの所有権**: リポジトリインターフェースとJWT生成インターフェースは、使用されるusecase層で定義（Goのベストプラクティス）
-4. **セキュリティ**:
+4. **Cookie + CSRF 二重保護**:
+   - `auth_token`: httpOnly Cookie（XSS攻撃からトークンを保護）
+   - `csrf_token`: 非httpOnly Cookie（JavaScriptが `X-CSRF-Token` ヘッダーにセット）
+   - 両トークンの一致を検証（Double Submit Cookieパターン）
+5. **セキュリティ**:
    - パスワードは保存前にbcryptでハッシュ化
    - タイミング攻撃の防止（ユーザー未検出時もbcrypt比較を実行）
    - JWTトークンはHS256アルゴリズムで署名（`platform/jwt` で実装）
@@ -534,13 +579,18 @@ PASSWORD_PEPPER=your-password-pepper-change-this-in-production
 
 1. **パスワードハッシュ化**: HMAC-SHA256ペッパー + bcryptを使用（デフォルトコスト: 10）。ペッパーは環境変数 `PASSWORD_PEPPER` で管理し、DBが漏洩した場合の追加防御層として機能。bcryptの72バイト入力制限を回避するため、HMAC-SHA256で固定長出力に変換後にbcryptでハッシュ化
 2. **タイミング攻撃防止**: ユーザーが存在しない場合でもダミーハッシュを使用してbcrypt比較を実行し、レスポンス時間の差異による情報漏洩を防止
-3. **JWTの有効期限**: 1時間で自動的に失効
-4. **エラーメッセージの統一化**:
+3. **Cookie + CSRF 二重保護**:
+   - `auth_token`（httpOnly）: JavaScriptから読み取り不可のためXSS攻撃でトークン窃取不可
+   - `csrf_token`（非httpOnly）: JavaScriptが読み取り `X-CSRF-Token` ヘッダーにセット → CSRF攻撃を防止
+   - `SameSite=Lax` 設定でクロスサイトリクエストを制限
+4. **JWTの有効期限**: 1時間で自動的に失効
+5. **認証方式フォールバック**: `auth_token` Cookieを優先、存在しない場合は `Authorization: Bearer <token>` ヘッダーにフォールバック（API/curlクライアント対応）
+6. **エラーメッセージの統一化**:
    - バリデーションエラー: 汎用 "invalid request" メッセージを返却
    - ログイン失敗: 統一された "invalid email or password" メッセージを返却
    - サインアップ失敗: 汎用 "signup failed" メッセージを返却
    - 列挙攻撃を防止するため、詳細なエラー情報はサーバーログにのみ記録
-5. **JWT_SECRET**: 環境変数で管理。本番環境では強力な秘密鍵を使用すること
+7. **JWT_SECRET**: 環境変数で管理。本番環境では強力な秘密鍵を使用すること
 
 ## 今後の拡張
 

--- a/internal/feature/candles/README.md
+++ b/internal/feature/candles/README.md
@@ -112,6 +112,10 @@ sequenceDiagram
 
 指定された銘柄のローソク足データを取得します。JWT認証が必要です。
 
+**認証方式**（優先順位順）:
+1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）— この場合CSRFチェックをスキップ
+
 **パスパラメータ**
 | パラメータ | 説明 | 例 |
 |-----------|------|-----|
@@ -123,9 +127,16 @@ sequenceDiagram
 | `interval` | `1day` | 時間間隔（`1day`, `1week`, `1month`） |
 | `outputsize` | `200` | 返却するデータポイント数（最大: 5000） |
 
-**リクエスト例**
+**リクエスト例（Cookieベース）**
+```http
+GET /v1/candles/7203.T?interval=1day&outputsize=100
+Cookie: auth_token=eyJhbGc...
+X-CSRF-Token: <csrf_token Cookieの値>
 ```
-GET /candles/7203.T?interval=1day&outputsize=100
+
+**リクエスト例（Bearerヘッダー）**
+```http
+GET /v1/candles/7203.T?interval=1day&outputsize=100
 Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```
 
@@ -154,10 +165,17 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
   ```
   注: 結果は時間の降順（新しい順）でソートされます。
 
-- **401 Unauthorized** - JWTトークンが未指定または無効
+- **401 Unauthorized** - 認証トークンが未指定または無効
   ```json
   {
-    "error": "authorization header required"
+    "error": "missing authentication token"
+  }
+  ```
+
+- **403 Forbidden** - CSRFトークンが不正（Cookieベース認証時）
+  ```json
+  {
+    "error": "invalid csrf token"
   }
   ```
 

--- a/internal/feature/logodetection/README.md
+++ b/internal/feature/logodetection/README.md
@@ -95,6 +95,10 @@ sequenceDiagram
 
 画像をアップロードしてロゴを検出します。JWT認証が必要です。
 
+**認証方式**（優先順位順）:
+1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
+
 **Content-Type**: `multipart/form-data`
 
 **リクエストフィールド**
@@ -106,7 +110,8 @@ sequenceDiagram
 **リクエスト例**
 ```http
 POST /v1/logo/detect
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Cookie: auth_token=eyJhbGc...
+X-CSRF-Token: <csrf_token Cookieの値>
 Content-Type: multipart/form-data; boundary=----FormBoundary
 
 ------FormBoundary
@@ -158,6 +163,10 @@ Content-Type: image/jpeg
 
 企業名からAI分析サマリーを生成します。JWT認証が必要です。
 
+**認証方式**（優先順位順）:
+1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
+
 **Content-Type**: `application/json`
 
 **リクエストボディ**
@@ -177,7 +186,8 @@ Content-Type: image/jpeg
 **リクエスト例**
 ```http
 POST /v1/logo/analyze
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+Cookie: auth_token=eyJhbGc...
+X-CSRF-Token: <csrf_token Cookieの値>
 Content-Type: application/json
 
 {

--- a/internal/feature/symbollist/README.md
+++ b/internal/feature/symbollist/README.md
@@ -46,7 +46,9 @@ sequenceDiagram
 
 アクティブな株式銘柄の一覧を取得します。
 
-**認証**: 必須（JWT Bearerトークン）
+**認証方式**（優先順位順）:
+1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
 
 **レスポンス**
 

--- a/internal/feature/watchlist/README.md
+++ b/internal/feature/watchlist/README.md
@@ -114,6 +114,10 @@ sequenceDiagram
 
 ログインユーザーのウォッチリストを `sort_key` 昇順で取得します。JWT認証が必要です。
 
+**認証方式**（優先順位順）:
+1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
+
 **レスポンス**
 
 - **200 OK** - 成功
@@ -129,7 +133,7 @@ sequenceDiagram
 
 ### POST /v1/watchlist
 
-ウォッチリストに銘柄を追加します。JWT認証が必要です。
+ウォッチリストに銘柄を追加します。JWT認証（+ CSRFトークン）が必要です。
 
 **リクエストボディ**
 ```json
@@ -150,7 +154,7 @@ sequenceDiagram
 
 ### DELETE /v1/watchlist/:code
 
-ウォッチリストから銘柄を削除します。JWT認証が必要です。
+ウォッチリストから銘柄を削除します。JWT認証（+ CSRFトークン）が必要です。
 
 **パスパラメータ**
 | パラメータ | 説明 | 例 |
@@ -170,7 +174,7 @@ sequenceDiagram
 
 ### PUT /v1/watchlist/order
 
-ウォッチリストの並び順を一括更新します。JWT認証が必要です。
+ウォッチリストの並び順を一括更新します。JWT認証（+ CSRFトークン）が必要です。
 
 **リクエストボディ**
 ```json


### PR DESCRIPTION
## 概要
Cookie/CSRF認証への移行、ロゴ検出・ウォッチリスト機能の追加、セキュリティ強化（レートリミット・セキュリティヘッダー）に伴い、プロジェクト全体のドキュメントを現状の実装に同期する。

## 変更内容
- **CLAUDE.md**: `platform/` に `csrf/`・`ratelimit/`・`http/middleware/` を追加、feature 一覧に `logodetection/`・`watchlist/` を追加
- **README.md**: セキュリティ機能セクション追加・`DELETE /v1/logout` エンドポイント追加・認証設計セクションを現状に更新・ディレクトリ構成・技術スタックを更新
- **auth/README.md**: Cookieベース認証（`auth_token` + `csrf_token`）・`DELETE /v1/logout` API・ログアウトシーケンス図を追加、ログインレスポンスを JSON token から Cookie Set に修正
- **candles/README.md**: Cookie+CSRF / Bearer の2段階認証方式とエラーレスポンス（403）を追記
- **logodetection/README.md**: 認証方式とリクエスト例を Cookie ベースに更新
- **symbollist/README.md**: 認証方式を更新
- **watchlist/README.md**: 全エンドポイントに CSRF トークン要件を追記

## テスト
- ドキュメント変更のみのため、実装への影響なし
- 記載内容が `internal/platform/jwt/middleware.go`・`internal/feature/auth/transport/handler/auth_handler.go` 等の実装と一致していることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)