### PR TITLE
ci: claude-code-review の PR コメント投稿権限を付与

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
## 概要
PR 作成・更新時に走る自動レビューワークフロー (`claude-code-review.yml`) が
実行は成功するものの PR にコメントを投稿できていない状態を解消する。
権限不足によりコメント投稿 API が失敗している仮説に基づき、
`pull-requests` と `issues` を `write` に昇格する。

## 変更内容
- `.github/workflows/claude-code-review.yml` の `pull-requests` 権限を read → write
- 同 `issues` 権限を read → write
- `contents` は read のまま維持（直接コミットは不要のため最小権限に抑える）

## テスト
- 本 PR 自体が検証対象。マージ前に claude[bot] から自動レビューコメントが
  付けば仮説通り（権限不足が原因）と確認できる
- 付かない場合は Anthropic App 側のスコープまたはプラグイン仕様の可能性あり、
  原因を追加調査する

## レビューポイント
- `contents: read` で十分かどうか（Suggested changes の自動コミット等を今後
  有効にしたい場合は write が必要になる）

🤖 Generated with [Claude Code](https://claude.com/claude-code)