### PR TITLE
fix: ingest の銘柄単位失敗を集計し、しきい値超過時に非ゼロ終了する

### DIFF
--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -29,7 +29,16 @@ func shouldFailExit(result candlesusecase.IngestResult, threshold float64) bool 
 	return result.FailureRate() > threshold
 }
 
+// main は run の戻り値で os.Exit するだけのラッパー。
+// os.Exit は defer を実行しないため、Redis Close 等の後処理が走るよう
+// 実体は run に分離している。
 func main() {
+	os.Exit(run())
+}
+
+// run は ingest 本体のセットアップと実行を行い、終了コード（0 or 1）を返す。
+// 戻り値で main に exit code を伝えるため、defer で登録した後処理が確実に実行される。
+func run() int {
 	db := db.OpenDB()
 	marketRepo := di.NewMarket()
 	candleRepo := candlesadapters.NewCandleRepository(db)
@@ -86,14 +95,15 @@ func main() {
 
 	if err != nil {
 		slog.Error("ingest aborted by fatal error", "error", err)
-		os.Exit(1)
+		return 1
 	}
 	if shouldFailExit(result, maxFailureRate) {
 		slog.Error("ingest failure rate exceeded threshold",
 			"failure_rate", result.FailureRate(),
 			"threshold", maxFailureRate,
 		)
-		os.Exit(1)
+		return 1
 	}
 	slog.Info("ingest ok")
+	return 0
 }

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log"
 	"log/slog"
 	"os"
 	"strconv"
@@ -20,8 +19,15 @@ import (
 )
 
 const (
-	rateLimitPerMinute = 7 // TwelveData APIのレートリミット（無料枠上限8/分、固定ウィンドウずれ対策で1つ余裕を持たせる）
+	rateLimitPerMinute    = 7   // TwelveData APIのレートリミット（無料枠上限8/分、固定ウィンドウずれ対策で1つ余裕を持たせる）
+	defaultMaxFailureRate = 0.2 // INGEST_MAX_FAILURE_RATE のデフォルト値
 )
+
+// shouldFailExit は ingest サマリと失敗率しきい値から非ゼロ終了すべきかを判定する。
+// しきい値ちょうど（FailureRate == threshold）は許容し、超過時のみ true を返す。
+func shouldFailExit(result candlesusecase.IngestResult, threshold float64) bool {
+	return result.FailureRate() > threshold
+}
 
 func main() {
 	db := db.OpenDB()
@@ -57,8 +63,37 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutHours)*time.Hour)
 	defer cancel()
 
-	if err := uc.IngestAll(ctx); err != nil {
-		log.Fatal(err)
+	maxFailureRate := defaultMaxFailureRate
+	if v := os.Getenv("INGEST_MAX_FAILURE_RATE"); v != "" {
+		if r, err := strconv.ParseFloat(v, 64); err == nil && r >= 0 && r <= 1 {
+			maxFailureRate = r
+		} else {
+			slog.Warn("invalid INGEST_MAX_FAILURE_RATE, using default", "value", v, "default", defaultMaxFailureRate)
+		}
 	}
-	log.Println("ingest ok")
+
+	start := time.Now()
+	result, err := uc.IngestAll(ctx)
+	duration := time.Since(start)
+
+	slog.Info("ingest summary",
+		"total", result.Total,
+		"succeeded", result.Succeeded,
+		"failed", result.Failed,
+		"failure_rate", result.FailureRate(),
+		"duration", duration.String(),
+	)
+
+	if err != nil {
+		slog.Error("ingest aborted by fatal error", "error", err)
+		os.Exit(1)
+	}
+	if shouldFailExit(result, maxFailureRate) {
+		slog.Error("ingest failure rate exceeded threshold",
+			"failure_rate", result.FailureRate(),
+			"threshold", maxFailureRate,
+		)
+		os.Exit(1)
+	}
+	slog.Info("ingest ok")
 }

--- a/cmd/ingest/main_test.go
+++ b/cmd/ingest/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	candlesusecase "stock_backend/internal/feature/candles/usecase"
+)
+
+// TestShouldFailExit はしきい値判定の境界条件を検証します。
+// しきい値ちょうど（FailureRate == threshold）は許容し、超過時のみ true を返すこと。
+func TestShouldFailExit(t *testing.T) {
+	testCases := []struct {
+		name      string
+		result    candlesusecase.IngestResult
+		threshold float64
+		want      bool
+	}{
+		{
+			name:      "全銘柄成功 → exit 0",
+			result:    candlesusecase.IngestResult{Total: 10, Succeeded: 10, Failed: 0},
+			threshold: 0.2,
+			want:      false,
+		},
+		{
+			name:      "失敗率がしきい値ちょうど → exit 0（許容）",
+			result:    candlesusecase.IngestResult{Total: 10, Succeeded: 8, Failed: 2},
+			threshold: 0.2,
+			want:      false,
+		},
+		{
+			name:      "失敗率がしきい値超過 → exit 1",
+			result:    candlesusecase.IngestResult{Total: 10, Succeeded: 7, Failed: 3},
+			threshold: 0.2,
+			want:      true,
+		},
+		{
+			name:      "全銘柄失敗 → exit 1",
+			result:    candlesusecase.IngestResult{Total: 5, Succeeded: 0, Failed: 5},
+			threshold: 0.2,
+			want:      true,
+		},
+		{
+			name:      "Total=0（symbol 空） → exit 0",
+			result:    candlesusecase.IngestResult{Total: 0},
+			threshold: 0.2,
+			want:      false,
+		},
+		{
+			name:      "threshold=0 で 1 件失敗 → exit 1（厳格モード）",
+			result:    candlesusecase.IngestResult{Total: 10, Succeeded: 9, Failed: 1},
+			threshold: 0,
+			want:      true,
+		},
+		{
+			name:      "threshold=1.0 で全件失敗 → exit 0（最寛容）",
+			result:    candlesusecase.IngestResult{Total: 5, Succeeded: 0, Failed: 5},
+			threshold: 1.0,
+			want:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldFailExit(tc.result, tc.threshold); got != tc.want {
+				t.Errorf("shouldFailExit(%+v, %v)=%v, want %v", tc.result, tc.threshold, got, tc.want)
+			}
+		})
+	}
+}

--- a/example.env.docker
+++ b/example.env.docker
@@ -36,6 +36,10 @@ TWELVE_DATA_BASE_URL=https://api.twelvedata.com
 # Ingest バッチのタイムアウト時間（任意。正の整数。未設定時は 3 時間）
 # INGEST_TIMEOUT_HOURS=3
 
+# Ingest バッチの許容失敗率（任意。0.0〜1.0 の浮動小数。未設定時は 0.2）
+# 銘柄単位の失敗率がこの値を超えた場合、ingest プロセスは exit 1 で終了する。
+# INGEST_MAX_FAILURE_RATE=0.2
+
 # Redis
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/internal/feature/candles/usecase/ingest_usecase.go
+++ b/internal/feature/candles/usecase/ingest_usecase.go
@@ -36,11 +36,12 @@ type SymbolRepository interface {
 
 // IngestResult は IngestAll 実行後の銘柄単位の集計結果を表します。
 // 致命的エラー時も部分集計が返されるため、main 側でサマリログを出力できます。
+// 個別エラーの内容は IngestAll 内で slog.Error として出力されるため、
+// 集約せず件数のみ保持します。
 type IngestResult struct {
-	Total     int     // 取り込み対象銘柄数
-	Succeeded int     // 成功数
-	Failed    int     // 失敗数
-	Errors    []error // 失敗した銘柄のエラー（symbol 情報付きで wrap）
+	Total     int // 取り込み対象銘柄数
+	Succeeded int // 成功数
+	Failed    int // 失敗数
 }
 
 // FailureRate は失敗率を [0.0, 1.0] で返します。Total が 0 の場合は 0 を返します。
@@ -144,7 +145,6 @@ func (iu *IngestUsecase) IngestAll(ctx context.Context) (IngestResult, error) {
 			// 1銘柄のエラーで処理を停止せず、エラーをログに記録して続行
 			slog.Error("failed to ingest data", "symbol", s, "error", err)
 			result.Failed++
-			result.Errors = append(result.Errors, fmt.Errorf("symbol %s: %w", s, err))
 			continue
 		}
 		result.Succeeded++

--- a/internal/feature/candles/usecase/ingest_usecase.go
+++ b/internal/feature/candles/usecase/ingest_usecase.go
@@ -34,6 +34,23 @@ type SymbolRepository interface {
 	ListActiveCodes(ctx context.Context) ([]string, error)
 }
 
+// IngestResult は IngestAll 実行後の銘柄単位の集計結果を表します。
+// 致命的エラー時も部分集計が返されるため、main 側でサマリログを出力できます。
+type IngestResult struct {
+	Total     int     // 取り込み対象銘柄数
+	Succeeded int     // 成功数
+	Failed    int     // 失敗数
+	Errors    []error // 失敗した銘柄のエラー（symbol 情報付きで wrap）
+}
+
+// FailureRate は失敗率を [0.0, 1.0] で返します。Total が 0 の場合は 0 を返します。
+func (r IngestResult) FailureRate() float64 {
+	if r.Total == 0 {
+		return 0
+	}
+	return float64(r.Failed) / float64(r.Total)
+}
+
 // IngestUsecase は外部APIからデータを取得し、データベースに永続化するユースケースを定義します。
 type IngestUsecase struct {
 	market      MarketRepository
@@ -103,25 +120,34 @@ func dedupCandles(candles []entity.Candle) []entity.Candle {
 // IngestAll はアクティブな全銘柄の時系列データを取得し、
 // 日足・週足・月足をデータベースに永続化します。
 // APIレート制限を遵守し、必要に応じてリクエスト間で待機します。
-func (iu *IngestUsecase) IngestAll(ctx context.Context) error {
+//
+// 銘柄単位の失敗は IngestResult に集約され処理は継続します。
+// 致命的エラー（symbol 一覧取得失敗、ctx キャンセル、rateLimiter 失敗）は
+// それまでの部分集計と共に error を返します。
+func (iu *IngestUsecase) IngestAll(ctx context.Context) (IngestResult, error) {
 	symbols, err := iu.symbol.ListActiveCodes(ctx)
 	if err != nil {
-		return err
+		return IngestResult{}, err
 	}
 
+	result := IngestResult{Total: len(symbols)}
 	for _, s := range symbols {
 		// WaitIfNeeded は limit 未到達なら cancelled ctx でも nil を返すため、
 		// ループごとに明示的に ctx をチェックして早期離脱する。
 		if err := ctx.Err(); err != nil {
-			return err
+			return result, err
 		}
 		if err := iu.rateLimiter.WaitIfNeeded(ctx); err != nil {
-			return err
+			return result, err
 		}
 		if err := iu.ingestOne(ctx, s, ingestOutputSize); err != nil {
 			// 1銘柄のエラーで処理を停止せず、エラーをログに記録して続行
 			slog.Error("failed to ingest data", "symbol", s, "error", err)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Errorf("symbol %s: %w", s, err))
+			continue
 		}
+		result.Succeeded++
 	}
-	return nil
+	return result, nil
 }

--- a/internal/feature/candles/usecase/ingest_usecase_test.go
+++ b/internal/feature/candles/usecase/ingest_usecase_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -292,11 +293,14 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 	testCases := []struct {
 		name                       string
 		inputSymbols               []string
+		listActiveCodesErr         error
 		mockGetTimeSeriesFunc      func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error)
 		mockUpsertBatchFunc        func(ctx context.Context, candles []entity.Candle) error
 		expectedErr                error
+		expectedResult             IngestResult // Errors の中身は verifyResult で個別検証
 		expectedGetTimeSeriesCalls int
 		verifyCalledIntervals      func(t *testing.T, intervals []string)
+		verifyResult               func(t *testing.T, result IngestResult)
 	}{
 		{
 			name:         "success: fetch all symbols",
@@ -307,7 +311,8 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			mockUpsertBatchFunc: func(ctx context.Context, candles []entity.Candle) error {
 				return nil
 			},
-			expectedErr: nil,
+			expectedErr:    nil,
+			expectedResult: IngestResult{Total: 2, Succeeded: 2, Failed: 0},
 			// 2銘柄 × 1回（日足のみ取得）= 2回呼び出し
 			expectedGetTimeSeriesCalls: 2,
 		},
@@ -320,7 +325,8 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			mockUpsertBatchFunc: func(ctx context.Context, candles []entity.Candle) error {
 				return nil
 			},
-			expectedErr: nil,
+			expectedErr:    nil,
+			expectedResult: IngestResult{Total: 1, Succeeded: 1, Failed: 0},
 			// 1銘柄 × 1回 = 1回呼び出し
 			expectedGetTimeSeriesCalls: 1,
 		},
@@ -336,10 +342,11 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 				return nil
 			},
 			expectedErr:                nil,
+			expectedResult:             IngestResult{Total: 0, Succeeded: 0, Failed: 0},
 			expectedGetTimeSeriesCalls: 0,
 		},
 		{
-			name:         "success: continues processing even when some symbols fail",
+			name:         "partial failure: continues processing and aggregates errors",
 			inputSymbols: []string{"AAPL", "INVALID", "GOOG"},
 			mockGetTimeSeriesFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
 				if symbol == "INVALID" {
@@ -350,12 +357,24 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			mockUpsertBatchFunc: func(ctx context.Context, candles []entity.Candle) error {
 				return nil
 			},
-			expectedErr: nil, // IngestAllはエラーを返さず処理を続行
+			expectedErr:    nil, // 銘柄単位の失敗は IngestResult に集約され、error は返らない
+			expectedResult: IngestResult{Total: 3, Succeeded: 2, Failed: 1},
 			// 3銘柄 × 1回 = 3回呼び出し（エラーが発生しても全銘柄が試行される）
 			expectedGetTimeSeriesCalls: 3,
+			verifyResult: func(t *testing.T, result IngestResult) {
+				if len(result.Errors) != 1 {
+					t.Fatalf("Errors length=%d, want 1", len(result.Errors))
+				}
+				if !errors.Is(result.Errors[0], ErrMarketAPI) {
+					t.Errorf("Errors[0] should wrap ErrMarketAPI, got %v", result.Errors[0])
+				}
+				if msg := result.Errors[0].Error(); !strings.Contains(msg, "INVALID") {
+					t.Errorf("Errors[0] should contain symbol name 'INVALID', got %q", msg)
+				}
+			},
 		},
 		{
-			name:         "success: continues processing even when UpsertBatch fails",
+			name:         "partial failure: UpsertBatch failure is aggregated",
 			inputSymbols: []string{"AAPL", "GOOG"},
 			mockGetTimeSeriesFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
 				return mockCandles, nil
@@ -366,9 +385,18 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 				}
 				return nil
 			},
-			expectedErr: nil, // IngestAllはエラーを返さず処理を続行
+			expectedErr:    nil,
+			expectedResult: IngestResult{Total: 2, Succeeded: 1, Failed: 1},
 			// 2銘柄 × 1回 = 2回呼び出し
 			expectedGetTimeSeriesCalls: 2,
+			verifyResult: func(t *testing.T, result IngestResult) {
+				if len(result.Errors) != 1 {
+					t.Fatalf("Errors length=%d, want 1", len(result.Errors))
+				}
+				if !errors.Is(result.Errors[0], ErrDB) {
+					t.Errorf("Errors[0] should wrap ErrDB, got %v", result.Errors[0])
+				}
+			},
 		},
 		{
 			name:         "success: only fetches 1day interval from API",
@@ -380,6 +408,7 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 				return nil
 			},
 			expectedErr:                nil,
+			expectedResult:             IngestResult{Total: 2, Succeeded: 2, Failed: 0},
 			expectedGetTimeSeriesCalls: 2,
 			verifyCalledIntervals: func(t *testing.T, intervals []string) {
 				for i, interval := range intervals {
@@ -388,6 +417,14 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 					}
 				}
 			},
+		},
+		{
+			name:                       "fatal: ListActiveCodes returns error",
+			inputSymbols:               nil,
+			listActiveCodesErr:         ErrDB,
+			expectedErr:                ErrDB,
+			expectedResult:             IngestResult{}, // 部分集計なし
+			expectedGetTimeSeriesCalls: 0,
 		},
 	}
 
@@ -405,13 +442,16 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			}
 			mockSymbol := &mockSymbolRepository{
 				ListActiveCodesFunc: func(ctx context.Context) ([]string, error) {
+					if tc.listActiveCodesErr != nil {
+						return nil, tc.listActiveCodesErr
+					}
 					return tc.inputSymbols, nil
 				},
 			}
 			mockRL := &mockRateLimiter{}
 
 			uc := NewIngestUsecase(mockMarket, mockCandle, mockSymbol, mockRL)
-			err := uc.IngestAll(ctx)
+			result, err := uc.IngestAll(ctx)
 
 			if tc.expectedErr == nil {
 				if err != nil {
@@ -421,12 +461,47 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 				t.Fatalf("expected %v, got %v", tc.expectedErr, err)
 			}
 
+			if result.Total != tc.expectedResult.Total {
+				t.Errorf("result.Total=%d, want %d", result.Total, tc.expectedResult.Total)
+			}
+			if result.Succeeded != tc.expectedResult.Succeeded {
+				t.Errorf("result.Succeeded=%d, want %d", result.Succeeded, tc.expectedResult.Succeeded)
+			}
+			if result.Failed != tc.expectedResult.Failed {
+				t.Errorf("result.Failed=%d, want %d", result.Failed, tc.expectedResult.Failed)
+			}
+
 			if mockMarket.GetTimeSeriesCalls != tc.expectedGetTimeSeriesCalls {
 				t.Errorf("GetTimeSeries was called %d times, expected %d", mockMarket.GetTimeSeriesCalls, tc.expectedGetTimeSeriesCalls)
 			}
 
 			if tc.verifyCalledIntervals != nil {
 				tc.verifyCalledIntervals(t, calledIntervals)
+			}
+			if tc.verifyResult != nil {
+				tc.verifyResult(t, result)
+			}
+		})
+	}
+}
+
+// TestIngestResult_FailureRate は FailureRate の境界条件を検証します。
+func TestIngestResult_FailureRate(t *testing.T) {
+	testCases := []struct {
+		name   string
+		result IngestResult
+		want   float64
+	}{
+		{name: "Total=0 returns 0", result: IngestResult{Total: 0, Failed: 0}, want: 0},
+		{name: "all succeeded", result: IngestResult{Total: 10, Failed: 0}, want: 0},
+		{name: "all failed", result: IngestResult{Total: 10, Failed: 10}, want: 1.0},
+		{name: "20% failure", result: IngestResult{Total: 10, Failed: 2}, want: 0.2},
+		{name: "50% failure", result: IngestResult{Total: 4, Failed: 2}, want: 0.5},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.result.FailureRate(); got != tc.want {
+				t.Errorf("FailureRate()=%v, want %v", got, tc.want)
 			}
 		})
 	}

--- a/internal/feature/candles/usecase/ingest_usecase_test.go
+++ b/internal/feature/candles/usecase/ingest_usecase_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -61,11 +60,15 @@ func (m *mockSymbolRepository) ListActiveCodes(ctx context.Context) ([]string, e
 // mockRateLimiter はRateLimiterInterfaceのモック実装です。
 type mockRateLimiter struct {
 	WaitIfNeededCalls int
+	// WaitIfNeededFunc が設定されていれば呼び出す。nil なら nil を返す（待機なし）。
+	WaitIfNeededFunc func(ctx context.Context, callCount int) error
 }
 
 func (m *mockRateLimiter) WaitIfNeeded(ctx context.Context) error {
 	m.WaitIfNeededCalls++
-	// テスト用に待機せず即座にリターン
+	if m.WaitIfNeededFunc != nil {
+		return m.WaitIfNeededFunc(ctx, m.WaitIfNeededCalls)
+	}
 	return nil
 }
 
@@ -297,10 +300,9 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 		mockGetTimeSeriesFunc      func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error)
 		mockUpsertBatchFunc        func(ctx context.Context, candles []entity.Candle) error
 		expectedErr                error
-		expectedResult             IngestResult // Errors の中身は verifyResult で個別検証
+		expectedResult             IngestResult
 		expectedGetTimeSeriesCalls int
 		verifyCalledIntervals      func(t *testing.T, intervals []string)
-		verifyResult               func(t *testing.T, result IngestResult)
 	}{
 		{
 			name:         "success: fetch all symbols",
@@ -361,17 +363,6 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			expectedResult: IngestResult{Total: 3, Succeeded: 2, Failed: 1},
 			// 3銘柄 × 1回 = 3回呼び出し（エラーが発生しても全銘柄が試行される）
 			expectedGetTimeSeriesCalls: 3,
-			verifyResult: func(t *testing.T, result IngestResult) {
-				if len(result.Errors) != 1 {
-					t.Fatalf("Errors length=%d, want 1", len(result.Errors))
-				}
-				if !errors.Is(result.Errors[0], ErrMarketAPI) {
-					t.Errorf("Errors[0] should wrap ErrMarketAPI, got %v", result.Errors[0])
-				}
-				if msg := result.Errors[0].Error(); !strings.Contains(msg, "INVALID") {
-					t.Errorf("Errors[0] should contain symbol name 'INVALID', got %q", msg)
-				}
-			},
 		},
 		{
 			name:         "partial failure: UpsertBatch failure is aggregated",
@@ -389,14 +380,6 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			expectedResult: IngestResult{Total: 2, Succeeded: 1, Failed: 1},
 			// 2銘柄 × 1回 = 2回呼び出し
 			expectedGetTimeSeriesCalls: 2,
-			verifyResult: func(t *testing.T, result IngestResult) {
-				if len(result.Errors) != 1 {
-					t.Fatalf("Errors length=%d, want 1", len(result.Errors))
-				}
-				if !errors.Is(result.Errors[0], ErrDB) {
-					t.Errorf("Errors[0] should wrap ErrDB, got %v", result.Errors[0])
-				}
-			},
 		},
 		{
 			name:         "success: only fetches 1day interval from API",
@@ -478,11 +461,106 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 			if tc.verifyCalledIntervals != nil {
 				tc.verifyCalledIntervals(t, calledIntervals)
 			}
-			if tc.verifyResult != nil {
-				tc.verifyResult(t, result)
-			}
 		})
 	}
+}
+
+// TestIngestUsecase_IngestAll_MidLoopFatal はループ途中で発生する致命的エラー
+// （ctx キャンセル、rateLimiter 失敗）が部分集計と共に error を返すことを検証します。
+func TestIngestUsecase_IngestAll_MidLoopFatal(t *testing.T) {
+	testTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+	mockCandles := []entity.Candle{
+		{Time: testTime, Open: 100, High: 110, Low: 90, Close: 105},
+	}
+
+	t.Run("ctx cancelled after first symbol succeeds", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		var processedCount int
+		mockMarket := &mockMarketRepository{
+			GetTimeSeriesFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
+				processedCount++
+				if processedCount == 1 {
+					// 1銘柄目の処理完了後に ctx をキャンセルし、2銘柄目のループ先頭で検出させる
+					cancel()
+				}
+				return mockCandles, nil
+			},
+		}
+		mockCandle := &mockCandleWriteRepository{
+			UpsertBatchFunc: func(ctx context.Context, candles []entity.Candle) error { return nil },
+		}
+		mockSymbol := &mockSymbolRepository{
+			ListActiveCodesFunc: func(ctx context.Context) ([]string, error) {
+				return []string{"AAPL", "GOOG", "MSFT"}, nil
+			},
+		}
+		mockRL := &mockRateLimiter{}
+
+		uc := NewIngestUsecase(mockMarket, mockCandle, mockSymbol, mockRL)
+		result, err := uc.IngestAll(ctx)
+
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("err=%v, want context.Canceled", err)
+		}
+		// 1銘柄目は成功、2銘柄目で ctx チェックに引っかかり離脱
+		if result.Total != 3 {
+			t.Errorf("result.Total=%d, want 3", result.Total)
+		}
+		if result.Succeeded != 1 {
+			t.Errorf("result.Succeeded=%d, want 1", result.Succeeded)
+		}
+		if result.Failed != 0 {
+			t.Errorf("result.Failed=%d, want 0", result.Failed)
+		}
+		// 部分集計は exit コード判定で問題ないこと（Failed=0 なので失敗率は 0）
+		if rate := result.FailureRate(); rate != 0 {
+			t.Errorf("FailureRate()=%v, want 0 (no symbol-level failures occurred)", rate)
+		}
+	})
+
+	t.Run("rateLimiter fails on second symbol", func(t *testing.T) {
+		ctx := context.Background()
+		errRateLimit := errors.New("rate limit exceeded")
+
+		mockMarket := &mockMarketRepository{
+			GetTimeSeriesFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]entity.Candle, error) {
+				return mockCandles, nil
+			},
+		}
+		mockCandle := &mockCandleWriteRepository{
+			UpsertBatchFunc: func(ctx context.Context, candles []entity.Candle) error { return nil },
+		}
+		mockSymbol := &mockSymbolRepository{
+			ListActiveCodesFunc: func(ctx context.Context) ([]string, error) {
+				return []string{"AAPL", "GOOG", "MSFT"}, nil
+			},
+		}
+		mockRL := &mockRateLimiter{
+			WaitIfNeededFunc: func(ctx context.Context, callCount int) error {
+				if callCount == 2 {
+					return errRateLimit
+				}
+				return nil
+			},
+		}
+
+		uc := NewIngestUsecase(mockMarket, mockCandle, mockSymbol, mockRL)
+		result, err := uc.IngestAll(ctx)
+
+		if !errors.Is(err, errRateLimit) {
+			t.Fatalf("err=%v, want errRateLimit", err)
+		}
+		if result.Total != 3 {
+			t.Errorf("result.Total=%d, want 3", result.Total)
+		}
+		if result.Succeeded != 1 {
+			t.Errorf("result.Succeeded=%d, want 1 (only AAPL processed)", result.Succeeded)
+		}
+		if result.Failed != 0 {
+			t.Errorf("result.Failed=%d, want 0", result.Failed)
+		}
+	})
 }
 
 // TestIngestResult_FailureRate は FailureRate の境界条件を検証します。


### PR DESCRIPTION
## 概要

closes #147

`IngestAll` が銘柄単位の失敗を握り潰して常に `nil` を返していたため、cron / CI から ingest の異常を検知できなかった問題を修正する。

- `IngestAll` のシグネチャを `(IngestResult, error)` に変更し、銘柄単位の成否を集計
- 致命的エラー（`ListActiveCodes` 失敗、`ctx.Err()`、rate limiter 失敗）は部分集計と共に `error` を返却
- `cmd/ingest/main.go` で `INGEST_MAX_FAILURE_RATE`（デフォルト 0.2）を超えたら `os.Exit(1)`
- `slog.Info(\"ingest summary\", total=, succeeded=, failed=, failure_rate=, duration=)` で構造化サマリログを出力
- しきい値判定ロジックは `shouldFailExit` 純粋関数として抽出し、単体テストで検証

## 変更ファイル

- `internal/feature/candles/usecase/ingest_usecase.go` — `IngestResult` 型 / `FailureRate()` 追加、`IngestAll` シグネチャ変更
- `cmd/ingest/main.go` — env パース、サマリログ、終了コード判定、`shouldFailExit` 抽出
- `internal/feature/candles/usecase/ingest_usecase_test.go` — `IngestResult` 検証への更新と `fatal: ListActiveCodes returns error` / `TestIngestResult_FailureRate` 追加
- `cmd/ingest/main_test.go`（新規）— `shouldFailExit` のテーブル駆動テスト
- `example.env.docker` — `INGEST_MAX_FAILURE_RATE` サンプル記載

## デフォルトしきい値

`INGEST_MAX_FAILURE_RATE=0.2` をデフォルトとした。一時的な API エラーは許容しつつ、20% 超の失敗率なら異常検知できるバランス。

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -race`（全パッケージ pass）
- [x] `golangci-lint run --timeout=5m`（0 issues）
- [x] 全銘柄成功時の終了コード 0、しきい値超過時の終了コード 1 を `TestShouldFailExit` で検証
- [x] サマリログが `slog.Info(\"ingest summary\", ...)` で構造化出力される
- [x] `IngestAll` の唯一の呼び出し元（`cmd/ingest/main.go`）が新シグネチャに追従
- [ ] ローカルで `docker compose ... run ingest` を起動し、サマリログと exit code を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)