### PR TITLE
refactor: cmd/server を main.go のみとし設定/FK処理を移設

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,10 +116,9 @@ feature/<name>/
    - Repositories → Usecases → Handlers のワイヤリングは主に main.go で直接実施
    - `internal/app/di/` には一部のファクトリ関数を配置（例: MarketRepositoryの生成）
 4. **2つのエントリーポイント**:
-   - `cmd/server/`: REST APIサーバー（ポート8080）
-     - `main.go`: 起動・DIワイヤリング
-     - `config.go`: 環境変数パース（`CORS_ALLOWED_ORIGINS` / `COOKIE_SECURE` 等の純粋関数ヘルパー）
-     - `migrations.go`: `AutoMigrate` 後に冪等に実行するFK制約追加処理
+   - `cmd/server/main.go`: REST APIサーバー（ポート8080）の起動・DIワイヤリング
+     - 環境変数パースの純粋関数ヘルパーは `internal/app/config/`（`CORS_ALLOWED_ORIGINS` / `COOKIE_SECURE` 等）
+     - `AutoMigrate` 後のFK制約追加など feature 固有のスキーマ補助は各 feature の `adapters/` に配置（例: `internal/feature/watchlist/adapters/migration.go`）
    - `cmd/ingest/main.go`: TwelveData APIから株価データを取得するバッチジョブ
 
 ### 外部依存

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -8,6 +8,7 @@ import (
 
 	redisv9 "github.com/redis/go-redis/v9"
 
+	"stock_backend/internal/app/config"
 	"stock_backend/internal/app/router"
 	authadapters "stock_backend/internal/feature/auth/adapters"
 	authentity "stock_backend/internal/feature/auth/domain/entity"
@@ -61,7 +62,7 @@ func main() {
 			slog.Error("failed to migrate", "error", err)
 			os.Exit(1)
 		}
-		if err := addWatchlistFKConstraints(db); err != nil {
+		if err := watchlistadapters.AddFKConstraints(db); err != nil {
 			slog.Error("failed to add watchlist FK constraints", "error", err)
 			os.Exit(1)
 		}
@@ -137,7 +138,7 @@ func main() {
 	// COOKIE_SECURE を優先し、未設定なら APP_ENV=production をフォールバックとして使用
 	cookieSecureRaw := os.Getenv("COOKIE_SECURE")
 	defaultSecure := os.Getenv("APP_ENV") == "production"
-	secureCookie, ok := parseBoolString(cookieSecureRaw, defaultSecure)
+	secureCookie, ok := config.ParseBoolString(cookieSecureRaw, defaultSecure)
 	if !ok {
 		slog.Warn("invalid COOKIE_SECURE value, falling back to default", "value", cookieSecureRaw, "default", secureCookie)
 	}
@@ -150,7 +151,7 @@ func main() {
 	watchlistH := watchlisthandler.NewWatchlistHandler(watchlistUC)
 
 	// CORS許可オリジンを環境変数から読み込む（デフォルト: http://localhost:3000）
-	corsOrigins := parseCORSOrigins(os.Getenv("CORS_ALLOWED_ORIGINS"))
+	corsOrigins := config.ParseCORSOrigins(os.Getenv("CORS_ALLOWED_ORIGINS"))
 	if corsOrigins == nil {
 		corsOrigins = []string{"http://localhost:3000"}
 	}

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -1,14 +1,16 @@
-package main
+// Package config はサーバー起動時に環境変数から設定を読み取るための
+// 純粋関数ヘルパーを提供します。
+package config
 
 import (
 	"strconv"
 	"strings"
 )
 
-// parseCORSOrigins は CORS_ALLOWED_ORIGINS env の生文字列を、カンマ区切りで
+// ParseCORSOrigins は CORS_ALLOWED_ORIGINS env の生文字列を、カンマ区切りで
 // trim して空要素を除いたスライスに変換する。raw が空なら nil を返し、
 // 呼び出し側にデフォルト適用を委ねる。
-func parseCORSOrigins(raw string) []string {
+func ParseCORSOrigins(raw string) []string {
 	if raw == "" {
 		return nil
 	}
@@ -25,13 +27,13 @@ func parseCORSOrigins(raw string) []string {
 	return origins
 }
 
-// parseBoolString は raw を bool として解釈する。
+// ParseBoolString は raw を bool として解釈する。
 //   - raw が空文字の場合は (fallback, true) を返す（未設定は正常系扱い）。
 //   - strconv.ParseBool で解釈できる場合は (parsed, true) を返す。
 //   - 不正値の場合は (fallback, false) を返す。呼び出し側で警告ログなどの判断に利用する。
 //
 // env を直接読まず純粋な文字列を受け取るため、呼び出し側は os.Getenv 等で取得した値を渡す。
-func parseBoolString(raw string, fallback bool) (value bool, ok bool) {
+func ParseBoolString(raw string, fallback bool) (value bool, ok bool) {
 	if raw == "" {
 		return fallback, true
 	}

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"reflect"
@@ -61,9 +61,9 @@ func TestParseCORSOrigins(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := parseCORSOrigins(tt.raw)
+			got := ParseCORSOrigins(tt.raw)
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("parseCORSOrigins(%q) = %v, want %v", tt.raw, got, tt.want)
+				t.Errorf("ParseCORSOrigins(%q) = %v, want %v", tt.raw, got, tt.want)
 			}
 		})
 	}
@@ -142,9 +142,9 @@ func TestParseBoolString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gotValue, gotOK := parseBoolString(tt.raw, tt.fallback)
+			gotValue, gotOK := ParseBoolString(tt.raw, tt.fallback)
 			if gotValue != tt.wantValue || gotOK != tt.wantOK {
-				t.Errorf("parseBoolString(%q, %v) = (%v, %v), want (%v, %v)",
+				t.Errorf("ParseBoolString(%q, %v) = (%v, %v), want (%v, %v)",
 					tt.raw, tt.fallback, gotValue, gotOK, tt.wantValue, tt.wantOK)
 			}
 		})

--- a/internal/feature/watchlist/adapters/migration.go
+++ b/internal/feature/watchlist/adapters/migration.go
@@ -1,4 +1,4 @@
-package main
+package adapters
 
 import (
 	"log/slog"
@@ -8,9 +8,9 @@ import (
 	watchlistentity "stock_backend/internal/feature/watchlist/domain/entity"
 )
 
-// addWatchlistFKConstraints はwatchlistsテーブルのFK制約を冪等に追加します。
+// AddFKConstraints はwatchlistsテーブルのFK制約を冪等に追加します。
 // GORMのAutoMigrateはFK制約を自動生成しないため、マイグレーション後に明示的に実行します。
-func addWatchlistFKConstraints(db *gorm.DB) error {
+func AddFKConstraints(db *gorm.DB) error {
 	if !db.Migrator().HasConstraint(&watchlistentity.UserSymbol{}, "fk_watchlists_user") {
 		if err := db.Exec(`ALTER TABLE watchlists ADD CONSTRAINT fk_watchlists_user
 			FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE`).Error; err != nil {


### PR DESCRIPTION
## 概要
`cmd/server` 配下にエントリーポイント以外のファイルが同居していたため、main.go のみを残す構成へリファクタリング。設定パースのヘルパーと watchlist 用 FK 制約追加処理を、責務に応じた既存ディレクトリへ移設する。

## 変更内容
- `cmd/server/config.go` / `config_test.go` を `internal/app/config/` パッケージへ移動し、`ParseCORSOrigins` / `ParseBoolString` として公開関数化
- `cmd/server/watchlist_fk.go` を `internal/feature/watchlist/adapters/migration.go` へ移動し `AddFKConstraints` として公開
- `cmd/server/main.go` を新パッケージ参照に更新
- `CLAUDE.md` のエントリーポイント記述を新レイアウトに合わせて更新

## テスト
- `go build ./...`
- `go test ./internal/app/config/... ./internal/feature/watchlist/... ./cmd/server/... -race -cover`
- `golangci-lint run --timeout=5m`（depguard ルール含め 0 issues）

## レビューポイント
- watchlist 固有の FK 追加処理を `feature/watchlist/adapters/` 配下に置いた点（`platform/db` は depguard により feature を import 不可のため）