### PR TITLE
feat: TwelveData ロゴURL取得バッチを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,12 @@ docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml -p 
 docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml -p stock run --rm --no-deps ingest
 ```
 
+### バッチプロセスの起動（ロゴURL取得）
+
+```bash
+docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml -p stock --profile on-demand run --rm logo-ingest
+```
+
 ### ER 図・テーブル定義書の生成（tbls）
 
 スキーマは [tbls](https://github.com/k1LoW/tbls) で稼働中の PostgreSQL から自動生成されます。

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -623,6 +623,7 @@ components:
       required:
         - code
         - name
+        - logo_url
       properties:
         code:
           type: string
@@ -630,6 +631,10 @@ components:
         name:
           type: string
           description: 企業名
+        logo_url:
+          type: string
+          nullable: true
+          description: Twelve DataのロゴURL（未取得時はnull）
 
     ErrorResponse:
       type: object

--- a/cmd/logo-ingest/main.go
+++ b/cmd/logo-ingest/main.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"stock_backend/internal/app/di"
+	symbollistadapters "stock_backend/internal/feature/symbollist/adapters"
+	symbollistusecase "stock_backend/internal/feature/symbollist/usecase"
+	"stock_backend/internal/platform/db"
+	"stock_backend/internal/shared/ratelimiter"
+)
+
+const (
+	logoRateLimitPerMinute = 7
+	defaultMaxFailureRate  = 0.2
+)
+
+func shouldFailExit(result symbollistusecase.LogoIngestResult, threshold float64) bool {
+	return result.FailureRate() > threshold
+}
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	db := db.OpenDB()
+	logoProvider := di.NewMarket()
+	symbolRepo := symbollistadapters.NewSymbolRepository(db)
+	rateLimiter := ratelimiter.NewRateLimiter(logoRateLimitPerMinute, time.Minute)
+	uc := symbollistusecase.NewLogoIngestUsecase(logoProvider, symbolRepo, rateLimiter)
+
+	timeoutHours := 3
+	if v := os.Getenv("LOGO_INGEST_TIMEOUT_HOURS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			timeoutHours = n
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeoutHours)*time.Hour)
+	defer cancel()
+
+	maxFailureRate := defaultMaxFailureRate
+	if v := os.Getenv("LOGO_INGEST_MAX_FAILURE_RATE"); v != "" {
+		if r, err := strconv.ParseFloat(v, 64); err == nil && r >= 0 && r <= 1 {
+			maxFailureRate = r
+		} else {
+			slog.Warn("invalid LOGO_INGEST_MAX_FAILURE_RATE, using default", "value", v, "default", defaultMaxFailureRate)
+		}
+	}
+
+	start := time.Now()
+	result, err := uc.IngestAll(ctx)
+	duration := time.Since(start)
+
+	slog.Info("logo ingest summary",
+		"total", result.Total,
+		"succeeded", result.Succeeded,
+		"failed", result.Failed,
+		"failure_rate", result.FailureRate(),
+		"duration", duration.String(),
+	)
+
+	if err != nil {
+		slog.Error("logo ingest aborted by fatal error", "error", err)
+		return 1
+	}
+	if shouldFailExit(result, maxFailureRate) {
+		slog.Error("logo ingest failure rate exceeded threshold",
+			"failure_rate", result.FailureRate(),
+			"threshold", maxFailureRate,
+		)
+		return 1
+	}
+	slog.Info("logo ingest ok")
+	return 0
+}

--- a/cmd/logo-ingest/main_test.go
+++ b/cmd/logo-ingest/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"testing"
+
+	symbollistusecase "stock_backend/internal/feature/symbollist/usecase"
+)
+
+func TestShouldFailExit(t *testing.T) {
+	testCases := []struct {
+		name      string
+		result    symbollistusecase.LogoIngestResult
+		threshold float64
+		want      bool
+	}{
+		{
+			name:      "all symbols succeed",
+			result:    symbollistusecase.LogoIngestResult{Total: 10, Succeeded: 10, Failed: 0},
+			threshold: 0.2,
+			want:      false,
+		},
+		{
+			name:      "failure rate equals threshold",
+			result:    symbollistusecase.LogoIngestResult{Total: 10, Succeeded: 8, Failed: 2},
+			threshold: 0.2,
+			want:      false,
+		},
+		{
+			name:      "failure rate exceeds threshold",
+			result:    symbollistusecase.LogoIngestResult{Total: 10, Succeeded: 7, Failed: 3},
+			threshold: 0.2,
+			want:      true,
+		},
+		{
+			name:      "no symbols",
+			result:    symbollistusecase.LogoIngestResult{Total: 0},
+			threshold: 0.2,
+			want:      false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldFailExit(tc.result, tc.threshold); got != tc.want {
+				t.Errorf("shouldFailExit(%+v, %v)=%v, want %v", tc.result, tc.threshold, got, tc.want)
+			}
+		})
+	}
+}

--- a/docker/Dockerfile.logo-ingest
+++ b/docker/Dockerfile.logo-ingest
@@ -1,0 +1,18 @@
+FROM golang:1.25.8-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o logo-ingest ./cmd/logo-ingest
+
+FROM alpine:3.21
+WORKDIR /app
+
+RUN apk add --no-cache tzdata
+ENV TZ=Asia/Tokyo
+
+COPY --from=builder /app/logo-ingest .
+RUN addgroup -S app && adduser -S app -G app && chown app:app /app/logo-ingest
+USER app
+
+ENTRYPOINT ["./logo-ingest"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,3 +22,14 @@ services:
       - ./.env.app
     restart: "no"
     profiles: ["on-demand"]
+
+  logo-ingest:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.logo-ingest
+    image: stock-logo-ingest
+    container_name: stock-logo-ingest
+    env_file:
+      - ./.env.app
+    restart: "no"
+    profiles: ["on-demand"]

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -51,11 +51,11 @@ erDiagram
   varchar_255_ name ""
   varchar_100_ market ""
   varchar_64_ timezone ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
-  text logo_url ""
-  timestamp_with_time_zone logo_updated_at ""
 }
 "public.watchlists" {
   bigint id ""

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -7,7 +7,7 @@
 | [public.users](public.users.md) | 5 |  | BASE TABLE |
 | [public.oauth_accounts](public.oauth_accounts.md) | 5 |  | BASE TABLE |
 | [public.candles](public.candles.md) | 9 |  | BASE TABLE |
-| [public.symbols](public.symbols.md) | 8 |  | BASE TABLE |
+| [public.symbols](public.symbols.md) | 10 |  | BASE TABLE |
 | [public.watchlists](public.watchlists.md) | 6 |  | BASE TABLE |
 
 ## Relations
@@ -54,6 +54,8 @@ erDiagram
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
 }
 "public.watchlists" {
   bigint id ""

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -52,11 +52,11 @@ erDiagram
   varchar_255_ name ""
   varchar_100_ market ""
   varchar_64_ timezone ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
-  text logo_url ""
-  timestamp_with_time_zone logo_updated_at ""
 }
 ```
 

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -55,6 +55,8 @@ erDiagram
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
 }
 ```
 

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -9,11 +9,11 @@
 | name | varchar(255) |  | false |  |  |  |
 | market | varchar(100) |  | false |  |  |  |
 | timezone | varchar(64) |  | false |  |  |  |
+| logo_url | text |  | true |  |  |  |
+| logo_updated_at | timestamp with time zone |  | true |  |  |  |
 | is_active | boolean | true | false |  |  |  |
 | created_at | timestamp with time zone |  | false |  |  |  |
 | updated_at | timestamp with time zone |  | false |  |  |  |
-| logo_url | text |  | true |  |  |  |
-| logo_updated_at | timestamp with time zone |  | true |  |  |  |
 
 ## Constraints
 
@@ -42,11 +42,11 @@ erDiagram
   varchar_255_ name ""
   varchar_100_ market ""
   varchar_64_ timezone ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
-  text logo_url ""
-  timestamp_with_time_zone logo_updated_at ""
 }
 "public.candles" {
   bigint id ""

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -12,6 +12,8 @@
 | is_active | boolean | true | false |  |  |  |
 | created_at | timestamp with time zone |  | false |  |  |  |
 | updated_at | timestamp with time zone |  | false |  |  |  |
+| logo_url | text |  | true |  |  |  |
+| logo_updated_at | timestamp with time zone |  | true |  |  |  |
 
 ## Constraints
 
@@ -43,6 +45,8 @@ erDiagram
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
 }
 "public.candles" {
   bigint id ""

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -60,6 +60,8 @@ erDiagram
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
 }
 ```
 

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -57,11 +57,11 @@ erDiagram
   varchar_255_ name ""
   varchar_100_ market ""
   varchar_64_ timezone ""
+  text logo_url ""
+  timestamp_with_time_zone logo_updated_at ""
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
-  text logo_url ""
-  timestamp_with_time_zone logo_updated_at ""
 }
 ```
 

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -290,6 +290,16 @@
           "name": "updated_at",
           "type": "timestamp with time zone",
           "nullable": false
+        },
+        {
+          "name": "logo_url",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "logo_updated_at",
+          "type": "timestamp with time zone",
+          "nullable": true
         }
       ],
       "indexes": [

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -276,6 +276,16 @@
           "nullable": false
         },
         {
+          "name": "logo_url",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "logo_updated_at",
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
           "name": "is_active",
           "type": "boolean",
           "nullable": false,
@@ -290,16 +300,6 @@
           "name": "updated_at",
           "type": "timestamp with time zone",
           "nullable": false
-        },
-        {
-          "name": "logo_url",
-          "type": "text",
-          "nullable": true
-        },
-        {
-          "name": "logo_updated_at",
-          "type": "timestamp with time zone",
-          "nullable": true
         }
       ],
       "indexes": [

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -8,8 +8,19 @@ import (
 )
 
 const (
-	BearerAuthScopes = "bearerAuth.Scopes"
 	CookieAuthScopes = "cookieAuth.Scopes"
+)
+
+// Defines values for BeginOAuthParamsProvider.
+const (
+	BeginOAuthParamsProviderGithub BeginOAuthParamsProvider = "github"
+	BeginOAuthParamsProviderGoogle BeginOAuthParamsProvider = "google"
+)
+
+// Defines values for OauthCallbackParamsProvider.
+const (
+	OauthCallbackParamsProviderGithub OauthCallbackParamsProvider = "github"
+	OauthCallbackParamsProviderGoogle OauthCallbackParamsProvider = "google"
 )
 
 // AddWatchlistRequest defines model for AddWatchlistRequest.
@@ -109,6 +120,9 @@ type SymbolItem struct {
 	// Code 銘柄コード（例: AAPL, 7203.T）
 	Code string `json:"code"`
 
+	// LogoUrl Twelve DataのロゴURL（未取得時はnull）
+	LogoUrl *string `json:"logo_url"`
+
 	// Name 企業名
 	Name string `json:"name"`
 }
@@ -124,6 +138,18 @@ type WatchlistItem struct {
 	// SymbolCode 銘柄コード（例: AAPL, 7203.T）
 	SymbolCode string `json:"symbol_code"`
 }
+
+// BeginOAuthParamsProvider defines parameters for BeginOAuth.
+type BeginOAuthParamsProvider string
+
+// OauthCallbackParams defines parameters for OauthCallback.
+type OauthCallbackParams struct {
+	Code  string `form:"code" json:"code"`
+	State string `form:"state" json:"state"`
+}
+
+// OauthCallbackParamsProvider defines parameters for OauthCallback.
+type OauthCallbackParamsProvider string
 
 // GetCandlesParams defines parameters for GetCandles.
 type GetCandlesParams struct {

--- a/internal/feature/candles/adapters/twelvedata/logo.go
+++ b/internal/feature/candles/adapters/twelvedata/logo.go
@@ -1,0 +1,48 @@
+package twelvedata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type logoResponse struct {
+	Status  string `json:"status"`
+	Message string `json:"message"`
+	URL     string `json:"url"`
+}
+
+// GetLogoURL はTwelve DataのLogo endpointから株式向けロゴURLを取得します。
+func (t *TwelveDataMarket) GetLogoURL(ctx context.Context, symbol string) (string, error) {
+	q := url.Values{}
+	q.Set("symbol", symbol)
+	q.Set("apikey", t.cfg.TwelveDataAPIKey)
+
+	u := fmt.Sprintf("%s/logo?%s", t.cfg.BaseURL, q.Encode())
+	res, err := t.doRequestWithRetry(ctx, http.MethodGet, u)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			slog.Warn("failed to close response body", "error", err)
+		}
+	}()
+
+	var body logoResponse
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return "", err
+	}
+	if body.Status == "error" {
+		return "", fmt.Errorf("twelvedata: %s", body.Message)
+	}
+	logoURL := strings.TrimSpace(body.URL)
+	if logoURL == "" {
+		return "", fmt.Errorf("twelvedata: empty logo url for %q", symbol)
+	}
+	return logoURL, nil
+}

--- a/internal/feature/candles/adapters/twelvedata/logo_test.go
+++ b/internal/feature/candles/adapters/twelvedata/logo_test.go
@@ -1,0 +1,121 @@
+package twelvedata
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTwelveDataMarket_GetLogoURL_Success(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/logo" {
+			t.Errorf("expected path /logo, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("symbol") != "AAPL" {
+			t.Errorf("expected symbol AAPL, got %s", r.URL.Query().Get("symbol"))
+		}
+		if r.URL.Query().Get("apikey") != "test-key" {
+			t.Errorf("expected apikey test-key, got %s", r.URL.Query().Get("apikey"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"meta":{"symbol":"AAPL"},"url":"https://api.twelvedata.com/logo/apple.com"}`))
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(Config{TwelveDataAPIKey: "test-key", BaseURL: server.URL}, server.Client())
+
+	logoURL, err := market.GetLogoURL(context.Background(), "AAPL")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logoURL != "https://api.twelvedata.com/logo/apple.com" {
+		t.Errorf("unexpected logo url: %s", logoURL)
+	}
+}
+
+func TestTwelveDataMarket_GetLogoURL_HTTPError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(Config{TwelveDataAPIKey: "test-key", BaseURL: server.URL}, server.Client())
+
+	_, err := market.GetLogoURL(context.Background(), "AAPL")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "twelvedata http") {
+		t.Errorf("expected HTTP error, got %v", err)
+	}
+}
+
+func TestTwelveDataMarket_GetLogoURL_APIError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"error","message":"Invalid API key"}`))
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(Config{TwelveDataAPIKey: "invalid-key", BaseURL: server.URL}, server.Client())
+
+	_, err := market.GetLogoURL(context.Background(), "AAPL")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "Invalid API key") {
+		t.Errorf("expected API error message, got %v", err)
+	}
+}
+
+func TestTwelveDataMarket_GetLogoURL_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{invalid json`))
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(Config{TwelveDataAPIKey: "test-key", BaseURL: server.URL}, server.Client())
+
+	if _, err := market.GetLogoURL(context.Background(), "AAPL"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestTwelveDataMarket_GetLogoURL_EmptyURL(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"meta":{"symbol":"AAPL"},"url":"   "}`))
+	}))
+	defer server.Close()
+
+	market := NewTwelveDataMarket(Config{TwelveDataAPIKey: "test-key", BaseURL: server.URL}, server.Client())
+
+	_, err := market.GetLogoURL(context.Background(), "AAPL")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty logo url") {
+		t.Errorf("expected empty logo url error, got %v", err)
+	}
+}

--- a/internal/feature/symbollist/adapters/symbol_repository.go
+++ b/internal/feature/symbollist/adapters/symbol_repository.go
@@ -3,6 +3,7 @@ package adapters
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"gorm.io/gorm"
@@ -16,7 +17,10 @@ type symbolRepository struct {
 	db *gorm.DB
 }
 
-var _ usecase.SymbolRepository = (*symbolRepository)(nil)
+var (
+	_ usecase.SymbolRepository     = (*symbolRepository)(nil)
+	_ usecase.LogoSymbolRepository = (*symbolRepository)(nil)
+)
 
 // NewSymbolRepository は指定されたDB接続でsymbolRepositoryの新しいインスタンスを生成します。
 func NewSymbolRepository(db *gorm.DB) *symbolRepository {
@@ -36,14 +40,22 @@ func (r *symbolRepository) ListActive(ctx context.Context) ([]entity.Symbol, err
 }
 
 // UpdateLogoURL は指定された銘柄のロゴURLと取得日時を更新します。
+// 対象行が存在しない場合はエラーとせず警告ログを出力します（バッチの続行を優先するため）。
 func (r *symbolRepository) UpdateLogoURL(ctx context.Context, code, logoURL string, updatedAt time.Time) error {
-	return r.db.WithContext(ctx).
+	result := r.db.WithContext(ctx).
 		Model(&entity.Symbol{}).
 		Where("code = ?", code).
 		Updates(map[string]any{
 			"logo_url":        logoURL,
 			"logo_updated_at": updatedAt,
-		}).Error
+		})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		slog.Warn("UpdateLogoURL: no matching symbol found", "code", code)
+	}
+	return nil
 }
 
 // ListActiveCodes はコード昇順にアクティブな銘柄のコードのみを返します。

--- a/internal/feature/symbollist/adapters/symbol_repository.go
+++ b/internal/feature/symbollist/adapters/symbol_repository.go
@@ -3,6 +3,7 @@ package adapters
 
 import (
 	"context"
+	"time"
 
 	"gorm.io/gorm"
 
@@ -32,6 +33,17 @@ func (r *symbolRepository) ListActive(ctx context.Context) ([]entity.Symbol, err
 		return nil, err
 	}
 	return symbols, nil
+}
+
+// UpdateLogoURL は指定された銘柄のロゴURLと取得日時を更新します。
+func (r *symbolRepository) UpdateLogoURL(ctx context.Context, code, logoURL string, updatedAt time.Time) error {
+	return r.db.WithContext(ctx).
+		Model(&entity.Symbol{}).
+		Where("code = ?", code).
+		Updates(map[string]any{
+			"logo_url":        logoURL,
+			"logo_updated_at": updatedAt,
+		}).Error
 }
 
 // ListActiveCodes はコード昇順にアクティブな銘柄のコードのみを返します。

--- a/internal/feature/symbollist/adapters/symbol_repository_test.go
+++ b/internal/feature/symbollist/adapters/symbol_repository_test.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -256,8 +257,77 @@ func TestSymbolRepository_ListActive_FieldValues(t *testing.T) {
 	assert.Equal(t, "Toyota Motor Corporation", symbol.Name)
 	assert.Equal(t, "Tokyo Stock Exchange", symbol.Market)
 	assert.Equal(t, "Asia/Tokyo", symbol.Timezone)
+	assert.Nil(t, symbol.LogoURL)
+	assert.Nil(t, symbol.LogoUpdatedAt)
 	assert.True(t, symbol.IsActive)
 	assert.False(t, symbol.UpdatedAt.IsZero(), "UpdatedAt should be set")
+}
+
+func TestSymbolRepository_ListActive_LogoURL(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	repo := NewSymbolRepository(db)
+
+	logoURL := "https://api.twelvedata.com/logo/apple.com"
+	logoUpdatedAt := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	symbol := &entity.Symbol{
+		Code:          "AAPL",
+		Name:          "Apple Inc.",
+		Market:        "NASDAQ",
+		Timezone:      "America/New_York",
+		LogoURL:       &logoURL,
+		LogoUpdatedAt: &logoUpdatedAt,
+		IsActive:      true,
+	}
+	require.NoError(t, db.Create(symbol).Error)
+
+	symbols, err := repo.ListActive(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, symbols, 1)
+	require.NotNil(t, symbols[0].LogoURL)
+	require.NotNil(t, symbols[0].LogoUpdatedAt)
+	assert.Equal(t, logoURL, *symbols[0].LogoURL)
+	assert.True(t, symbols[0].LogoUpdatedAt.Equal(logoUpdatedAt))
+}
+
+func TestSymbolRepository_UpdateLogoURL(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	repo := NewSymbolRepository(db)
+	symbol := seedSymbol(t, db, "AAPL", "Apple Inc.", "NASDAQ", true)
+	oldLogoURL := "https://api.twelvedata.com/logo/old-apple.com"
+	oldLogoUpdatedAt := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	require.NoError(t, db.Model(symbol).Updates(map[string]any{
+		"logo_url":        oldLogoURL,
+		"logo_updated_at": oldLogoUpdatedAt,
+	}).Error)
+
+	newLogoURL := "https://api.twelvedata.com/logo/apple.com"
+	newLogoUpdatedAt := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+
+	err := repo.UpdateLogoURL(context.Background(), "AAPL", newLogoURL, newLogoUpdatedAt)
+
+	require.NoError(t, err)
+	var got entity.Symbol
+	require.NoError(t, db.Where("code = ?", "AAPL").First(&got).Error)
+	require.NotNil(t, got.LogoURL)
+	require.NotNil(t, got.LogoUpdatedAt)
+	assert.Equal(t, newLogoURL, *got.LogoURL)
+	assert.True(t, got.LogoUpdatedAt.Equal(newLogoUpdatedAt))
+}
+
+func TestSymbolRepository_UpdateLogoURL_NoMatchingSymbol(t *testing.T) {
+	t.Parallel()
+
+	db := setupTestDB(t)
+	repo := NewSymbolRepository(db)
+
+	err := repo.UpdateLogoURL(context.Background(), "MISSING", "https://api.twelvedata.com/logo/missing.com", time.Now())
+
+	assert.NoError(t, err)
 }
 
 // TestSymbolRepository_Exists はExistsメソッドの各種シナリオをテーブル駆動テストで検証します。

--- a/internal/feature/symbollist/domain/entity/symbol.go
+++ b/internal/feature/symbollist/domain/entity/symbol.go
@@ -6,12 +6,14 @@ import "time"
 // Symbol はシステム内の株式銘柄コードを表します。
 // 銘柄コード、企業名、市場などの取引証券に関する情報を保持します。
 type Symbol struct {
-	ID        uint      `gorm:"primaryKey"`                   // 主キー
-	Code      string    `gorm:"size:20;not null;uniqueIndex"` // 銘柄コード（例: "AAPL", "7203.T"）
-	Name      string    `gorm:"size:255;not null"`            // 企業名
-	Market    string    `gorm:"size:100;not null"`            // 市場識別子（例: "NASDAQ", "TSE"）
-	Timezone  string    `gorm:"size:64;not null"`             // 取引所の IANA タイムゾーン（例: "America/New_York", "Asia/Tokyo"）
-	IsActive  bool      `gorm:"not null;default:true"`        // トラッキング対象かどうか
-	CreatedAt time.Time `gorm:"autoCreateTime;not null"`      // 登録日時
-	UpdatedAt time.Time `gorm:"autoUpdateTime;not null"`      // 最終更新日時
+	ID            uint       `gorm:"primaryKey"`                   // 主キー
+	Code          string     `gorm:"size:20;not null;uniqueIndex"` // 銘柄コード（例: "AAPL", "7203.T"）
+	Name          string     `gorm:"size:255;not null"`            // 企業名
+	Market        string     `gorm:"size:100;not null"`            // 市場識別子（例: "NASDAQ", "TSE"）
+	Timezone      string     `gorm:"size:64;not null"`             // 取引所の IANA タイムゾーン（例: "America/New_York", "Asia/Tokyo"）
+	LogoURL       *string    `gorm:"type:text"`                    // Twelve DataのロゴURL（未取得時はNULL）
+	LogoUpdatedAt *time.Time // ロゴURLを最後に取得・更新した日時
+	IsActive      bool       `gorm:"not null;default:true"`   // トラッキング対象かどうか
+	CreatedAt     time.Time  `gorm:"autoCreateTime;not null"` // 登録日時
+	UpdatedAt     time.Time  `gorm:"autoUpdateTime;not null"` // 最終更新日時
 }

--- a/internal/feature/symbollist/transport/handler/symbol_handler.go
+++ b/internal/feature/symbollist/transport/handler/symbol_handler.go
@@ -38,7 +38,7 @@ func (h *SymbolHandler) List(c *gin.Context) {
 	}
 	out := make([]api.SymbolItem, 0, len(symbols))
 	for _, s := range symbols {
-		out = append(out, api.SymbolItem{Code: s.Code, Name: s.Name})
+		out = append(out, api.SymbolItem{Code: s.Code, Name: s.Name, LogoUrl: s.LogoURL})
 	}
 	c.JSON(http.StatusOK, out)
 }

--- a/internal/feature/symbollist/transport/handler/symbol_handler_test.go
+++ b/internal/feature/symbollist/transport/handler/symbol_handler_test.go
@@ -14,6 +14,10 @@ import (
 	"stock_backend/internal/feature/symbollist/transport/handler"
 )
 
+func strPtr(s string) *string {
+	return &s
+}
+
 // mockSymbolUsecase はSymbolUsecaseインターフェースのモック実装です。
 type mockSymbolUsecase struct {
 	ListActiveSymbolsFunc func(ctx context.Context) ([]entity.Symbol, error)
@@ -51,12 +55,12 @@ func TestSymbolHandler_List(t *testing.T) {
 			name: "success: returns list of symbols",
 			mockListActiveFunc: func(ctx context.Context) ([]entity.Symbol, error) {
 				return []entity.Symbol{
-					{ID: 1, Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
+					{ID: 1, Code: "7203.T", Name: "Toyota Motor", Market: "TSE", LogoURL: strPtr("https://api.twelvedata.com/logo/toyota.com"), IsActive: true},
 					{ID: 2, Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
 				}, nil
 			},
 			expectedStatus: http.StatusOK,
-			expectedBody:   `[{"code":"7203.T","name":"Toyota Motor"},{"code":"6758.T","name":"Sony Group"}]`,
+			expectedBody:   `[{"code":"7203.T","name":"Toyota Motor","logo_url":"https://api.twelvedata.com/logo/toyota.com"},{"code":"6758.T","name":"Sony Group","logo_url":null}]`,
 		},
 		{
 			name: "success: returns empty list when no symbols",
@@ -74,7 +78,7 @@ func TestSymbolHandler_List(t *testing.T) {
 				}, nil
 			},
 			expectedStatus: http.StatusOK,
-			expectedBody:   `[{"code":"9984.T","name":"SoftBank Group"}]`,
+			expectedBody:   `[{"code":"9984.T","name":"SoftBank Group","logo_url":null}]`,
 		},
 		{
 			name: "failure: usecase returns error",
@@ -117,12 +121,12 @@ func TestSymbolHandler_List(t *testing.T) {
 	}
 }
 
-// TestSymbolHandler_List_DTOConversion はレスポンスにcodeとnameのみが含まれ、内部フィールドが公開されないことを検証します。
+// TestSymbolHandler_List_DTOConversion はレスポンスに公開DTOフィールドのみが含まれ、内部フィールドが公開されないことを検証します。
 func TestSymbolHandler_List_DTOConversion(t *testing.T) {
 	t.Parallel()
 	gin.SetMode(gin.TestMode)
 
-	// レスポンスにcodeとnameのみが含まれることを検証（ID、Market、IsActiveは含まれない）
+	// レスポンスに公開DTOフィールドのみが含まれることを検証（ID、Market、IsActiveは含まれない）
 	mockUC := &mockSymbolUsecase{
 		ListActiveSymbolsFunc: func(ctx context.Context) ([]entity.Symbol, error) {
 			return []entity.Symbol{
@@ -131,6 +135,7 @@ func TestSymbolHandler_List_DTOConversion(t *testing.T) {
 					Code:     "TEST.T",
 					Name:     "Test Company",
 					Market:   "NYSE",
+					LogoURL:  strPtr("https://api.twelvedata.com/logo/test.com"),
 					IsActive: true,
 				},
 			}, nil
@@ -147,8 +152,7 @@ func TestSymbolHandler_List_DTOConversion(t *testing.T) {
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	// レスポンスにはcodeとnameフィールドのみ含まれるべき
-	assert.JSONEq(t, `[{"code":"TEST.T","name":"Test Company"}]`, w.Body.String())
+	assert.JSONEq(t, `[{"code":"TEST.T","name":"Test Company","logo_url":"https://api.twelvedata.com/logo/test.com"}]`, w.Body.String())
 	// 内部フィールドが公開されていないことを検証
 	assert.NotContains(t, w.Body.String(), "999")
 	assert.NotContains(t, w.Body.String(), "NYSE")

--- a/internal/feature/symbollist/usecase/logo_ingest_usecase.go
+++ b/internal/feature/symbollist/usecase/logo_ingest_usecase.go
@@ -1,0 +1,87 @@
+package usecase
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"stock_backend/internal/feature/symbollist/domain/entity"
+	"stock_backend/internal/shared/ratelimiter"
+)
+
+// LogoProvider は外部APIからロゴURLを取得するリポジトリを抽象化します。
+type LogoProvider interface {
+	GetLogoURL(ctx context.Context, symbol string) (string, error)
+}
+
+// LogoSymbolRepository はロゴURL取得バッチで使う銘柄リポジトリを抽象化します。
+type LogoSymbolRepository interface {
+	ListActive(ctx context.Context) ([]entity.Symbol, error)
+	UpdateLogoURL(ctx context.Context, code, logoURL string, updatedAt time.Time) error
+}
+
+// LogoIngestResult はロゴURL取得バッチの銘柄単位の集計結果を表します。
+type LogoIngestResult struct {
+	Total     int
+	Succeeded int
+	Failed    int
+}
+
+// FailureRate は失敗率を [0.0, 1.0] で返します。Total が 0 の場合は 0 を返します。
+func (r LogoIngestResult) FailureRate() float64 {
+	if r.Total == 0 {
+		return 0
+	}
+	return float64(r.Failed) / float64(r.Total)
+}
+
+// LogoIngestUsecase はactive銘柄のロゴURLを外部APIから取得して保存します。
+type LogoIngestUsecase struct {
+	logoProvider LogoProvider
+	symbolRepo   LogoSymbolRepository
+	rateLimiter  ratelimiter.RateLimiterInterface
+	now          func() time.Time
+}
+
+// NewLogoIngestUsecase はLogoIngestUsecaseの新しいインスタンスを生成します。
+func NewLogoIngestUsecase(provider LogoProvider, symbolRepo LogoSymbolRepository, rateLimiter ratelimiter.RateLimiterInterface) *LogoIngestUsecase {
+	return &LogoIngestUsecase{
+		logoProvider: provider,
+		symbolRepo:   symbolRepo,
+		rateLimiter:  rateLimiter,
+		now:          time.Now,
+	}
+}
+
+// IngestAll はactive銘柄のロゴURLを毎回再取得し、成功時のみDBを更新します。
+// 銘柄単位の失敗では処理を止めず、既存logo_urlも保持します。
+func (u *LogoIngestUsecase) IngestAll(ctx context.Context) (LogoIngestResult, error) {
+	symbols, err := u.symbolRepo.ListActive(ctx)
+	if err != nil {
+		return LogoIngestResult{}, err
+	}
+
+	result := LogoIngestResult{Total: len(symbols)}
+	for _, s := range symbols {
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if err := u.rateLimiter.WaitIfNeeded(ctx); err != nil {
+			return result, err
+		}
+
+		logoURL, err := u.logoProvider.GetLogoURL(ctx, s.Code)
+		if err != nil {
+			slog.Error("failed to fetch logo url", "symbol", s.Code, "error", err)
+			result.Failed++
+			continue
+		}
+		if err := u.symbolRepo.UpdateLogoURL(ctx, s.Code, logoURL, u.now()); err != nil {
+			slog.Error("failed to update logo url", "symbol", s.Code, "error", err)
+			result.Failed++
+			continue
+		}
+		result.Succeeded++
+	}
+	return result, nil
+}

--- a/internal/feature/symbollist/usecase/logo_ingest_usecase_test.go
+++ b/internal/feature/symbollist/usecase/logo_ingest_usecase_test.go
@@ -1,0 +1,173 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stock_backend/internal/feature/symbollist/domain/entity"
+)
+
+type mockLogoProvider struct {
+	getLogoURLFunc func(ctx context.Context, symbol string) (string, error)
+}
+
+func (m *mockLogoProvider) GetLogoURL(ctx context.Context, symbol string) (string, error) {
+	if m.getLogoURLFunc != nil {
+		return m.getLogoURLFunc(ctx, symbol)
+	}
+	return "", nil
+}
+
+type mockLogoSymbolRepository struct {
+	symbols           []entity.Symbol
+	listActiveErr     error
+	updateLogoURLFunc func(ctx context.Context, code, logoURL string, updatedAt time.Time) error
+	updates           []logoUpdate
+}
+
+type logoUpdate struct {
+	code      string
+	logoURL   string
+	updatedAt time.Time
+}
+
+func (m *mockLogoSymbolRepository) ListActive(ctx context.Context) ([]entity.Symbol, error) {
+	if m.listActiveErr != nil {
+		return nil, m.listActiveErr
+	}
+	return m.symbols, nil
+}
+
+func (m *mockLogoSymbolRepository) UpdateLogoURL(ctx context.Context, code, logoURL string, updatedAt time.Time) error {
+	if m.updateLogoURLFunc != nil {
+		if err := m.updateLogoURLFunc(ctx, code, logoURL, updatedAt); err != nil {
+			return err
+		}
+	}
+	m.updates = append(m.updates, logoUpdate{code: code, logoURL: logoURL, updatedAt: updatedAt})
+	return nil
+}
+
+type mockRateLimiter struct {
+	waitFunc func(ctx context.Context) error
+	calls    int
+}
+
+func (m *mockRateLimiter) WaitIfNeeded(ctx context.Context) error {
+	m.calls++
+	if m.waitFunc != nil {
+		return m.waitFunc(ctx)
+	}
+	return nil
+}
+
+func TestLogoIngestUsecase_IngestAll_Success(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	repo := &mockLogoSymbolRepository{
+		symbols: []entity.Symbol{
+			{Code: "AAPL", IsActive: true},
+			{Code: "MSFT", IsActive: true},
+		},
+	}
+	provider := &mockLogoProvider{
+		getLogoURLFunc: func(ctx context.Context, symbol string) (string, error) {
+			return "https://api.twelvedata.com/logo/" + symbol + ".com", nil
+		},
+	}
+	limiter := &mockRateLimiter{}
+	uc := NewLogoIngestUsecase(provider, repo, limiter)
+	uc.now = func() time.Time { return now }
+
+	result, err := uc.IngestAll(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, LogoIngestResult{Total: 2, Succeeded: 2}, result)
+	assert.Equal(t, 2, limiter.calls)
+	require.Len(t, repo.updates, 2)
+	assert.Equal(t, "AAPL", repo.updates[0].code)
+	assert.Equal(t, "https://api.twelvedata.com/logo/AAPL.com", repo.updates[0].logoURL)
+	assert.Equal(t, now, repo.updates[0].updatedAt)
+	assert.Equal(t, "MSFT", repo.updates[1].code)
+}
+
+func TestLogoIngestUsecase_IngestAll_ContinuesOnFetchFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockLogoSymbolRepository{
+		symbols: []entity.Symbol{
+			{Code: "AAPL", IsActive: true},
+			{Code: "MSFT", IsActive: true},
+		},
+	}
+	provider := &mockLogoProvider{
+		getLogoURLFunc: func(ctx context.Context, symbol string) (string, error) {
+			if symbol == "AAPL" {
+				return "", errors.New("temporary error")
+			}
+			return "https://api.twelvedata.com/logo/microsoft.com", nil
+		},
+	}
+	uc := NewLogoIngestUsecase(provider, repo, &mockRateLimiter{})
+
+	result, err := uc.IngestAll(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, LogoIngestResult{Total: 2, Succeeded: 1, Failed: 1}, result)
+	require.Len(t, repo.updates, 1)
+	assert.Equal(t, "MSFT", repo.updates[0].code)
+}
+
+func TestLogoIngestUsecase_IngestAll_UpdateFailureDoesNotStopBatch(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockLogoSymbolRepository{
+		symbols: []entity.Symbol{
+			{Code: "AAPL", IsActive: true},
+			{Code: "MSFT", IsActive: true},
+		},
+		updateLogoURLFunc: func(ctx context.Context, code, logoURL string, updatedAt time.Time) error {
+			if code == "AAPL" {
+				return errors.New("db error")
+			}
+			return nil
+		},
+	}
+	provider := &mockLogoProvider{
+		getLogoURLFunc: func(ctx context.Context, symbol string) (string, error) {
+			return "https://api.twelvedata.com/logo/" + symbol + ".com", nil
+		},
+	}
+	uc := NewLogoIngestUsecase(provider, repo, &mockRateLimiter{})
+
+	result, err := uc.IngestAll(context.Background())
+
+	require.NoError(t, err)
+	assert.Equal(t, LogoIngestResult{Total: 2, Succeeded: 1, Failed: 1}, result)
+	require.Len(t, repo.updates, 1)
+	assert.Equal(t, "MSFT", repo.updates[0].code)
+}
+
+func TestLogoIngestUsecase_IngestAll_ListActiveFatalError(t *testing.T) {
+	t.Parallel()
+
+	uc := NewLogoIngestUsecase(&mockLogoProvider{}, &mockLogoSymbolRepository{listActiveErr: errors.New("db down")}, &mockRateLimiter{})
+
+	result, err := uc.IngestAll(context.Background())
+
+	assert.Error(t, err)
+	assert.Equal(t, LogoIngestResult{}, result)
+}
+
+func TestLogoIngestResult_FailureRate(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, 0.0, LogoIngestResult{}.FailureRate())
+	assert.Equal(t, 0.25, LogoIngestResult{Total: 4, Failed: 1}.FailureRate())
+}

--- a/internal/feature/symbollist/usecase/logo_ingest_usecase_test.go
+++ b/internal/feature/symbollist/usecase/logo_ingest_usecase_test.go
@@ -165,6 +165,34 @@ func TestLogoIngestUsecase_IngestAll_ListActiveFatalError(t *testing.T) {
 	assert.Equal(t, LogoIngestResult{}, result)
 }
 
+func TestLogoIngestUsecase_IngestAll_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockLogoSymbolRepository{
+		symbols: []entity.Symbol{
+			{Code: "AAPL", IsActive: true},
+			{Code: "MSFT", IsActive: true},
+		},
+	}
+	provider := &mockLogoProvider{
+		getLogoURLFunc: func(ctx context.Context, symbol string) (string, error) {
+			return "https://api.twelvedata.com/logo/" + symbol + ".com", nil
+		},
+	}
+	limiter := &mockRateLimiter{}
+	uc := NewLogoIngestUsecase(provider, repo, limiter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	result, err := uc.IngestAll(ctx)
+
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, LogoIngestResult{Total: 2, Succeeded: 0, Failed: 0}, result)
+	assert.Equal(t, 0, limiter.calls)
+	assert.Empty(t, repo.updates)
+}
+
 func TestLogoIngestResult_FailureRate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概要

TwelveData の Logo API を利用して、アクティブな銘柄のロゴURLを一括取得・保存するバッチ処理を追加する。取得したロゴURLは `symbols` テーブルに保存し、`GET /v1/symbols` レスポンスにも含める。

## 変更内容

- `Symbol` エンティティに `logo_url`（nullable）・`logo_updated_at` フィールドを追加
- `TwelveDataMarket` に `GetLogoURL` メソッドを追加（`candles/adapters/twelvedata/logo.go`）
- `LogoIngestUsecase` を追加：アクティブ銘柄を順次処理しレートリミット（7req/min）を考慮しながらロゴURLを保存
- `symbolRepository` に `UpdateLogoURL` メソッドを追加
- `SymbolHandler.List` のレスポンスに `logo_url` を含める（OpenAPI 型更新）
- `cmd/logo-ingest` エントリーポイントと `docker/Dockerfile.logo-ingest` を追加
- `docker-compose.yml` に `logo-ingest` サービスを追加（`on-demand` プロファイル）

## 破壊的変更

- `GET /v1/symbols` のレスポンス `SymbolItem` に `logo_url` フィールドが追加される（nullable、未取得時は `null`）。厳密な型チェックを行うクライアントは対応が必要。

## テスト

- `go test ./internal/feature/candles/adapters/twelvedata/... -v` — Logo API クライアントのユニットテスト
- `go test ./internal/feature/symbollist/usecase/... -v` — LogoIngestUsecase のユニットテスト
- `go test ./internal/feature/symbollist/... -v` — リポジトリ・ハンドラーのテスト
- 手動実行：`docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml -p stock --profile on-demand run --rm logo-ingest`

## レビューポイント

- `LogoIngestUsecase.IngestAll` は銘柄単位の失敗でも処理を継続し、既存の `logo_url` を保持する設計（失敗率が閾値を超えると非ゼロ終了）
- `LOGO_INGEST_TIMEOUT_HOURS`・`LOGO_INGEST_MAX_FAILURE_RATE` 環境変数でバッチ挙動を調整可能