### PR TITLE
chore: .gitignore に .claude/worktrees/ を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ docker/.env
 
 # tmp
 tmp
+
+# Claude Code のサブエージェント隔離用 worktree
+.claude/worktrees/


### PR DESCRIPTION
## 概要
Claude Code のサブエージェントが隔離モード（worktree）で実行された際に作成される `.claude/worktrees/` ディレクトリを Git の追跡対象から除外する。

## 変更内容
- `.gitignore` に `.claude/worktrees/` を追加

## テスト
- `git status` 実行時に `.claude/worktrees/` が表示されないことを確認