### PR TITLE
refactor: candles.symbol を symbol_code に改名し symbols.code への FK を追加

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -37,6 +37,10 @@ func main() {
 		slog.Error("failed to add watchlist FK constraints", "error", err)
 		os.Exit(1)
 	}
+	if err := candlesadapters.AddFKConstraints(db); err != nil {
+		slog.Error("failed to add candles FK constraints", "error", err)
+		os.Exit(1)
+	}
 
 	slog.Info("migrate ok")
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -65,6 +65,10 @@ func main() {
 			slog.Error("failed to add watchlist FK constraints", "error", err)
 			os.Exit(1)
 		}
+		if err := candlesadapters.AddFKConstraints(db); err != nil {
+			slog.Error("failed to add candles FK constraints", "error", err)
+			os.Exit(1)
+		}
 	}
 
 	// Redis接続

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -5,9 +5,9 @@
 | Name | Columns | Comment | Type |
 | ---- | ------- | ------- | ---- |
 | [public.users](public.users.md) | 5 |  | BASE TABLE |
-| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
 | [public.symbols](public.symbols.md) | 7 |  | BASE TABLE |
 | [public.watchlists](public.watchlists.md) | 6 |  | BASE TABLE |
+| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
 
 ## Relations
 
@@ -16,6 +16,7 @@ erDiagram
 
 "public.watchlists" }o--|| "public.users" : "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
 "public.watchlists" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
+"public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.users" {
   bigint id ""
@@ -23,17 +24,6 @@ erDiagram
   varchar_255_ password ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
-}
-"public.candles" {
-  bigint id ""
-  varchar_32_ symbol ""
-  varchar_16_ interval ""
-  timestamp_with_time_zone time ""
-  numeric open ""
-  numeric high ""
-  numeric low ""
-  numeric close ""
-  bigint volume ""
 }
 "public.symbols" {
   bigint id ""
@@ -51,6 +41,17 @@ erDiagram
   bigint sort_key ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+}
+"public.candles" {
+  bigint id ""
+  varchar_20_ symbol_code FK ""
+  varchar_16_ interval ""
+  timestamp_with_time_zone time ""
+  numeric open ""
+  numeric high ""
+  numeric low ""
+  numeric close ""
+  bigint volume ""
 }
 ```
 

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -5,18 +5,18 @@
 | Name | Columns | Comment | Type |
 | ---- | ------- | ------- | ---- |
 | [public.users](public.users.md) | 5 |  | BASE TABLE |
+| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
 | [public.symbols](public.symbols.md) | 7 |  | BASE TABLE |
 | [public.watchlists](public.watchlists.md) | 6 |  | BASE TABLE |
-| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
+"public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 "public.watchlists" }o--|| "public.users" : "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
 "public.watchlists" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
-"public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.users" {
   bigint id ""
@@ -24,6 +24,17 @@ erDiagram
   varchar_255_ password ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+}
+"public.candles" {
+  bigint id ""
+  varchar_20_ symbol_code FK ""
+  varchar_16_ interval ""
+  timestamp_with_time_zone time ""
+  numeric open ""
+  numeric high ""
+  numeric low ""
+  numeric close ""
+  bigint volume ""
 }
 "public.symbols" {
   bigint id ""
@@ -41,17 +52,6 @@ erDiagram
   bigint sort_key ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
-}
-"public.candles" {
-  bigint id ""
-  varchar_20_ symbol_code FK ""
-  varchar_16_ interval ""
-  timestamp_with_time_zone time ""
-  numeric open ""
-  numeric high ""
-  numeric low ""
-  numeric close ""
-  bigint volume ""
 }
 ```
 

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -18,8 +18,8 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
-| fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | candles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 
 ## Indexes
 

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -5,7 +5,7 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | bigint | nextval('candles_id_seq'::regclass) | false |  |  |  |
-| symbol | varchar(32) |  | false |  |  |  |
+| symbol_code | varchar(20) |  | false |  | [public.symbols](public.symbols.md) |  |
 | interval | varchar(16) |  | false |  |  |  |
 | time | timestamp with time zone |  | false |  |  |  |
 | open | numeric |  | false |  |  |  |
@@ -18,6 +18,7 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | candles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
@@ -25,17 +26,18 @@
 | Name | Definition |
 | ---- | ---------- |
 | candles_pkey | CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id) |
-| candle_sym_int_time | CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol, "interval", "time") |
+| candle_sym_int_time | CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol_code, "interval", "time") |
 
 ## Relations
 
 ```mermaid
 erDiagram
 
+"public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.candles" {
   bigint id ""
-  varchar_32_ symbol ""
+  varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""
   numeric open ""
@@ -43,6 +45,15 @@ erDiagram
   numeric low ""
   numeric close ""
   bigint volume ""
+}
+"public.symbols" {
+  bigint id ""
+  varchar_20_ code ""
+  varchar_255_ name ""
+  varchar_100_ market ""
+  boolean is_active ""
+  timestamp_with_time_zone created_at ""
+  timestamp_with_time_zone updated_at ""
 }
 ```
 

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -5,7 +5,7 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | bigint | nextval('symbols_id_seq'::regclass) | false |  |  |  |
-| code | varchar(20) |  | false | [public.watchlists](public.watchlists.md) |  |  |
+| code | varchar(20) |  | false | [public.watchlists](public.watchlists.md) [public.candles](public.candles.md) |  |  |
 | name | varchar(255) |  | false |  |  |  |
 | market | varchar(100) |  | false |  |  |  |
 | is_active | boolean | true | false |  |  |  |
@@ -31,6 +31,7 @@
 erDiagram
 
 "public.watchlists" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
+"public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.symbols" {
   bigint id ""
@@ -48,6 +49,17 @@ erDiagram
   bigint sort_key ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+}
+"public.candles" {
+  bigint id ""
+  varchar_20_ symbol_code FK ""
+  varchar_16_ interval ""
+  timestamp_with_time_zone time ""
+  numeric open ""
+  numeric high ""
+  numeric low ""
+  numeric close ""
+  bigint volume ""
 }
 ```
 

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -5,7 +5,7 @@
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | bigint | nextval('symbols_id_seq'::regclass) | false |  |  |  |
-| code | varchar(20) |  | false | [public.watchlists](public.watchlists.md) [public.candles](public.candles.md) |  |  |
+| code | varchar(20) |  | false | [public.candles](public.candles.md) [public.watchlists](public.watchlists.md) |  |  |
 | name | varchar(255) |  | false |  |  |  |
 | market | varchar(100) |  | false |  |  |  |
 | is_active | boolean | true | false |  |  |  |
@@ -30,8 +30,8 @@
 ```mermaid
 erDiagram
 
-"public.watchlists" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 "public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
+"public.watchlists" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.symbols" {
   bigint id ""
@@ -39,14 +39,6 @@ erDiagram
   varchar_255_ name ""
   varchar_100_ market ""
   boolean is_active ""
-  timestamp_with_time_zone created_at ""
-  timestamp_with_time_zone updated_at ""
-}
-"public.watchlists" {
-  bigint id ""
-  bigint user_id FK ""
-  varchar_20_ symbol_code FK ""
-  bigint sort_key ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
 }
@@ -60,6 +52,14 @@ erDiagram
   numeric low ""
   numeric close ""
   bigint volume ""
+}
+"public.watchlists" {
+  bigint id ""
+  bigint user_id FK ""
+  varchar_20_ symbol_code FK ""
+  bigint sort_key ""
+  timestamp_with_time_zone created_at ""
+  timestamp_with_time_zone updated_at ""
 }
 ```
 

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -64,6 +64,104 @@
       ]
     },
     {
+      "name": "public.candles",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('candles_id_seq'::regclass)"
+        },
+        {
+          "name": "symbol_code",
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "interval",
+          "type": "varchar(16)",
+          "nullable": false
+        },
+        {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "nullable": false
+        },
+        {
+          "name": "open",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "high",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "low",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "close",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "volume",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "candles_pkey",
+          "def": "CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id)",
+          "table": "public.candles",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "candle_sym_int_time",
+          "def": "CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol_code, \"interval\", \"time\")",
+          "table": "public.candles",
+          "columns": [
+            "symbol_code",
+            "interval",
+            "time"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "candles_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "fk_candles_symbol",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
+          "table": "public.candles",
+          "referenced_table": "public.symbols",
+          "columns": [
+            "symbol_code"
+          ],
+          "referenced_columns": [
+            "code"
+          ]
+        }
+      ]
+    },
+    {
       "name": "public.symbols",
       "type": "BASE TABLE",
       "columns": [
@@ -239,107 +337,22 @@
           ]
         }
       ]
-    },
-    {
-      "name": "public.candles",
-      "type": "BASE TABLE",
-      "columns": [
-        {
-          "name": "id",
-          "type": "bigint",
-          "nullable": false,
-          "default": "nextval('candles_id_seq'::regclass)"
-        },
-        {
-          "name": "symbol_code",
-          "type": "varchar(20)",
-          "nullable": false
-        },
-        {
-          "name": "interval",
-          "type": "varchar(16)",
-          "nullable": false
-        },
-        {
-          "name": "time",
-          "type": "timestamp with time zone",
-          "nullable": false
-        },
-        {
-          "name": "open",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "high",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "low",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "close",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "volume",
-          "type": "bigint",
-          "nullable": false,
-          "default": "0"
-        }
-      ],
-      "indexes": [
-        {
-          "name": "candles_pkey",
-          "def": "CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id)",
-          "table": "public.candles",
-          "columns": [
-            "id"
-          ]
-        },
-        {
-          "name": "candle_sym_int_time",
-          "def": "CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol_code, \"interval\", \"time\")",
-          "table": "public.candles",
-          "columns": [
-            "symbol_code",
-            "interval",
-            "time"
-          ]
-        }
-      ],
-      "constraints": [
-        {
-          "name": "fk_candles_symbol",
-          "type": "FOREIGN KEY",
-          "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
-          "table": "public.candles",
-          "referenced_table": "public.symbols",
-          "columns": [
-            "symbol_code"
-          ],
-          "referenced_columns": [
-            "code"
-          ]
-        },
-        {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "id"
-          ]
-        }
-      ]
     }
   ],
   "relations": [
+    {
+      "table": "public.candles",
+      "columns": [
+        "symbol_code"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.symbols",
+      "parent_columns": [
+        "code"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
+    },
     {
       "table": "public.watchlists",
       "columns": [
@@ -355,19 +368,6 @@
     },
     {
       "table": "public.watchlists",
-      "columns": [
-        "symbol_code"
-      ],
-      "cardinality": "zero_or_more",
-      "parent_table": "public.symbols",
-      "parent_columns": [
-        "code"
-      ],
-      "parent_cardinality": "exactly_one",
-      "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
-    },
-    {
-      "table": "public.candles",
       "columns": [
         "symbol_code"
       ],

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -64,91 +64,6 @@
       ]
     },
     {
-      "name": "public.candles",
-      "type": "BASE TABLE",
-      "columns": [
-        {
-          "name": "id",
-          "type": "bigint",
-          "nullable": false,
-          "default": "nextval('candles_id_seq'::regclass)"
-        },
-        {
-          "name": "symbol",
-          "type": "varchar(32)",
-          "nullable": false
-        },
-        {
-          "name": "interval",
-          "type": "varchar(16)",
-          "nullable": false
-        },
-        {
-          "name": "time",
-          "type": "timestamp with time zone",
-          "nullable": false
-        },
-        {
-          "name": "open",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "high",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "low",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "close",
-          "type": "numeric",
-          "nullable": false
-        },
-        {
-          "name": "volume",
-          "type": "bigint",
-          "nullable": false,
-          "default": "0"
-        }
-      ],
-      "indexes": [
-        {
-          "name": "candles_pkey",
-          "def": "CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id)",
-          "table": "public.candles",
-          "columns": [
-            "id"
-          ]
-        },
-        {
-          "name": "candle_sym_int_time",
-          "def": "CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol, \"interval\", \"time\")",
-          "table": "public.candles",
-          "columns": [
-            "symbol",
-            "interval",
-            "time"
-          ]
-        }
-      ],
-      "constraints": [
-        {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "id"
-          ]
-        }
-      ]
-    },
-    {
       "name": "public.symbols",
       "type": "BASE TABLE",
       "columns": [
@@ -324,6 +239,104 @@
           ]
         }
       ]
+    },
+    {
+      "name": "public.candles",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('candles_id_seq'::regclass)"
+        },
+        {
+          "name": "symbol_code",
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "interval",
+          "type": "varchar(16)",
+          "nullable": false
+        },
+        {
+          "name": "time",
+          "type": "timestamp with time zone",
+          "nullable": false
+        },
+        {
+          "name": "open",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "high",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "low",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "close",
+          "type": "numeric",
+          "nullable": false
+        },
+        {
+          "name": "volume",
+          "type": "bigint",
+          "nullable": false,
+          "default": "0"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "candles_pkey",
+          "def": "CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id)",
+          "table": "public.candles",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "candle_sym_int_time",
+          "def": "CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol_code, \"interval\", \"time\")",
+          "table": "public.candles",
+          "columns": [
+            "symbol_code",
+            "interval",
+            "time"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "fk_candles_symbol",
+          "type": "FOREIGN KEY",
+          "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
+          "table": "public.candles",
+          "referenced_table": "public.symbols",
+          "columns": [
+            "symbol_code"
+          ],
+          "referenced_columns": [
+            "code"
+          ]
+        },
+        {
+          "name": "candles_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
     }
   ],
   "relations": [
@@ -342,6 +355,19 @@
     },
     {
       "table": "public.watchlists",
+      "columns": [
+        "symbol_code"
+      ],
+      "cardinality": "zero_or_more",
+      "parent_table": "public.symbols",
+      "parent_columns": [
+        "code"
+      ],
+      "parent_cardinality": "exactly_one",
+      "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
+    },
+    {
+      "table": "public.candles",
       "columns": [
         "symbol_code"
       ],

--- a/internal/feature/candles/README.md
+++ b/internal/feature/candles/README.md
@@ -41,7 +41,7 @@ sequenceDiagram
         else Cache MISS
             Redis-->>Cache: nil
             Cache->>Repository: Find(symbol, interval, outputsize)
-            Repository->>DB: SELECT * FROM candles WHERE symbol=? AND interval=? ORDER BY time DESC LIMIT ?
+            Repository->>DB: SELECT * FROM candles WHERE symbol_code=? AND interval=? ORDER BY time DESC LIMIT ?
             DB-->>Repository: Rows
             Repository-->>Cache: []Candle
             Cache->>Redis: SET candles:AAPL:1day:200 (TTL)
@@ -280,7 +280,7 @@ graph TB
 
 #### ドメイン層
 - **Candle Entity**（[domain/entity/candle.go](domain/entity/candle.go)）: OHLCVローソク足データモデル
-  - `Symbol`: 銘柄コード（例: "AAPL", "7203.T"）
+  - `SymbolCode`: 銘柄コード（例: "AAPL", "7203.T"）。`symbols.code` への外部キー
   - `Interval`: 時間間隔（例: "1day", "1week", "1month"）
   - `Time`: ローソク足期間のタイムスタンプ
   - `Open`, `High`, `Low`, `Close`: 価格データ
@@ -290,7 +290,8 @@ graph TB
 - **candleDBRepository**: CandleRepositoryのリポジトリ実装（GORMを使用）
   - `Find`: 時間の降順でローソク足を取得
   - `UpsertBatch`: `ON CONFLICT DO UPDATE`によるバッチ挿入/更新
-  - （symbol, interval, time）の複合ユニークインデックス
+  - （symbol_code, interval, time）の複合ユニークインデックス
+  - `symbol_code` は `symbols.code` への FK（ON DELETE RESTRICT、`migration.go` の `AddFKConstraints` で付与）
 
 #### アダプター層（キャッシュ）
 - **CachingCandleRepository**（[adapters/caching_candle_repository.go](adapters/caching_candle_repository.go)）: Redisキャッシュデコレータ

--- a/internal/feature/candles/adapters/caching_candle_repository.go
+++ b/internal/feature/candles/adapters/caching_candle_repository.go
@@ -71,7 +71,7 @@ func (c *CachingCandleRepository) UpsertBatch(ctx context.Context, candles []ent
 	}
 	seen := map[symbolInterval]struct{}{}
 	for _, cd := range candles {
-		seen[symbolInterval{cd.Symbol, cd.Interval}] = struct{}{}
+		seen[symbolInterval{cd.SymbolCode, cd.Interval}] = struct{}{}
 	}
 
 	// 各 symbol+interval のキャッシュを削除し、最新データで再生成（ウォームアップ）

--- a/internal/feature/candles/adapters/caching_candle_repository_test.go
+++ b/internal/feature/candles/adapters/caching_candle_repository_test.go
@@ -89,7 +89,7 @@ func TestCachingCandleRepository_Find_NilRedis(t *testing.T) {
 	t.Parallel()
 
 	expectedCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
 	}
 
 	inner := &mockCandleRepo{
@@ -118,7 +118,7 @@ func TestCachingCandleRepository_Find_CacheHit(t *testing.T) {
 	defer func() { _ = rdb.Close() }()
 
 	cachedCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
 	}
 	cachedJSON, _ := json.Marshal(cachedCandles)
 
@@ -158,11 +158,11 @@ func TestCachingCandleRepository_Find_CacheHit_Slices(t *testing.T) {
 
 	// キャッシュには5件保存されている
 	cachedCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 100.0},
-		{Symbol: "AAPL", Interval: "1day", Open: 101.0},
-		{Symbol: "AAPL", Interval: "1day", Open: 102.0},
-		{Symbol: "AAPL", Interval: "1day", Open: 103.0},
-		{Symbol: "AAPL", Interval: "1day", Open: 104.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 100.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 101.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 102.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 103.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 104.0},
 	}
 	cachedJSON, _ := json.Marshal(cachedCandles)
 
@@ -192,7 +192,7 @@ func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 	defer func() { _ = rdb.Close() }()
 
 	expectedCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
 	}
 	expectedJSON, _ := json.Marshal(expectedCandles)
 
@@ -260,7 +260,7 @@ func TestCachingCandleRepository_Find_CorruptedCache(t *testing.T) {
 	defer func() { _ = rdb.Close() }()
 
 	expectedCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
 	}
 	expectedJSON, _ := json.Marshal(expectedCandles)
 
@@ -304,7 +304,7 @@ func TestCachingCandleRepository_UpsertBatch_NilRedis(t *testing.T) {
 
 	repo := NewCachingCandleRepository(nil, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day"},
+		{SymbolCode: "AAPL", Interval: "1day"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -327,7 +327,7 @@ func TestCachingCandleRepository_UpsertBatch_InnerError(t *testing.T) {
 
 	repo := NewCachingCandleRepository(nil, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day"},
+		{SymbolCode: "AAPL", Interval: "1day"},
 	})
 
 	if !errors.Is(err, expectedErr) {
@@ -363,7 +363,7 @@ func TestCachingCandleRepository_UpsertBatch_CacheWarmUp(t *testing.T) {
 	defer func() { _ = rdb.Close() }()
 
 	warmCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
 	}
 	warmJSON, _ := json.Marshal(warmCandles)
 
@@ -382,7 +382,7 @@ func TestCachingCandleRepository_UpsertBatch_CacheWarmUp(t *testing.T) {
 
 	repo := NewCachingCandleRepository(rdb, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day"},
+		{SymbolCode: "AAPL", Interval: "1day"},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -400,7 +400,7 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
 	defer func() { _ = rdb.Close() }()
 
 	warmCandles := []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Open: 150.0},
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0},
 	}
 	warmJSON, _ := json.Marshal(warmCandles)
 
@@ -421,9 +421,9 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
 
 	repo := NewCachingCandleRepository(rdb, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []entity.Candle{
-		{Symbol: "AAPL", Interval: "1day", Time: time.Now()},
-		{Symbol: "AAPL", Interval: "1day", Time: time.Now().Add(-24 * time.Hour)},
-		{Symbol: "AAPL", Interval: "1day", Time: time.Now().Add(-48 * time.Hour)},
+		{SymbolCode: "AAPL", Interval: "1day", Time: time.Now()},
+		{SymbolCode: "AAPL", Interval: "1day", Time: time.Now().Add(-24 * time.Hour)},
+		{SymbolCode: "AAPL", Interval: "1day", Time: time.Now().Add(-48 * time.Hour)},
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/feature/candles/adapters/candle_repository.go
+++ b/internal/feature/candles/adapters/candle_repository.go
@@ -30,7 +30,7 @@ func NewCandleRepository(db *gorm.DB) *candleDBRepository {
 // symbol_code は symbols.code への外部キー（FK制約は AddFKConstraints で付与）。
 type CandleModel struct {
 	ID         uint      `gorm:"primaryKey"`
-	SymbolCode string    `gorm:"size:20;not null;column:symbol_code;uniqueIndex:candle_sym_int_time,priority:1"`
+	SymbolCode string    `gorm:"size:20;not null;uniqueIndex:candle_sym_int_time,priority:1"`
 	Interval   string    `gorm:"size:16;not null;uniqueIndex:candle_sym_int_time,priority:2"`
 	Time       time.Time `gorm:"not null;uniqueIndex:candle_sym_int_time,priority:3"`
 

--- a/internal/feature/candles/adapters/candle_repository.go
+++ b/internal/feature/candles/adapters/candle_repository.go
@@ -26,12 +26,13 @@ func NewCandleRepository(db *gorm.DB) *candleDBRepository {
 }
 
 // CandleModel はローソク足データのデータベースモデルです。
-// Upsert操作のために（symbol, interval, time）の複合ユニークインデックスを使用します。
+// Upsert操作のために（symbol_code, interval, time）の複合ユニークインデックスを使用します。
+// symbol_code は symbols.code への外部キー（FK制約は AddFKConstraints で付与）。
 type CandleModel struct {
-	ID       uint      `gorm:"primaryKey"`
-	Symbol   string    `gorm:"size:32;not null;uniqueIndex:candle_sym_int_time,priority:1"`
-	Interval string    `gorm:"size:16;not null;uniqueIndex:candle_sym_int_time,priority:2"`
-	Time     time.Time `gorm:"not null;uniqueIndex:candle_sym_int_time,priority:3"`
+	ID         uint      `gorm:"primaryKey"`
+	SymbolCode string    `gorm:"size:20;not null;column:symbol_code;uniqueIndex:candle_sym_int_time,priority:1"`
+	Interval   string    `gorm:"size:16;not null;uniqueIndex:candle_sym_int_time,priority:2"`
+	Time       time.Time `gorm:"not null;uniqueIndex:candle_sym_int_time,priority:3"`
 
 	Open   float64 `gorm:"not null"`
 	High   float64 `gorm:"not null"`
@@ -48,14 +49,14 @@ func (CandleModel) TableName() string {
 // toModel はドメインエンティティをデータベースモデルに変換します。
 func toModel(e entity.Candle) CandleModel {
 	return CandleModel{
-		Symbol:   e.Symbol,
-		Interval: e.Interval,
-		Time:     e.Time,
-		Open:     e.Open,
-		High:     e.High,
-		Low:      e.Low,
-		Close:    e.Close,
-		Volume:   e.Volume,
+		SymbolCode: e.SymbolCode,
+		Interval:   e.Interval,
+		Time:       e.Time,
+		Open:       e.Open,
+		High:       e.High,
+		Low:        e.Low,
+		Close:      e.Close,
+		Volume:     e.Volume,
 	}
 }
 
@@ -71,7 +72,7 @@ func (r *candleDBRepository) UpsertBatch(ctx context.Context, candles []entity.C
 	}
 
 	return r.db.WithContext(ctx).Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "symbol"}, {Name: "interval"}, {Name: "time"}},
+		Columns:   []clause.Column{{Name: "symbol_code"}, {Name: "interval"}, {Name: "time"}},
 		DoUpdates: clause.AssignmentColumns([]string{"open", "high", "low", "close", "volume"}),
 	}).Create(&ms).Error
 }
@@ -81,7 +82,7 @@ func (r *candleDBRepository) UpsertBatch(ctx context.Context, candles []entity.C
 func (r *candleDBRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
 	var rows []CandleModel
 	q := r.db.WithContext(ctx).
-		Where("symbol = ? AND \"interval\" = ?", symbol, interval).
+		Where("symbol_code = ? AND \"interval\" = ?", symbol, interval).
 		Order("\"time\" DESC")
 	if outputsize > 0 {
 		q = q.Limit(outputsize)
@@ -92,14 +93,14 @@ func (r *candleDBRepository) Find(ctx context.Context, symbol, interval string, 
 	out := make([]entity.Candle, 0, len(rows))
 	for _, m := range rows {
 		out = append(out, entity.Candle{
-			Symbol:   m.Symbol,
-			Interval: m.Interval,
-			Time:     m.Time,
-			Open:     m.Open,
-			High:     m.High,
-			Low:      m.Low,
-			Close:    m.Close,
-			Volume:   m.Volume,
+			SymbolCode: m.SymbolCode,
+			Interval:   m.Interval,
+			Time:       m.Time,
+			Open:       m.Open,
+			High:       m.High,
+			Low:        m.Low,
+			Close:      m.Close,
+			Volume:     m.Volume,
 		})
 	}
 	return out, nil

--- a/internal/feature/candles/adapters/candle_repository_test.go
+++ b/internal/feature/candles/adapters/candle_repository_test.go
@@ -31,14 +31,14 @@ func seedCandle(t *testing.T, db *gorm.DB, symbol, interval string, time time.Ti
 	t.Helper()
 
 	candle := &CandleModel{
-		Symbol:   symbol,
-		Interval: interval,
-		Time:     time,
-		Open:     100.0,
-		High:     110.0,
-		Low:      90.0,
-		Close:    105.0,
-		Volume:   1000,
+		SymbolCode: symbol,
+		Interval:   interval,
+		Time:       time,
+		Open:       100.0,
+		High:       110.0,
+		Low:        90.0,
+		Close:      105.0,
+		Volume:     1000,
 	}
 	err := db.Create(candle).Error
 	require.NoError(t, err, "failed to seed candle")
@@ -73,14 +73,14 @@ func TestCandleRepository_UpsertBatch(t *testing.T) {
 			name: "success: insert single candle",
 			candles: []entity.Candle{
 				{
-					Symbol:   "AAPL",
-					Interval: "1day",
-					Time:     baseTime,
-					Open:     100.0,
-					High:     110.0,
-					Low:      90.0,
-					Close:    105.0,
-					Volume:   1000,
+					SymbolCode: "AAPL",
+					Interval:   "1day",
+					Time:       baseTime,
+					Open:       100.0,
+					High:       110.0,
+					Low:        90.0,
+					Close:      105.0,
+					Volume:     1000,
 				},
 			},
 			wantErr: false,
@@ -94,24 +94,24 @@ func TestCandleRepository_UpsertBatch(t *testing.T) {
 			name: "success: insert multiple candles",
 			candles: []entity.Candle{
 				{
-					Symbol:   "AAPL",
-					Interval: "1day",
-					Time:     baseTime,
-					Open:     100.0,
-					High:     110.0,
-					Low:      90.0,
-					Close:    105.0,
-					Volume:   1000,
+					SymbolCode: "AAPL",
+					Interval:   "1day",
+					Time:       baseTime,
+					Open:       100.0,
+					High:       110.0,
+					Low:        90.0,
+					Close:      105.0,
+					Volume:     1000,
 				},
 				{
-					Symbol:   "AAPL",
-					Interval: "1day",
-					Time:     baseTime.AddDate(0, 0, 1),
-					Open:     105.0,
-					High:     115.0,
-					Low:      95.0,
-					Close:    110.0,
-					Volume:   1500,
+					SymbolCode: "AAPL",
+					Interval:   "1day",
+					Time:       baseTime.AddDate(0, 0, 1),
+					Open:       105.0,
+					High:       115.0,
+					Low:        95.0,
+					Close:      110.0,
+					Volume:     1500,
 				},
 			},
 			wantErr: false,
@@ -135,14 +135,14 @@ func TestCandleRepository_UpsertBatch(t *testing.T) {
 			name: "success: upsert updates existing candle",
 			candles: []entity.Candle{
 				{
-					Symbol:   "AAPL",
-					Interval: "1day",
-					Time:     baseTime,
-					Open:     200.0,
-					High:     220.0,
-					Low:      180.0,
-					Close:    210.0,
-					Volume:   2000,
+					SymbolCode: "AAPL",
+					Interval:   "1day",
+					Time:       baseTime,
+					Open:       200.0,
+					High:       220.0,
+					Low:        180.0,
+					Close:      210.0,
+					Volume:     2000,
 				},
 			},
 			wantErr: false,
@@ -167,24 +167,24 @@ func TestCandleRepository_UpsertBatch(t *testing.T) {
 			name: "success: upsert with mixed insert and update",
 			candles: []entity.Candle{
 				{
-					Symbol:   "AAPL",
-					Interval: "1day",
-					Time:     baseTime,
-					Open:     200.0,
-					High:     220.0,
-					Low:      180.0,
-					Close:    210.0,
-					Volume:   2000,
+					SymbolCode: "AAPL",
+					Interval:   "1day",
+					Time:       baseTime,
+					Open:       200.0,
+					High:       220.0,
+					Low:        180.0,
+					Close:      210.0,
+					Volume:     2000,
 				},
 				{
-					Symbol:   "AAPL",
-					Interval: "1day",
-					Time:     baseTime.AddDate(0, 0, 1),
-					Open:     210.0,
-					High:     230.0,
-					Low:      190.0,
-					Close:    220.0,
-					Volume:   2500,
+					SymbolCode: "AAPL",
+					Interval:   "1day",
+					Time:       baseTime.AddDate(0, 0, 1),
+					Open:       210.0,
+					High:       230.0,
+					Low:        190.0,
+					Close:      220.0,
+					Volume:     2500,
 				},
 			},
 			wantErr: false,
@@ -275,7 +275,7 @@ func TestCandleRepository_Find(t *testing.T) {
 			},
 			validateFunc: func(t *testing.T, candles []entity.Candle) {
 				assert.Len(t, candles, 1, "should return only AAPL candle")
-				assert.Equal(t, "AAPL", candles[0].Symbol)
+				assert.Equal(t, "AAPL", candles[0].SymbolCode)
 			},
 		},
 		{
@@ -376,14 +376,14 @@ func TestCandleRepository_Find_EntityMapping(t *testing.T) {
 
 	testTime := time.Date(2024, 6, 15, 12, 0, 0, 0, time.UTC)
 	candle := &CandleModel{
-		Symbol:   "AAPL",
-		Interval: "1day",
-		Time:     testTime,
-		Open:     150.5,
-		High:     155.75,
-		Low:      149.25,
-		Close:    154.0,
-		Volume:   5000000,
+		SymbolCode: "AAPL",
+		Interval:   "1day",
+		Time:       testTime,
+		Open:       150.5,
+		High:       155.75,
+		Low:        149.25,
+		Close:      154.0,
+		Volume:     5000000,
 	}
 	err := db.Create(candle).Error
 	require.NoError(t, err)
@@ -392,7 +392,7 @@ func TestCandleRepository_Find_EntityMapping(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
-	assert.Equal(t, "AAPL", result[0].Symbol, "Symbol does not match")
+	assert.Equal(t, "AAPL", result[0].SymbolCode, "SymbolCode does not match")
 	assert.Equal(t, "1day", result[0].Interval, "Interval does not match")
 	assert.Equal(t, testTime.Unix(), result[0].Time.Unix(), "Time does not match")
 	assert.Equal(t, 150.5, result[0].Open, "Open does not match")

--- a/internal/feature/candles/adapters/migration.go
+++ b/internal/feature/candles/adapters/migration.go
@@ -1,0 +1,20 @@
+package adapters
+
+import (
+	"log/slog"
+
+	"gorm.io/gorm"
+)
+
+// AddFKConstraints は candles テーブルの FK 制約を冪等に追加します。
+// GORMのAutoMigrateはFK制約を自動生成しないため、マイグレーション後に明示的に実行します。
+func AddFKConstraints(db *gorm.DB) error {
+	if !db.Migrator().HasConstraint(&CandleModel{}, "fk_candles_symbol") {
+		if err := db.Exec(`ALTER TABLE candles ADD CONSTRAINT fk_candles_symbol
+			FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT`).Error; err != nil {
+			return err
+		}
+		slog.Info("added FK constraint: fk_candles_symbol")
+	}
+	return nil
+}

--- a/internal/feature/candles/domain/entity/candle.go
+++ b/internal/feature/candles/domain/entity/candle.go
@@ -5,7 +5,7 @@ import "time"
 
 // Candle は特定の銘柄・時間間隔におけるOHLCV（始値、高値、安値、終値、出来高）ローソク足データを表します。
 type Candle struct {
-	SymbolCode string    // 銘柄コード（例: "AAPL", "7203.T"）。symbols.code への FK。
+	SymbolCode string    // 銘柄コード（例: "AAPL", "7203.T"）
 	Interval   string    // 時間間隔（例: "1day", "1week", "1month"）
 	Time       time.Time // このローソク足期間の開始タイムスタンプ
 	Open       float64   // 始値

--- a/internal/feature/candles/domain/entity/candle.go
+++ b/internal/feature/candles/domain/entity/candle.go
@@ -5,12 +5,12 @@ import "time"
 
 // Candle は特定の銘柄・時間間隔におけるOHLCV（始値、高値、安値、終値、出来高）ローソク足データを表します。
 type Candle struct {
-	Symbol   string    // 銘柄コード（例: "AAPL", "7203.T"）
-	Interval string    // 時間間隔（例: "1day", "1week", "1month"）
-	Time     time.Time // このローソク足期間の開始タイムスタンプ
-	Open     float64   // 始値
-	High     float64   // 期間中の高値
-	Low      float64   // 期間中の安値
-	Close    float64   // 終値
-	Volume   int64     // 出来高
+	SymbolCode string    // 銘柄コード（例: "AAPL", "7203.T"）。symbols.code への FK。
+	Interval   string    // 時間間隔（例: "1day", "1week", "1month"）
+	Time       time.Time // このローソク足期間の開始タイムスタンプ
+	Open       float64   // 始値
+	High       float64   // 期間中の高値
+	Low        float64   // 期間中の安値
+	Close      float64   // 終値
+	Volume     int64     // 出来高
 }

--- a/internal/feature/candles/usecase/candle_aggregation.go
+++ b/internal/feature/candles/usecase/candle_aggregation.go
@@ -99,7 +99,7 @@ func aggregate(
 	for _, k := range keyOrder {
 		b := buckets[k]
 		out = append(out, entity.Candle{
-			// Symbol と Interval は呼び出し元（ingestOne）でセットする
+			// SymbolCode と Interval は呼び出し元（ingestOne）でセットする
 			Time:   b.time,
 			Open:   b.open,
 			High:   b.high,

--- a/internal/feature/candles/usecase/candle_aggregation_test.go
+++ b/internal/feature/candles/usecase/candle_aggregation_test.go
@@ -190,7 +190,7 @@ func TestAggregateMonthly(t *testing.T) {
 	}
 }
 
-// assertCandlesEqual は2つの Candle スライスを比較します（Symbol/Interval は無視）。
+// assertCandlesEqual は2つの Candle スライスを比較します（SymbolCode/Interval は無視）。
 func assertCandlesEqual(t *testing.T, got, want []entity.Candle) {
 	t.Helper()
 	if want == nil {

--- a/internal/feature/candles/usecase/ingest_usecase.go
+++ b/internal/feature/candles/usecase/ingest_usecase.go
@@ -56,7 +56,7 @@ func (iu *IngestUsecase) ingestOne(ctx context.Context, symbol string, outputsiz
 	}
 
 	for i := range daily {
-		daily[i].Symbol = symbol
+		daily[i].SymbolCode = symbol
 		daily[i].Interval = "1day"
 	}
 
@@ -64,7 +64,7 @@ func (iu *IngestUsecase) ingestOne(ctx context.Context, symbol string, outputsiz
 		return int(t.Weekday()) == 1 // 月曜日が ISO 週の開始
 	})
 	for i := range weekly {
-		weekly[i].Symbol = symbol
+		weekly[i].SymbolCode = symbol
 		weekly[i].Interval = "1week"
 	}
 
@@ -72,7 +72,7 @@ func (iu *IngestUsecase) ingestOne(ctx context.Context, symbol string, outputsiz
 		return t.Day() == 1 // 1日が月の開始
 	})
 	for i := range monthly {
-		monthly[i].Symbol = symbol
+		monthly[i].SymbolCode = symbol
 		monthly[i].Interval = "1month"
 	}
 
@@ -91,7 +91,7 @@ func dedupCandles(candles []entity.Candle) []entity.Candle {
 	seen := make(map[string]struct{}, len(candles))
 	out := make([]entity.Candle, 0, len(candles))
 	for _, c := range candles {
-		key := fmt.Sprintf("%s|%s|%d", c.Symbol, c.Interval, c.Time.Unix())
+		key := fmt.Sprintf("%s|%s|%d", c.SymbolCode, c.Interval, c.Time.Unix())
 		if _, ok := seen[key]; !ok {
 			seen[key] = struct{}{}
 			out = append(out, c)

--- a/internal/feature/candles/usecase/ingest_usecase_test.go
+++ b/internal/feature/candles/usecase/ingest_usecase_test.go
@@ -80,32 +80,32 @@ func TestDedupCandles(t *testing.T) {
 		{
 			name: "重複なしの場合は全件返す",
 			input: []entity.Candle{
-				{Symbol: "AAPL", Interval: "1day", Time: base},
-				{Symbol: "AAPL", Interval: "1day", Time: base.AddDate(0, 0, 1)},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base.AddDate(0, 0, 1)},
 			},
 			wantLen: 2,
 		},
 		{
 			name: "同一タイムスタンプの重複は1件に絞る",
 			input: []entity.Candle{
-				{Symbol: "AAPL", Interval: "1day", Time: base},
-				{Symbol: "AAPL", Interval: "1day", Time: base},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base},
 			},
 			wantLen: 1,
 		},
 		{
 			name: "symbolが異なれば別エントリとして扱う",
 			input: []entity.Candle{
-				{Symbol: "AAPL", Interval: "1day", Time: base},
-				{Symbol: "GOOG", Interval: "1day", Time: base},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base},
+				{SymbolCode: "GOOG", Interval: "1day", Time: base},
 			},
 			wantLen: 2,
 		},
 		{
 			name: "intervalが異なれば別エントリとして扱う",
 			input: []entity.Candle{
-				{Symbol: "AAPL", Interval: "1day", Time: base},
-				{Symbol: "AAPL", Interval: "1week", Time: base},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base},
+				{SymbolCode: "AAPL", Interval: "1week", Time: base},
 			},
 			wantLen: 2,
 		},
@@ -117,9 +117,9 @@ func TestDedupCandles(t *testing.T) {
 		{
 			name: "元スライスを変更しない（backing array 非共有）",
 			input: []entity.Candle{
-				{Symbol: "AAPL", Interval: "1day", Time: base, Close: 100},
-				{Symbol: "AAPL", Interval: "1day", Time: base, Close: 200}, // 重複
-				{Symbol: "AAPL", Interval: "1day", Time: base.AddDate(0, 0, 1), Close: 300},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base, Close: 100},
+				{SymbolCode: "AAPL", Interval: "1day", Time: base, Close: 200}, // 重複
+				{SymbolCode: "AAPL", Interval: "1day", Time: base.AddDate(0, 0, 1), Close: 300},
 			},
 			wantLen: 2,
 		},
@@ -147,7 +147,7 @@ func TestDedupCandles(t *testing.T) {
 			// 出力に重複がないことを確認
 			seen := make(map[string]struct{})
 			for _, c := range got {
-				key := fmt.Sprintf("%s|%s|%d", c.Symbol, c.Interval, c.Time.Unix())
+				key := fmt.Sprintf("%s|%s|%d", c.SymbolCode, c.Interval, c.Time.Unix())
 				if _, exists := seen[key]; exists {
 					t.Errorf("duplicate key in output: %s", key)
 				}
@@ -200,8 +200,8 @@ func TestIngestUsecase_ingestOne(t *testing.T) {
 			verifyCandles: func(t *testing.T, candles []entity.Candle) {
 				counts := map[string]int{}
 				for _, c := range candles {
-					if c.Symbol != "AAPL" {
-						t.Errorf("candle Symbol not set: got %s, want AAPL", c.Symbol)
+					if c.SymbolCode != "AAPL" {
+						t.Errorf("candle SymbolCode not set: got %s, want AAPL", c.SymbolCode)
 					}
 					counts[c.Interval]++
 				}
@@ -360,7 +360,7 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 				return mockCandles, nil
 			},
 			mockUpsertBatchFunc: func(ctx context.Context, candles []entity.Candle) error {
-				if len(candles) > 0 && candles[0].Symbol == "AAPL" {
+				if len(candles) > 0 && candles[0].SymbolCode == "AAPL" {
 					return ErrDB
 				}
 				return nil


### PR DESCRIPTION
## 概要

`candles.symbol` が `symbols.code` への外部キー制約を持たず、さらにカラム長・命名が watchlists 側と不整合（varchar(32) / `symbol` vs varchar(20) / `symbol_code`）だったため、存在しない銘柄のローソク足が混入しうる状態だった。本 PR でスキーマを watchlist と揃え、整合性を制約レベルで担保する。

## 変更内容

- `CandleModel` / `entity.Candle` のフィールド `Symbol` を `SymbolCode` にリネーム
- DB カラムを `symbol_code varchar(20)` に変更し、`uniqueIndex` / `OnConflict` / `Find` クエリを追従
- `internal/feature/candles/adapters/migration.go` を追加し、`fk_candles_symbol`（`symbols.code` への `ON DELETE RESTRICT`）を冪等に付与
- `cmd/server/main.go` のマイグレーション節で candles 版 `AddFKConstraints` を呼び出し
- ingest usecase・キャッシュデコレータ・各テストを `SymbolCode` 表記に追従
- tbls ドキュメントと candles README を新スキーマに合わせて再生成

## 破壊的変更

- **DB スキーマ変更**: `candles.symbol (varchar 32)` → `candles.symbol_code (varchar 20)`、および `fk_candles_symbol` 制約の追加
- **移行手順（ローカル/開発環境）**:
  1. `DROP TABLE IF EXISTS candles;`
  2. `RUN_MIGRATIONS=true` で `backend-dev` を起動 → AutoMigrate と `AddFKConstraints` が新スキーマを作成
  3. `ingest` を再実行してデータを再取得
- データ保全が必要な環境には未適用。適用前に `symbols` に存在しない `symbol` 値を持つ行をクリーンアップする必要あり

## テスト

- `go build ./...` ✅
- `go test ./... -race` ✅（candles 関連の repository / cache / handler / ingest テスト含む全緑）
- `golangci-lint run --timeout=5m` ✅（0 issues）
- ローカル DB 適用後の確認:
  - `\d candles` で `symbol_code varchar(20)` と `fk_candles_symbol` を確認済み
  - `tbls diff` が差分なし（ドキュメントと DB 一致）

## レビューポイント

- `ON DELETE RESTRICT` を採用（watchlist と同パターン）。candles は ingest で再生成される性質上 `CASCADE` でも運用可能だが、意図しない一括削除を防ぐため RESTRICT にした
- キャッシュキー形式 `candles:{symbol}:{interval}` は値にカラム名を含まないため変更なし（既存キャッシュは TTL（7日）経過で自然に置換される）

🤖 Generated with [Claude Code](https://claude.com/claude-code)