### PR TITLE
fix: DB設定のDSN特殊文字エスケープとパスワードマスキングを追加

### DIFF
--- a/internal/platform/db/db_gorm.go
+++ b/internal/platform/db/db_gorm.go
@@ -13,10 +13,28 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// Password はログ出力・文字列化・JSONシリアライズ時に値をマスクする機密文字列型です。
+// fmt.Stringer / fmt.GoStringer / json.Marshaler / slog.LogValuer を実装しているため、
+// 誤って構造体ごとログ出力しても平文パスワードは "***" に置換されます。
+// DSN 構築など実値が必要な場合は string(p) で明示的に変換してください。
+type Password string
+
+// String は %s / %v などのフォーマット時にパスワードをマスクします。
+func (Password) String() string { return "***" }
+
+// GoString は %#v 書式でのマスク出力を提供します。
+func (Password) GoString() string { return "***" }
+
+// MarshalJSON は JSON シリアライズ時にパスワードをマスクします。
+func (Password) MarshalJSON() ([]byte, error) { return []byte(`"***"`), nil }
+
+// LogValue は slog による構造化ログ出力時にパスワードをマスクします。
+func (Password) LogValue() slog.Value { return slog.StringValue("***") }
+
 // Config はデータベース接続設定を保持します。
 type Config struct {
 	User         string
-	Password     string
+	Password     Password
 	Name         string
 	Host         string
 	Port         string
@@ -27,7 +45,7 @@ type Config struct {
 func LoadConfigFromEnv() Config {
 	return Config{
 		User:         os.Getenv("DB_USER"),
-		Password:     os.Getenv("DB_PASSWORD"),
+		Password:     Password(os.Getenv("DB_PASSWORD")),
 		Name:         os.Getenv("DB_NAME"),
 		Host:         os.Getenv("DB_HOST"),
 		Port:         os.Getenv("DB_PORT"),
@@ -61,16 +79,38 @@ func (c Config) Validate() error {
 	return nil
 }
 
+// quotePGValue は libpq の key=value 形式で安全に値を埋め込めるようエスケープします。
+// 値に空白・'='・シングルクオート・バックスラッシュが含まれる場合、または空値の場合は
+// シングルクオートで囲み、内部の '\' と '\” をエスケープします。
+// 参考: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-KEYWORD-VALUE
+func quotePGValue(v string) string {
+	if v == "" || strings.ContainsAny(v, " \t\n\r='\\") {
+		escaped := strings.ReplaceAll(v, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+		return "'" + escaped + "'"
+	}
+	return v
+}
+
 // BuildDSN は設定からPostgreSQL DSN文字列を構築します。
 // InstanceNameが設定されている場合はCloud SQL Unixソケット接続を作成します。
 // それ以外の場合はHostとPortを使用してTCP接続を作成します。
+// 各値は libpq の仕様に従ってエスケープされるため、パスワード等に空白や特殊文字が
+// 含まれていても安全に DSN を生成できます。
 func BuildDSN(cfg Config) string {
 	if cfg.InstanceName != "" {
-		return fmt.Sprintf("host=/cloudsql/%s user=%s password=%s dbname=%s",
-			cfg.InstanceName, cfg.User, cfg.Password, cfg.Name)
+		return fmt.Sprintf("host=%s user=%s password=%s dbname=%s",
+			quotePGValue("/cloudsql/"+cfg.InstanceName),
+			quotePGValue(cfg.User),
+			quotePGValue(string(cfg.Password)),
+			quotePGValue(cfg.Name))
 	}
 	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
-		cfg.Host, cfg.Port, cfg.User, cfg.Password, cfg.Name)
+		quotePGValue(cfg.Host),
+		quotePGValue(cfg.Port),
+		quotePGValue(cfg.User),
+		quotePGValue(string(cfg.Password)),
+		quotePGValue(cfg.Name))
 }
 
 // Opener はデータベース接続を開くための関数型です。

--- a/internal/platform/db/db_gorm_test.go
+++ b/internal/platform/db/db_gorm_test.go
@@ -1,7 +1,11 @@
 package db
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +76,145 @@ func TestBuildDSN_CloudSQLTakesPrecedence(t *testing.T) {
 	if dsn != expected {
 		t.Errorf("expected DSN %q, got %q", expected, dsn)
 	}
+}
+
+// TestBuildDSN_EscapesSpecialCharacters は値に空白・シングルクオート・バックスラッシュを含む場合に
+// libpq 仕様に従って DSN が正しくエスケープされることを検証します。
+func TestBuildDSN_EscapesSpecialCharacters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		cfg      Config
+		expected string
+	}{
+		{
+			name: "password with space",
+			cfg: Config{
+				User:     "u",
+				Password: "p@ss word",
+				Name:     "d",
+				Host:     "h",
+				Port:     "5432",
+			},
+			expected: "host=h port=5432 user=u password='p@ss word' dbname=d sslmode=disable",
+		},
+		{
+			name: "password with single quote and backslash",
+			cfg: Config{
+				User:     "u",
+				Password: `p'a\ss`,
+				Name:     "d",
+				Host:     "h",
+				Port:     "5432",
+			},
+			expected: `host=h port=5432 user=u password='p\'a\\ss' dbname=d sslmode=disable`,
+		},
+		{
+			name: "empty password is quoted",
+			cfg: Config{
+				User:     "u",
+				Password: "",
+				Name:     "d",
+				Host:     "h",
+				Port:     "5432",
+			},
+			expected: "host=h port=5432 user=u password='' dbname=d sslmode=disable",
+		},
+		{
+			name: "user with equals sign",
+			cfg: Config{
+				User:     "us=er",
+				Password: "p",
+				Name:     "d",
+				Host:     "h",
+				Port:     "5432",
+			},
+			expected: "host=h port=5432 user='us=er' password=p dbname=d sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := BuildDSN(tt.cfg)
+			if got != tt.expected {
+				t.Errorf("BuildDSN mismatch\n want: %q\n  got: %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+// TestPassword_Masking は Password 型がログ・文字列化・JSON シリアライズのいずれの経路でも
+// 平文を露出せず "***" にマスクされることを検証します。
+func TestPassword_Masking(t *testing.T) {
+	t.Parallel()
+
+	const secret = "super-secret"
+	p := Password(secret)
+
+	t.Run("String", func(t *testing.T) {
+		t.Parallel()
+		if got := p.String(); got != "***" {
+			t.Errorf("String() = %q, want %q", got, "***")
+		}
+	})
+
+	t.Run("fmt %v and %s do not leak", func(t *testing.T) {
+		t.Parallel()
+		for _, verb := range []string{"%v", "%s", "%+v", "%#v"} {
+			got := fmt.Sprintf(verb, p)
+			if strings.Contains(got, secret) {
+				t.Errorf("fmt %q leaked secret: %q", verb, got)
+			}
+		}
+	})
+
+	t.Run("embedded in Config via %+v does not leak", func(t *testing.T) {
+		t.Parallel()
+		cfg := Config{User: "u", Password: p, Name: "d"}
+		got := fmt.Sprintf("%+v", cfg)
+		if strings.Contains(got, secret) {
+			t.Errorf("Config format leaked secret: %q", got)
+		}
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(b) != `"***"` {
+			t.Errorf("MarshalJSON = %s, want %q", b, `"***"`)
+		}
+		cfg := Config{User: "u", Password: p, Name: "d"}
+		cb, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.Contains(string(cb), secret) {
+			t.Errorf("Config JSON leaked secret: %s", cb)
+		}
+	})
+
+	t.Run("slog structured logging does not leak", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		logger.Info("connecting", "password", p)
+		if strings.Contains(buf.String(), secret) {
+			t.Errorf("slog leaked secret: %s", buf.String())
+		}
+	})
+
+	t.Run("explicit string conversion still exposes value", func(t *testing.T) {
+		t.Parallel()
+		// DSN 構築など実値が必要な場面では明示的変換で取得できる
+		if string(p) != secret {
+			t.Errorf("string(p) = %q, want %q", string(p), secret)
+		}
+	})
 }
 
 // TestConnectWithRetry_SuccessOnFirstTry は初回接続成功時にリトライせずDBを返すことを検証します。
@@ -288,8 +431,8 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	if cfg.User != "envuser" {
 		t.Errorf("expected User 'envuser', got %q", cfg.User)
 	}
-	if cfg.Password != "envpass" {
-		t.Errorf("expected Password 'envpass', got %q", cfg.Password)
+	if string(cfg.Password) != "envpass" {
+		t.Errorf("expected Password 'envpass', got %q", string(cfg.Password))
 	}
 	if cfg.Name != "envdb" {
 		t.Errorf("expected Name 'envdb', got %q", cfg.Name)


### PR DESCRIPTION
## 概要
DB 接続設定まわりの潜在的な安全性の問題を 2 点修正する。パスワード等に特殊文字が含まれた場合に DSN が壊れる問題と、構造体ログ出力時に平文パスワードが漏洩しうるリスクに対処する。

## 変更内容
- `quotePGValue` を追加し、libpq の key=value 形式で空白・`=`・シングルクオート・バックスラッシュを含む値を正しくエスケープ
- `BuildDSN` を `quotePGValue` 経由に変更し、全 DSN 値を安全に埋め込み
- `Password` 型を新設（`fmt.Stringer` / `fmt.GoStringer` / `json.Marshaler` / `slog.LogValuer` を実装）。`%v` / `%+v` / `%#v` / `slog` / `json.Marshal` いずれの経路でも自動的に `"***"` にマスクされる
- `Config.Password` の型を `string` → `Password` に変更し、`LoadConfigFromEnv` も追従
- 実値が必要な `BuildDSN` 内でのみ `string(cfg.Password)` で明示的に変換

## テスト
- `TestBuildDSN_EscapesSpecialCharacters`: 空白・クオート・バックスラッシュ・空値・`=` の 4 ケース
- `TestPassword_Masking`: `String` / 各種 `fmt` 書式 / 構造体埋め込み / `json.Marshal` / `slog` / 明示変換の 6 サブテスト
- 既存の `TestBuildDSN_*` / `TestLoadConfigFromEnv` も含めてローカルで全パス（`go test -race`）
- `golangci-lint` / `go vet` / `go build` いずれもエラーなし

## レビューポイント
- `quotePGValue` のエスケープ順序（バックスラッシュ → シングルクオート）に意図がある点（逆順だと二重エスケープになる）
- `Config.Password` の型変更は `db` パッケージ内部のみで閉じており、他の呼び出し元（`cmd/server/main.go` は `OpenDB()` 経由）には影響しない
- `sslmode` の環境変数化は今回スコープ外（必要になったら別 PR）

🤖 Generated with [Claude Code](https://claude.com/claude-code)