### PR TITLE
chore: example.env.docker の未使用項目を削除し任意項目を追記

### DIFF
--- a/example.env.docker
+++ b/example.env.docker
@@ -1,6 +1,8 @@
 # Docker
 APP_ENV=docker
-APP_PORT=8080
+
+# ログレベル（任意。DEBUG を指定した場合のみ slog のレベルを下げる。未設定時は INFO 相当）
+# LOG_LEVEL=DEBUG
 
 # DB
 DB_HOST=db
@@ -8,8 +10,10 @@ DB_PORT=5432
 DB_USER=appuser
 DB_PASSWORD=apppass
 DB_NAME=app
-DB_TZ=Asia/Tokyo
 RUN_MIGRATIONS=true
+
+# GORM ログレベル（任意。info / warn / error のいずれか。未設定・不明値は Silent）
+# DB_LOG_LEVEL=warn
 
 # CORS（許可するオリジン、カンマ区切りで複数指定可。未設定時は http://localhost:3000）
 CORS_ALLOWED_ORIGINS=http://localhost:3000
@@ -28,6 +32,9 @@ PASSWORD_PEPPER=your_password_pepper_here
 # twelvedata
 TWELVE_DATA_API_KEY=your_twelvedata_api_key_here
 TWELVE_DATA_BASE_URL=https://api.twelvedata.com
+
+# Ingest バッチのタイムアウト時間（任意。正の整数。未設定時は 3 時間）
+# INGEST_TIMEOUT_HOURS=3
 
 # Redis
 REDIS_HOST=redis


### PR DESCRIPTION
## 概要
`example.env.docker` に記載されていたがGoコードから参照されていない項目を削除し、代わりに挙動を変更できる任意項目をコメントアウト状態で追記した。

## 変更内容
- 未使用の `APP_PORT=8080` と `DB_TZ=Asia/Tokyo` を削除
  - `APP_PORT`: サーバは `cmd/server/main.go` で `:8080` をハードコード、未参照
  - `DB_TZ`: `LoadConfigFromEnv` で未参照、DBコンテナのTZは `docker-compose.dev.yml` 側でハードコード
- 任意項目をコメントアウトで追記（デフォルトから変更したい場合のみ有効化）
  - `LOG_LEVEL`: slog のログレベル（`DEBUG` 指定時のみレベルを下げる、未設定時 INFO）
  - `DB_LOG_LEVEL`: GORM のログレベル（`info` / `warn` / `error`、未設定時 Silent）
  - `INGEST_TIMEOUT_HOURS`: ingest バッチのタイムアウト時間（未設定時 3 時間）

## テスト
- テンプレートファイルのみの変更のため自動テストなし
- 手動確認: `.env.docker` をコピーして `backend-dev` / `ingest` が従来どおり起動することを確認済み

## レビューポイント
- 削除した `APP_PORT` / `DB_TZ` がどこからも参照されていない点の確認
- 追記した任意項目のデフォルト値（コメント内の記述）がコード実装と一致している点の確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)