### PR TITLE
refactor: DBスキーマの整合性向上と candles の numeric 精度明示

### DIFF
--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -30,10 +30,10 @@ erDiagram
   varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""
-  numeric open ""
-  numeric high ""
-  numeric low ""
-  numeric close ""
+  numeric_15_4_ open ""
+  numeric_15_4_ high ""
+  numeric_15_4_ low ""
+  numeric_15_4_ close ""
   bigint volume ""
 }
 "public.symbols" {

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -8,10 +8,10 @@
 | symbol_code | varchar(20) |  | false |  | [public.symbols](public.symbols.md) |  |
 | interval | varchar(16) |  | false |  |  |  |
 | time | timestamp with time zone |  | false |  |  |  |
-| open | numeric |  | false |  |  |  |
-| high | numeric |  | false |  |  |  |
-| low | numeric |  | false |  |  |  |
-| close | numeric |  | false |  |  |  |
+| open | numeric(15,4) |  | false |  |  |  |
+| high | numeric(15,4) |  | false |  |  |  |
+| low | numeric(15,4) |  | false |  |  |  |
+| close | numeric(15,4) |  | false |  |  |  |
 | volume | bigint | 0 | false |  |  |  |
 
 ## Constraints
@@ -40,10 +40,10 @@ erDiagram
   varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""
-  numeric open ""
-  numeric high ""
-  numeric low ""
-  numeric close ""
+  numeric_15_4_ open ""
+  numeric_15_4_ high ""
+  numeric_15_4_ low ""
+  numeric_15_4_ close ""
   bigint volume ""
 }
 "public.symbols" {

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -47,10 +47,10 @@ erDiagram
   varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""
-  numeric open ""
-  numeric high ""
-  numeric low ""
-  numeric close ""
+  numeric_15_4_ open ""
+  numeric_15_4_ high ""
+  numeric_15_4_ low ""
+  numeric_15_4_ close ""
   bigint volume ""
 }
 "public.watchlists" {

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -9,8 +9,8 @@
 | name | varchar(255) |  | false |  |  |  |
 | market | varchar(100) |  | false |  |  |  |
 | is_active | boolean | true | false |  |  |  |
-| created_at | timestamp with time zone |  | true |  |  |  |
-| updated_at | timestamp with time zone |  | true |  |  |  |
+| created_at | timestamp with time zone |  | false |  |  |  |
+| updated_at | timestamp with time zone |  | false |  |  |  |
 
 ## Constraints
 

--- a/docs/schema/public.users.md
+++ b/docs/schema/public.users.md
@@ -7,8 +7,8 @@
 | id | bigint | nextval('users_id_seq'::regclass) | false | [public.watchlists](public.watchlists.md) |  |  |
 | email | varchar(255) |  | false |  |  |  |
 | password | varchar(255) |  | false |  |  |  |
-| created_at | timestamp with time zone |  | true |  |  |  |
-| updated_at | timestamp with time zone |  | true |  |  |  |
+| created_at | timestamp with time zone |  | false |  |  |  |
+| updated_at | timestamp with time zone |  | false |  |  |  |
 
 ## Constraints
 

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -8,8 +8,8 @@
 | user_id | bigint |  | false |  | [public.users](public.users.md) |  |
 | symbol_code | varchar(20) |  | false |  | [public.symbols](public.symbols.md) |  |
 | sort_key | bigint | 0 | false |  |  |  |
-| created_at | timestamp with time zone |  | true |  |  |  |
-| updated_at | timestamp with time zone |  | true |  |  |  |
+| created_at | timestamp with time zone |  | false |  |  |  |
+| updated_at | timestamp with time zone |  | false |  |  |  |
 
 ## Constraints
 
@@ -26,6 +26,7 @@
 | watchlists_pkey | CREATE UNIQUE INDEX watchlists_pkey ON public.watchlists USING btree (id) |
 | idx_watchlist_user_sort_key | CREATE UNIQUE INDEX idx_watchlist_user_sort_key ON public.watchlists USING btree (user_id, sort_key) |
 | idx_watchlist_user_symbol | CREATE UNIQUE INDEX idx_watchlist_user_symbol ON public.watchlists USING btree (user_id, symbol_code) |
+| idx_watchlists_symbol_code | CREATE INDEX idx_watchlists_symbol_code ON public.watchlists USING btree (symbol_code) |
 
 ## Relations
 

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -24,12 +24,12 @@
         {
           "name": "created_at",
           "type": "timestamp with time zone",
-          "nullable": true
+          "nullable": false
         },
         {
           "name": "updated_at",
           "type": "timestamp with time zone",
-          "nullable": true
+          "nullable": false
         }
       ],
       "indexes": [
@@ -90,22 +90,22 @@
         },
         {
           "name": "open",
-          "type": "numeric",
+          "type": "numeric(15,4)",
           "nullable": false
         },
         {
           "name": "high",
-          "type": "numeric",
+          "type": "numeric(15,4)",
           "nullable": false
         },
         {
           "name": "low",
-          "type": "numeric",
+          "type": "numeric(15,4)",
           "nullable": false
         },
         {
           "name": "close",
-          "type": "numeric",
+          "type": "numeric(15,4)",
           "nullable": false
         },
         {
@@ -263,12 +263,12 @@
         {
           "name": "created_at",
           "type": "timestamp with time zone",
-          "nullable": true
+          "nullable": false
         },
         {
           "name": "updated_at",
           "type": "timestamp with time zone",
-          "nullable": true
+          "nullable": false
         }
       ],
       "indexes": [
@@ -295,6 +295,14 @@
           "table": "public.watchlists",
           "columns": [
             "user_id",
+            "symbol_code"
+          ]
+        },
+        {
+          "name": "idx_watchlists_symbol_code",
+          "def": "CREATE INDEX idx_watchlists_symbol_code ON public.watchlists USING btree (symbol_code)",
+          "table": "public.watchlists",
+          "columns": [
             "symbol_code"
           ]
         }

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -195,12 +195,12 @@
         {
           "name": "created_at",
           "type": "timestamp with time zone",
-          "nullable": true
+          "nullable": false
         },
         {
           "name": "updated_at",
           "type": "timestamp with time zone",
-          "nullable": true
+          "nullable": false
         }
       ],
       "indexes": [

--- a/internal/feature/auth/domain/entity/user.go
+++ b/internal/feature/auth/domain/entity/user.go
@@ -18,8 +18,8 @@ type User struct {
 	Password string `gorm:"size:255;not null"`
 
 	// CreatedAt はユーザーが作成された日時です。
-	CreatedAt time.Time
+	CreatedAt time.Time `gorm:"autoCreateTime;not null"`
 
 	// UpdatedAt はユーザーが最後に更新された日時です。
-	UpdatedAt time.Time
+	UpdatedAt time.Time `gorm:"autoUpdateTime;not null"`
 }

--- a/internal/feature/candles/adapters/candle_repository.go
+++ b/internal/feature/candles/adapters/candle_repository.go
@@ -34,10 +34,10 @@ type CandleModel struct {
 	Interval   string    `gorm:"size:16;not null;uniqueIndex:candle_sym_int_time,priority:2"`
 	Time       time.Time `gorm:"not null;uniqueIndex:candle_sym_int_time,priority:3"`
 
-	Open   float64 `gorm:"not null"`
-	High   float64 `gorm:"not null"`
-	Low    float64 `gorm:"not null"`
-	Close  float64 `gorm:"not null"`
+	Open   float64 `gorm:"type:numeric(15,4);not null"`
+	High   float64 `gorm:"type:numeric(15,4);not null"`
+	Low    float64 `gorm:"type:numeric(15,4);not null"`
+	Close  float64 `gorm:"type:numeric(15,4);not null"`
 	Volume int64   `gorm:"not null;default:0"`
 }
 

--- a/internal/feature/symbollist/domain/entity/symbol.go
+++ b/internal/feature/symbollist/domain/entity/symbol.go
@@ -11,6 +11,6 @@ type Symbol struct {
 	Name      string    `gorm:"size:255;not null"`            // 企業名
 	Market    string    `gorm:"size:100;not null"`            // 市場識別子（例: "NASDAQ", "TSE"）
 	IsActive  bool      `gorm:"not null;default:true"`        // トラッキング対象かどうか
-	CreatedAt time.Time `gorm:"autoCreateTime"`               // 登録日時
-	UpdatedAt time.Time `gorm:"autoUpdateTime"`               // 最終更新日時
+	CreatedAt time.Time `gorm:"autoCreateTime;not null"`      // 登録日時
+	UpdatedAt time.Time `gorm:"autoUpdateTime;not null"`      // 最終更新日時
 }

--- a/internal/feature/watchlist/adapters/migration.go
+++ b/internal/feature/watchlist/adapters/migration.go
@@ -25,5 +25,11 @@ func AddFKConstraints(db *gorm.DB) error {
 		}
 		slog.Info("added FK constraint: fk_watchlists_symbol")
 	}
+	// symbols への FK 参照チェック（ON DELETE RESTRICT）をフルスキャンにしないため、
+	// 複合 UNIQUE 先頭ではない symbol_code 単独のインデックスを追加する。
+	if err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_watchlists_symbol_code
+		ON watchlists (symbol_code)`).Error; err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/feature/watchlist/domain/entity/user_symbol.go
+++ b/internal/feature/watchlist/domain/entity/user_symbol.go
@@ -6,12 +6,12 @@ import "time"
 // UserSymbol はユーザーのウォッチリストエントリを表します。
 // watchlists テーブルにマップされ、users.id と symbols.code に FK 制約を持ちます。
 type UserSymbol struct {
-	ID         uint   `gorm:"primaryKey"`
-	UserID     uint   `gorm:"not null;uniqueIndex:idx_watchlist_user_symbol,priority:1;uniqueIndex:idx_watchlist_user_sort_key,priority:1"`
-	SymbolCode string `gorm:"size:20;not null;uniqueIndex:idx_watchlist_user_symbol,priority:2"`
-	SortKey    int    `gorm:"not null;default:0;uniqueIndex:idx_watchlist_user_sort_key,priority:2"`
-	CreatedAt  time.Time
-	UpdatedAt  time.Time
+	ID         uint      `gorm:"primaryKey"`
+	UserID     uint      `gorm:"not null;uniqueIndex:idx_watchlist_user_symbol,priority:1;uniqueIndex:idx_watchlist_user_sort_key,priority:1"`
+	SymbolCode string    `gorm:"size:20;not null;uniqueIndex:idx_watchlist_user_symbol,priority:2"`
+	SortKey    int       `gorm:"not null;default:0;uniqueIndex:idx_watchlist_user_sort_key,priority:2"`
+	CreatedAt  time.Time `gorm:"autoCreateTime;not null"`
+	UpdatedAt  time.Time `gorm:"autoUpdateTime;not null"`
 }
 
 // TableName は GORM が使用するテーブル名を返します。


### PR DESCRIPTION
## Summary

- users / watchlists の `CreatedAt` / `UpdatedAt` に GORM タグ (`autoCreateTime;not null` / `autoUpdateTime;not null`) を追加し、NOT NULL 化して symbols と挙動を揃えた
- candles の OHLC カラムに `type:numeric(15,4)` を指定し、精度未指定だった `numeric` を明示
- watchlists に `symbol_code` 単独インデックス `idx_watchlists_symbol_code` を追加し、`symbols` 削除時の FK 参照チェックでフルスキャンにならないよう予防
- fresh DB に対して `tbls doc` を再生成し `docs/schema/` を更新

## 背景

`docs/schema/` の出力と各 feature の entity / adapter を突き合わせた結果、以下が判明したため整理した:
- `users` / `watchlists` の timestamps が NULL 許可になっていた（symbols だけが NOT NULL）
- candles の OHLC が精度未指定の `numeric` で、float64 との往復で微小誤差が入るリスクがあった
- watchlists の `symbol_code` は複合 UNIQUE `(user_id, symbol_code)` の 2 番目にしか存在せず、symbol 側の削除時に FK 参照検証がフルスキャンになる可能性があった

## 変更ファイル

| ファイル | 内容 |
| -------- | -------- |
| internal/feature/auth/domain/entity/user.go | timestamps に GORM タグ追加 |
| internal/feature/watchlist/domain/entity/user_symbol.go | 同上 |
| internal/feature/candles/adapters/candle_repository.go | OHLC に `type:numeric(15,4)` 追加 |
| internal/feature/watchlist/adapters/migration.go | `symbol_code` 単独インデックス作成の Exec を追加 |
| docs/schema/* | fresh DB で tbls 再生成 |

## 非対象（別タスク）

- `users.password` → `password_hash` へのリネーム（破壊的変更）
- `symbols` の `(is_active, code)` 複合インデックス（現状で十分効率的）

## Test plan

- [x] `go build ./...` が通ること
- [x] `go test ./... -race -cover` が全パスすること
- [x] `golangci-lint run --timeout=5m` が 0 issues であること
- [x] fresh DB で `AutoMigrate` + `AddFKConstraints` が成功すること
- [x] tbls ドキュメントで以下を確認:
  - users / watchlists の `created_at` / `updated_at` が `Nullable: false`
  - candles の OHLC が `numeric(15,4)`
  - watchlists に `idx_watchlists_symbol_code` が追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)