### PR TITLE
fix: RedisクライアントのアドレスIPv6対応とパスワードマスキングを追加

### DIFF
--- a/internal/platform/redis/redis_client.go
+++ b/internal/platform/redis/redis_client.go
@@ -4,21 +4,40 @@ package redis
 import (
 	"context"
 	"log/slog"
+	"net"
 	"os"
 
 	"github.com/redis/go-redis/v9"
 )
 
+// Password はログ出力・文字列化・JSONシリアライズ時に値をマスクする機密文字列型です。
+// fmt.Stringer / fmt.GoStringer / json.Marshaler / slog.LogValuer を実装しているため、
+// 誤って構造体ごとログ出力しても平文パスワードは "***" に置換されます。
+// redis.Options への設定時など実値が必要な場合は string(p) で明示的に変換してください。
+type Password string
+
+// String は %s / %v などのフォーマット時にパスワードをマスクします。
+func (Password) String() string { return "***" }
+
+// GoString は %#v 書式でのマスク出力を提供します。
+func (Password) GoString() string { return "***" }
+
+// MarshalJSON は JSON シリアライズ時にパスワードをマスクします。
+func (Password) MarshalJSON() ([]byte, error) { return []byte(`"***"`), nil }
+
+// LogValue は slog による構造化ログ出力時にパスワードをマスクします。
+func (Password) LogValue() slog.Value { return slog.StringValue("***") }
+
 // NewRedisClient は環境変数を使用して設定された新しいRedisクライアントを作成します。
 // 返却前にPINGコマンドで接続を検証します。
 // 必要な環境変数: REDIS_HOST, REDIS_PORT, REDIS_PASSWORD（オプション）。
 func NewRedisClient() (*redis.Client, error) {
-	addr := os.Getenv("REDIS_HOST") + ":" + os.Getenv("REDIS_PORT")
-	password := os.Getenv("REDIS_PASSWORD")
+	addr := net.JoinHostPort(os.Getenv("REDIS_HOST"), os.Getenv("REDIS_PORT"))
+	password := Password(os.Getenv("REDIS_PASSWORD"))
 
 	rdb := redis.NewClient(&redis.Options{
 		Addr:     addr,
-		Password: password,
+		Password: string(password),
 		DB:       0,
 	})
 

--- a/internal/platform/redis/redis_client_test.go
+++ b/internal/platform/redis/redis_client_test.go
@@ -1,0 +1,72 @@
+package redis
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestPassword_Masking は Password 型がログ・文字列化・JSON シリアライズのいずれの経路でも
+// 平文を露出せず "***" にマスクされることを検証します。
+func TestPassword_Masking(t *testing.T) {
+	t.Parallel()
+
+	const secret = "super-secret"
+	p := Password(secret)
+
+	t.Run("String", func(t *testing.T) {
+		t.Parallel()
+		if got := p.String(); got != "***" {
+			t.Errorf("String() = %q, want %q", got, "***")
+		}
+	})
+
+	t.Run("GoString", func(t *testing.T) {
+		t.Parallel()
+		if got := p.GoString(); got != "***" {
+			t.Errorf("GoString() = %q, want %q", got, "***")
+		}
+	})
+
+	t.Run("fmt %v and %s do not leak", func(t *testing.T) {
+		t.Parallel()
+		for _, verb := range []string{"%v", "%s", "%+v", "%#v"} {
+			got := fmt.Sprintf(verb, p)
+			if strings.Contains(got, secret) {
+				t.Errorf("fmt %q leaked secret: %q", verb, got)
+			}
+		}
+	})
+
+	t.Run("MarshalJSON", func(t *testing.T) {
+		t.Parallel()
+		b, err := json.Marshal(p)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(b) != `"***"` {
+			t.Errorf("MarshalJSON = %s, want %q", b, `"***"`)
+		}
+	})
+
+	t.Run("slog structured logging does not leak", func(t *testing.T) {
+		t.Parallel()
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		logger.Info("connecting", "password", p)
+		if strings.Contains(buf.String(), secret) {
+			t.Errorf("slog leaked secret: %s", buf.String())
+		}
+	})
+
+	t.Run("explicit string conversion still exposes value", func(t *testing.T) {
+		t.Parallel()
+		// redis.Options.Password への設定など実値が必要な場面では明示的変換で取得できる
+		if string(p) != secret {
+			t.Errorf("string(p) = %q, want %q", string(p), secret)
+		}
+	})
+}


### PR DESCRIPTION
## 概要
Redis クライアントのアドレス組み立てを `net.JoinHostPort` に変更し、将来の IPv6 対応を担保する。また [db_gorm.go](internal/platform/db/db_gorm.go) と同様の `Password` 型を Redis パッケージにも導入し、構造化ログや JSON シリアライズ時にパスワードが漏洩しないようマスキング層を追加する。

## 変更内容
- `net.JoinHostPort` で `REDIS_HOST:REDIS_PORT` を組み立て、IPv6 アドレスを正しく扱えるようにした
- `Password` 型（`fmt.Stringer` / `fmt.GoStringer` / `json.Marshaler` / `slog.LogValuer` 実装）を redis パッケージに新規追加
- `NewRedisClient` で Redis パスワードを `Password` 型として保持し、`redis.Options` へ渡す際のみ `string(password)` で明示変換
- Password 型のマスキング挙動を検証するユニットテストを新規追加

## テスト
- `go test ./internal/platform/redis/... -v -race -cover` 全 PASS
- `go build ./...` 成功
- `golangci-lint run` 0 issues

## レビューポイント
- `NewRedisClient` のシグネチャは変更していないため呼び出し側（[cmd/server/main.go](cmd/server/main.go), [cmd/ingest/main.go](cmd/ingest/main.go)）の修正は不要
- `Password` 型は [db_gorm.go](internal/platform/db/db_gorm.go) の同名型と同じ実装を重複定義している。platform 層同士の依存を避けるための意図的な重複。将来 3 例目が出た際に `internal/shared/secret` への切り出しを再検討する方針

🤖 Generated with [Claude Code](https://claude.com/claude-code)