### PR TITLE
feat: TwelveData API 呼び出しにリトライを追加

### DIFF
--- a/internal/feature/candles/adapters/twelvedata/config.go
+++ b/internal/feature/candles/adapters/twelvedata/config.go
@@ -11,6 +11,12 @@ type Config struct {
 	TwelveDataAPIKey string        // 認証用APIキー
 	BaseURL          string        // APIのベースURL（例: "https://api.twelvedata.com"）
 	Timeout          time.Duration // HTTPリクエストタイムアウト
+
+	// リトライ設定（5xx・ネットワークエラー・429 を対象とする指数バックオフ）。
+	MaxRetries       int           // リトライ回数（0 でリトライ無効、合計試行回数は MaxRetries+1）
+	RetryBaseBackoff time.Duration // 初回バックオフ（係数 4 で増加: 例 500ms → 2s → 8s）
+	RetryMaxBackoff  time.Duration // バックオフ上限（Retry-After 含む）
+	RetryJitterRatio float64       // ジッター比率（0.2 なら ±20%）
 }
 
 // LoadConfig は環境変数からTwelve Dataの設定を読み込みます。
@@ -19,5 +25,9 @@ func LoadConfig() Config {
 		TwelveDataAPIKey: os.Getenv("TWELVE_DATA_API_KEY"),
 		BaseURL:          os.Getenv("TWELVE_DATA_BASE_URL"),
 		Timeout:          10 * time.Second,
+		MaxRetries:       3,
+		RetryBaseBackoff: 500 * time.Millisecond,
+		RetryMaxBackoff:  30 * time.Second,
+		RetryJitterRatio: 0.2,
 	}
 }

--- a/internal/feature/candles/adapters/twelvedata/repository.go
+++ b/internal/feature/candles/adapters/twelvedata/repository.go
@@ -143,6 +143,9 @@ func (t *TwelveDataMarket) doRequestWithRetry(ctx context.Context, method, urlSt
 				return nil, ctxErr
 			}
 			lastErr = err
+			if attempt == maxAttempts-1 {
+				break
+			}
 			if !t.sleepBeforeRetry(ctx, attempt, 0) {
 				return nil, ctx.Err()
 			}
@@ -184,12 +187,7 @@ func (t *TwelveDataMarket) doRequestWithRetry(ctx context.Context, method, urlSt
 // それ以外は attempt（0 起算）に応じた指数バックオフ + ジッターで待機します。
 // ctx キャンセル時は false を返し即時に中断します。
 func (t *TwelveDataMarket) sleepBeforeRetry(ctx context.Context, attempt int, retryAfter time.Duration) bool {
-	d := retryAfter
-	if d <= 0 {
-		d = backoffDelay(attempt, t.cfg.RetryBaseBackoff, t.cfg.RetryMaxBackoff, t.cfg.RetryJitterRatio)
-	} else if t.cfg.RetryMaxBackoff > 0 && d > t.cfg.RetryMaxBackoff {
-		d = t.cfg.RetryMaxBackoff
-	}
+	d := computeRetryDelay(attempt, retryAfter, t.cfg)
 	if d <= 0 {
 		return ctx.Err() == nil
 	}
@@ -204,6 +202,23 @@ func (t *TwelveDataMarket) sleepBeforeRetry(ctx context.Context, attempt int, re
 	}
 }
 
+// computeRetryDelay は次のリトライまでの待機時間を決定します。
+// retryAfter > 0 ならそれを優先し、RetryMaxBackoff を上限にクランプします。
+// retryAfter <= 0 の場合は attempt（0 起算）に応じた指数バックオフ + ジッターで決定します。
+// 純粋関数として副作用なく実装され、テストから直接検証可能です。
+func computeRetryDelay(attempt int, retryAfter time.Duration, cfg Config) time.Duration {
+	d := retryAfter
+	if d <= 0 {
+		d = backoffDelay(attempt, cfg.RetryBaseBackoff, cfg.RetryMaxBackoff, cfg.RetryJitterRatio)
+	} else if cfg.RetryMaxBackoff > 0 && d > cfg.RetryMaxBackoff {
+		d = cfg.RetryMaxBackoff
+	}
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
 // isRetryableStatus はリトライ対象の HTTP ステータスかを判定します。
 // 5xx（500-599）と 429 が対象。401/403/404/422 等の 4xx はリトライ対象外。
 func isRetryableStatus(status int) bool {
@@ -213,16 +228,23 @@ func isRetryableStatus(status int) bool {
 	return status >= 500 && status < 600
 }
 
+// maxRetryAfterSecs は Retry-After で受け入れる秒数の上限（int64 オーバーフロー回避と現実的な上限のため 1 時間）。
+const maxRetryAfterSecs = 3600
+
 // parseRetryAfter は Retry-After ヘッダを time.Duration として解釈します。
 // 数値（秒）と HTTP-date の両方をサポートし、解釈不能な場合は 0 を返します。
+// 秒数は maxRetryAfterSecs（1 時間）でクランプし、time.Duration 変換時の int64 オーバーフローを防ぎます。
 func parseRetryAfter(res *http.Response) time.Duration {
 	v := res.Header.Get("Retry-After")
 	if v == "" {
 		return 0
 	}
 	if secs, err := strconv.Atoi(v); err == nil {
-		if secs < 0 {
+		if secs <= 0 {
 			return 0
+		}
+		if secs > maxRetryAfterSecs {
+			secs = maxRetryAfterSecs
 		}
 		return time.Duration(secs) * time.Second
 	}
@@ -230,6 +252,9 @@ func parseRetryAfter(res *http.Response) time.Duration {
 		d := time.Until(t)
 		if d < 0 {
 			return 0
+		}
+		if d > maxRetryAfterSecs*time.Second {
+			d = maxRetryAfterSecs * time.Second
 		}
 		return d
 	}

--- a/internal/feature/candles/adapters/twelvedata/repository.go
+++ b/internal/feature/candles/adapters/twelvedata/repository.go
@@ -3,8 +3,11 @@ package twelvedata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
+	"math"
+	"math/rand/v2"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -42,14 +45,7 @@ func (t *TwelveDataMarket) GetTimeSeries(ctx context.Context, symbol, interval s
 	// URLを生成
 	u := fmt.Sprintf("%s/time_series?%s", t.cfg.BaseURL, q.Encode())
 
-	// リクエストオブジェクトを作成
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// リクエストを実行
-	res, err := t.client.Do(req)
+	res, err := t.doRequestWithRetry(ctx, http.MethodGet, u)
 	if err != nil {
 		return nil, err
 	}
@@ -58,10 +54,6 @@ func (t *TwelveDataMarket) GetTimeSeries(ctx context.Context, symbol, interval s
 			slog.Warn("failed to close response body", "error", err)
 		}
 	}()
-
-	if res.StatusCode >= 400 {
-		return nil, fmt.Errorf("twelvedata http %d", res.StatusCode)
-	}
 
 	// JSONレスポンスをDTOにデコード
 	var body dto.TimeSeriesResponse
@@ -120,4 +112,148 @@ func (t *TwelveDataMarket) GetTimeSeries(ctx context.Context, symbol, interval s
 		})
 	}
 	return candles, nil
+}
+
+// doRequestWithRetry は指定された HTTP リクエストを実行し、
+// ネットワークエラー・5xx・429 に対して指数バックオフ + ジッターでリトライします。
+// 4xx（429 を除く）は即エラーを返し、ctx キャンセル時はリトライを中断します。
+// 外側のレートリミッタとは独立に動作するため、リトライは外側のレート消費を増やしません。
+func (t *TwelveDataMarket) doRequestWithRetry(ctx context.Context, method, urlStr string) (*http.Response, error) {
+	maxAttempts := t.cfg.MaxRetries + 1
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		// ctx が既にキャンセル済みなら即終了
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, urlStr, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		res, err := t.client.Do(req)
+		if err != nil {
+			// ctx 起因のエラーはリトライしない
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			lastErr = err
+			if !t.sleepBeforeRetry(ctx, attempt, 0) {
+				return nil, ctx.Err()
+			}
+			continue
+		}
+
+		// 成功
+		if res.StatusCode < 400 {
+			return res, nil
+		}
+
+		// リトライ対象外のエラーは即返す
+		if !isRetryableStatus(res.StatusCode) {
+			statusErr := fmt.Errorf("twelvedata http %d", res.StatusCode)
+			_ = res.Body.Close()
+			return nil, statusErr
+		}
+
+		// リトライ対象（5xx / 429）。最終試行ならエラーを返す。
+		retryAfter := parseRetryAfter(res)
+		lastErr = fmt.Errorf("twelvedata http %d", res.StatusCode)
+		_ = res.Body.Close()
+
+		if attempt == maxAttempts-1 {
+			break
+		}
+		if !t.sleepBeforeRetry(ctx, attempt, retryAfter) {
+			return nil, ctx.Err()
+		}
+	}
+
+	if lastErr == nil {
+		lastErr = errors.New("twelvedata: retry exhausted")
+	}
+	return nil, lastErr
+}
+
+// sleepBeforeRetry は次のリトライまで待機します。retryAfter > 0 ならそれを優先し、
+// それ以外は attempt（0 起算）に応じた指数バックオフ + ジッターで待機します。
+// ctx キャンセル時は false を返し即時に中断します。
+func (t *TwelveDataMarket) sleepBeforeRetry(ctx context.Context, attempt int, retryAfter time.Duration) bool {
+	d := retryAfter
+	if d <= 0 {
+		d = backoffDelay(attempt, t.cfg.RetryBaseBackoff, t.cfg.RetryMaxBackoff, t.cfg.RetryJitterRatio)
+	} else if t.cfg.RetryMaxBackoff > 0 && d > t.cfg.RetryMaxBackoff {
+		d = t.cfg.RetryMaxBackoff
+	}
+	if d <= 0 {
+		return ctx.Err() == nil
+	}
+
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// isRetryableStatus はリトライ対象の HTTP ステータスかを判定します。
+// 5xx（500-599）と 429 が対象。401/403/404/422 等の 4xx はリトライ対象外。
+func isRetryableStatus(status int) bool {
+	if status == http.StatusTooManyRequests {
+		return true
+	}
+	return status >= 500 && status < 600
+}
+
+// parseRetryAfter は Retry-After ヘッダを time.Duration として解釈します。
+// 数値（秒）と HTTP-date の両方をサポートし、解釈不能な場合は 0 を返します。
+func parseRetryAfter(res *http.Response) time.Duration {
+	v := res.Header.Get("Retry-After")
+	if v == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(v); err == nil {
+		if secs < 0 {
+			return 0
+		}
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(v); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+// backoffDelay は attempt（0 起算）に応じた指数バックオフ + ジッター付き待機時間を返します。
+// base * 4^attempt（max でクリップ）に対し ±jitter の乱数を加算します。
+func backoffDelay(attempt int, base, maxDelay time.Duration, jitter float64) time.Duration {
+	if base <= 0 {
+		return 0
+	}
+	mult := math.Pow(4, float64(attempt))
+	d := time.Duration(float64(base) * mult)
+	if maxDelay > 0 && d > maxDelay {
+		d = maxDelay
+	}
+	if jitter > 0 {
+		// [-jitter, +jitter] の乱数比率を加算
+		delta := (rand.Float64()*2 - 1) * jitter
+		d = time.Duration(float64(d) * (1 + delta))
+	}
+	if d < 0 {
+		return 0
+	}
+	return d
 }

--- a/internal/feature/candles/adapters/twelvedata/repository_test.go
+++ b/internal/feature/candles/adapters/twelvedata/repository_test.go
@@ -5,9 +5,22 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// retryTestConfig はリトライ系テストで使用する高速バックオフ設定の Config を返します。
+func retryTestConfig(baseURL string, maxRetries int) Config {
+	return Config{
+		TwelveDataAPIKey: "test-key",
+		BaseURL:          baseURL,
+		MaxRetries:       maxRetries,
+		RetryBaseBackoff: 1 * time.Millisecond,
+		RetryMaxBackoff:  50 * time.Millisecond,
+		RetryJitterRatio: 0.0,
+	}
+}
 
 // TestNewTwelveDataMarket はTwelveDataMarketインスタンスが正しく生成されることを検証します。
 func TestNewTwelveDataMarket(t *testing.T) {
@@ -366,7 +379,7 @@ func TestTwelveDataMarket_GetTimeSeries_ContextCancellation(t *testing.T) {
 	}
 }
 
-// TestLoadConfig はデフォルトのタイムアウト値が正しく設定されることを検証します。
+// TestLoadConfig はデフォルトのタイムアウト値とリトライ設定のデフォルト値が正しく設定されることを検証します。
 func TestLoadConfig(t *testing.T) {
 	t.Parallel()
 
@@ -375,5 +388,289 @@ func TestLoadConfig(t *testing.T) {
 
 	if cfg.Timeout != 10*time.Second {
 		t.Errorf("expected timeout 10s, got %v", cfg.Timeout)
+	}
+	if cfg.MaxRetries != 3 {
+		t.Errorf("expected MaxRetries 3, got %d", cfg.MaxRetries)
+	}
+	if cfg.RetryBaseBackoff != 500*time.Millisecond {
+		t.Errorf("expected RetryBaseBackoff 500ms, got %v", cfg.RetryBaseBackoff)
+	}
+}
+
+// successTimeSeriesBody は GetTimeSeries 成功レスポンスの最小 JSON です。
+const successTimeSeriesBody = `{
+	"status": "ok",
+	"values": [
+		{"datetime": "2025-01-15", "open": "150.00", "high": "155.00", "low": "149.00", "close": "154.50", "volume": "1000000"}
+	]
+}`
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_SuccessAfter503 は
+// 503 が連続した後に成功レスポンスを返した場合、合計リクエスト回数とデータ取得成功を検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_SuccessAfter503(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(successTimeSeriesBody))
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(retryTestConfig(server.URL, 3), server.Client())
+
+	candles, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candles) != 1 {
+		t.Fatalf("expected 1 candle, got %d", len(candles))
+	}
+	if got := calls.Load(); got != 3 {
+		t.Errorf("expected 3 HTTP calls (2 retries + success), got %d", got)
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_ExhaustedOn503 は
+// 503 が継続する場合、MaxRetries+1 回試行後にエラーを返すことを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_ExhaustedOn503(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(retryTestConfig(server.URL, 3), server.Client())
+
+	_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected error message to contain status code, got %v", err)
+	}
+	if got := calls.Load(); got != 4 {
+		t.Errorf("expected 4 HTTP calls (1 initial + 3 retries), got %d", got)
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_NoRetryOn4xx は
+// 4xx（429 を除く）ではリトライせず即エラーを返すことを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_NoRetryOn4xx(t *testing.T) {
+	t.Parallel()
+
+	statuses := []int{
+		http.StatusBadRequest,
+		http.StatusUnauthorized,
+		http.StatusForbidden,
+		http.StatusNotFound,
+		http.StatusUnprocessableEntity,
+	}
+	for _, status := range statuses {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+
+			var calls atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				w.WriteHeader(status)
+			}))
+			defer server.Close()
+
+			market := NewTwelveDataMarket(retryTestConfig(server.URL, 3), server.Client())
+
+			_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if got := calls.Load(); got != 1 {
+				t.Errorf("expected 1 HTTP call (no retry), got %d", got)
+			}
+		})
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_RespectsRetryAfter は
+// 429 + Retry-After ヘッダで指定された秒数だけ待機してからリトライすることを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_RespectsRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(successTimeSeriesBody))
+	}))
+	defer server.Close()
+
+	cfg := retryTestConfig(server.URL, 3)
+	// RetryMaxBackoff を Retry-After 以上にして、ヘッダ値が効くことを確認する。
+	cfg.RetryMaxBackoff = 5 * time.Second
+	market := NewTwelveDataMarket(cfg, server.Client())
+
+	start := time.Now()
+	_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if elapsed < 900*time.Millisecond {
+		t.Errorf("expected to wait at least ~1s for Retry-After, waited %v", elapsed)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 HTTP calls, got %d", got)
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_RetryAfterHTTPDate は
+// Retry-After に HTTP-date 形式が渡された場合も正しく扱われることを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_RetryAfterHTTPDate(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := calls.Add(1)
+		if n == 1 {
+			// 過去日時 → 待機なしで即リトライされること
+			w.Header().Set("Retry-After", time.Now().Add(-1*time.Hour).UTC().Format(http.TimeFormat))
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(successTimeSeriesBody))
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(retryTestConfig(server.URL, 3), server.Client())
+
+	_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected 2 HTTP calls, got %d", got)
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_NetworkError は
+// ネットワークエラー（接続失敗）でリトライが行われ、最終的にエラーになることを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_NetworkError(t *testing.T) {
+	t.Parallel()
+
+	// サーバを起動して URL を取り、Close で接続を不可能にする
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	market := NewTwelveDataMarket(retryTestConfig(url, 2), &http.Client{Timeout: 200 * time.Millisecond})
+
+	_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+	if err == nil {
+		t.Fatal("expected network error, got nil")
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_ContextCanceledMidRetry は
+// バックオフ中に ctx がキャンセルされた場合、即座に終了することを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_ContextCanceledMidRetry(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	cfg := retryTestConfig(server.URL, 5)
+	cfg.RetryBaseBackoff = 200 * time.Millisecond
+	cfg.RetryMaxBackoff = 1 * time.Second
+	market := NewTwelveDataMarket(cfg, server.Client())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, err := market.GetTimeSeries(ctx, "AAPL", "1day", 100)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	// バックオフ全体（200ms+800ms+...）よりはるかに早く終了するはず
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("expected to return quickly on ctx cancel, took %v", elapsed)
+	}
+}
+
+// TestParseRetryAfter は Retry-After ヘッダのパース挙動を検証します。
+func TestParseRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		header string
+		want   time.Duration
+		approx bool
+	}{
+		{"empty", "", 0, false},
+		{"seconds", "5", 5 * time.Second, false},
+		{"negative seconds", "-1", 0, false},
+		{"invalid", "not-a-number", 0, false},
+		{"past http-date", time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat), 0, false},
+		{"future http-date", time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat), 2 * time.Second, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			res := &http.Response{Header: http.Header{}}
+			if tt.header != "" {
+				res.Header.Set("Retry-After", tt.header)
+			}
+			got := parseRetryAfter(res)
+			if tt.approx {
+				if got <= 0 || got > 3*time.Second {
+					t.Errorf("expected ~%v, got %v", tt.want, got)
+				}
+				return
+			}
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// TestIsRetryableStatus はリトライ対象ステータス判定を検証します。
+func TestIsRetryableStatus(t *testing.T) {
+	t.Parallel()
+
+	retryable := []int{429, 500, 502, 503, 504, 599}
+	notRetryable := []int{200, 301, 400, 401, 403, 404, 422, 418}
+
+	for _, s := range retryable {
+		if !isRetryableStatus(s) {
+			t.Errorf("status %d should be retryable", s)
+		}
+	}
+	for _, s := range notRetryable {
+		if isRetryableStatus(s) {
+			t.Errorf("status %d should not be retryable", s)
+		}
 	}
 }

--- a/internal/feature/candles/adapters/twelvedata/repository_test.go
+++ b/internal/feature/candles/adapters/twelvedata/repository_test.go
@@ -523,14 +523,11 @@ func TestTwelveDataMarket_GetTimeSeries_Retry_RespectsRetryAfter(t *testing.T) {
 	cfg.RetryMaxBackoff = 5 * time.Second
 	market := NewTwelveDataMarket(cfg, server.Client())
 
-	start := time.Now()
+	// Retry-After ヘッダ付きでもリトライが行われることを検証する。
+	// Retry-After とバックオフの選択ロジック自体は TestComputeRetryDelay で別途検証する。
 	_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
-	elapsed := time.Since(start)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if elapsed < 900*time.Millisecond {
-		t.Errorf("expected to wait at least ~1s for Retry-After, waited %v", elapsed)
 	}
 	if got := calls.Load(); got != 2 {
 		t.Errorf("expected 2 HTTP calls, got %d", got)
@@ -630,8 +627,11 @@ func TestParseRetryAfter(t *testing.T) {
 	}{
 		{"empty", "", 0, false},
 		{"seconds", "5", 5 * time.Second, false},
+		{"zero seconds", "0", 0, false},
 		{"negative seconds", "-1", 0, false},
 		{"invalid", "not-a-number", 0, false},
+		{"overflow seconds", "99999999999", maxRetryAfterSecs * time.Second, false},
+		{"upper bound seconds", "3600", maxRetryAfterSecs * time.Second, false},
 		{"past http-date", time.Now().Add(-1 * time.Hour).UTC().Format(http.TimeFormat), 0, false},
 		{"future http-date", time.Now().Add(2 * time.Second).UTC().Format(http.TimeFormat), 2 * time.Second, true},
 	}
@@ -672,5 +672,92 @@ func TestIsRetryableStatus(t *testing.T) {
 		if isRetryableStatus(s) {
 			t.Errorf("status %d should not be retryable", s)
 		}
+	}
+}
+
+// TestComputeRetryDelay は待機時間決定ロジックを検証します（実待機なし）。
+func TestComputeRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		RetryBaseBackoff: 500 * time.Millisecond,
+		RetryMaxBackoff:  8 * time.Second,
+		RetryJitterRatio: 0.0, // 決定的にするためジッター無効
+	}
+
+	tests := []struct {
+		name       string
+		attempt    int
+		retryAfter time.Duration
+		want       time.Duration
+	}{
+		{"retry-after takes precedence", 0, 2 * time.Second, 2 * time.Second},
+		{"retry-after clamped to max", 0, 30 * time.Second, 8 * time.Second},
+		{"retry-after exactly at max", 0, 8 * time.Second, 8 * time.Second},
+		{"backoff attempt 0", 0, 0, 500 * time.Millisecond},
+		{"backoff attempt 1", 1, 0, 2 * time.Second},
+		{"backoff attempt 2", 2, 0, 8 * time.Second},
+		{"backoff attempt 3 clamped", 3, 0, 8 * time.Second},
+		{"negative retry-after falls back to backoff", 0, -1 * time.Second, 500 * time.Millisecond},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := computeRetryDelay(tt.attempt, tt.retryAfter, cfg)
+			if got != tt.want {
+				t.Errorf("computeRetryDelay(%d, %v) = %v, want %v", tt.attempt, tt.retryAfter, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestComputeRetryDelay_NoMaxBackoff は RetryMaxBackoff 未設定時に
+// retryAfter がクランプされず素通しされることを検証します。
+func TestComputeRetryDelay_NoMaxBackoff(t *testing.T) {
+	t.Parallel()
+
+	cfg := Config{
+		RetryBaseBackoff: 500 * time.Millisecond,
+		RetryMaxBackoff:  0, // クランプ無効
+		RetryJitterRatio: 0.0,
+	}
+
+	got := computeRetryDelay(0, 1*time.Hour, cfg)
+	if got != 1*time.Hour {
+		t.Errorf("expected retry-after to pass through when MaxBackoff=0, got %v", got)
+	}
+}
+
+// TestTwelveDataMarket_GetTimeSeries_Retry_NetworkError_NoSleepOnLastAttempt は
+// ネットワークエラーが連続した場合、最終試行後に余分なバックオフ待機が発生しないことを検証します。
+func TestTwelveDataMarket_GetTimeSeries_Retry_NetworkError_NoSleepOnLastAttempt(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	url := server.URL
+	server.Close()
+
+	cfg := Config{
+		TwelveDataAPIKey: "test-key",
+		BaseURL:          url,
+		MaxRetries:       2, // 合計 3 試行
+		RetryBaseBackoff: 100 * time.Millisecond,
+		RetryMaxBackoff:  500 * time.Millisecond,
+		RetryJitterRatio: 0.0,
+	}
+	market := NewTwelveDataMarket(cfg, &http.Client{Timeout: 50 * time.Millisecond})
+
+	start := time.Now()
+	_, err := market.GetTimeSeries(context.Background(), "AAPL", "1day", 100)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected network error, got nil")
+	}
+	// 試行間バックオフは 100ms + 400ms = 500ms。最終試行後の追加待機があると elapsed が
+	// さらに 1600ms 以上増える。最終試行後の待機が無いことを上限で確認する。
+	// 各試行はクライアントタイムアウト 50ms 以下で失敗する想定。
+	maxExpected := 100*time.Millisecond + 400*time.Millisecond + 3*50*time.Millisecond + 200*time.Millisecond
+	if elapsed > maxExpected {
+		t.Errorf("expected total elapsed <= %v (no trailing sleep), got %v", maxExpected, elapsed)
 	}
 }


### PR DESCRIPTION
## 概要

Closes #146

`twelvedata.GetTimeSeries` は単発呼び出しで、5xx・ネットワーク瞬断で即エラーになり、`IngestUsecase.IngestAll` ではログ出力のみで次の銘柄に進むため、次回 ingest（24h 後）まで該当銘柄のデータが欠損していました。

5xx・429・ネットワークエラーに対して指数バックオフ + ジッターでリトライする薄いヘルパーをリポジトリ内部に追加し、瞬断による欠損を防ぎます。新規依存は追加していません。

## 変更内容

- `Config` にリトライ設定を追加（`MaxRetries` / `RetryBaseBackoff` / `RetryMaxBackoff` / `RetryJitterRatio`）。`LoadConfig()` のデフォルトは 3 回 / 500ms → 2s → 8s / ±20% ジッター。
- `repository.go` に以下のヘルパーを追加し、`GetTimeSeries` の HTTP 部分を置き換え：
  - `doRequestWithRetry` — リトライ本体
  - `sleepBeforeRetry` — `time.Timer` + `ctx.Done()` の select 待機
  - `isRetryableStatus` — 5xx / 429 を判定
  - `parseRetryAfter` — 数値（秒）と HTTP-date 両対応
  - `backoffDelay` — `base * 4^attempt` を `RetryMaxBackoff` でクリップ + ジッター
- 受け入れ条件をカバーするテストを 9 件追加。

## リトライポリシー

| 条件 | 挙動 |
|---|---|
| ネットワークエラー（`ctx` 起因を除く） | リトライ |
| HTTP 5xx | リトライ |
| HTTP 429 | `Retry-After` を尊重（無ければ通常バックオフ） |
| HTTP 4xx（429 以外: 400/401/403/404/422 等） | 即エラー |
| `ctx.Done()` | 即 `ctx.Err()` を返す |

外側のレートリミッタ（`IngestUsecase` 内の `WaitIfNeeded`）はリトライ単位ではなく銘柄単位で消費されるため、リトライによってレート枠が余分に消費されることはありません。

## 受け入れ条件

- [x] HTTP 503 を返すモックサーバで「3 回リトライ後に成功」「3 回失敗で諦める」がテストで検証されている
- [x] 4xx ではリトライしないことをテストで検証（400/401/403/404/422 のテーブル駆動）
- [x] レートリミット消費はリトライごとにカウントしない（リトライをリポジトリ内部に閉じる構造で担保）

## Test plan

- [x] \`go test ./... -race -cover\` が通る
- [x] \`golangci-lint run --timeout=5m\` が通る
- [x] 既存テスト（`TestTwelveDataMarket_GetTimeSeries_HTTPError` 等）は `MaxRetries: 0`（ゼロ値）で従来挙動が保たれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)