### PR TITLE
ci: PR作成・更新時にClaude自動レビューを有効化

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,8 @@
 name: Claude Code
 
 on:
+  pull_request:
+    types: [opened, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -13,6 +15,7 @@ on:
 jobs:
   claude:
     if: |
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
@@ -20,8 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -41,7 +44,11 @@ jobs:
             actions: read
 
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
-          # prompt: 'Update the pull request description to include a summary of changes.'
+          prompt: |
+            このPRのコードレビューを行ってください。
+            - バグや潜在的な問題を指摘
+            - コード品質・可読性のフィードバック
+            - セキュリティ上の懸念点があれば報告
 
           # Optional: Add claude_args to customize behavior and configuration
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md


### PR DESCRIPTION
## 概要
`pull_request` トリガーを追加し、PR作成・コミット追加時にClaude Codeが自動でレビューを実行するよう変更する。
これまでは `@claude` メンションが必要だったが、PRを開くだけで自動的にレビューが走るようになる。

## 変更内容
- `on.pull_request` トリガー（`opened`, `synchronize`）を追加
- `if` 条件に `github.event_name == 'pull_request'` を追加
- `@claude` メンションによる手動起動は引き続き有効