### PR TITLE
chore: Claude Code 設定の更新（レビューコメント化と git switch ルール追加）

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -38,7 +38,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }} --comment'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,3 +169,10 @@ feature/<name>/
 コミットメッセージおよびプルリクエストのタイトル・説明はすべて**日本語**で記述してください。
 
 - コミット前のコードレビューは `/code-check` スキル（`.claude/skills/code-check/SKILL.md`）を参照
+
+## Git ブランチ操作のルール
+
+ブランチを切る・切り替える際は `git checkout` ではなく `git switch` を使用してください。
+
+- 新しいブランチを作成して切り替える: `git switch -c <branch-name>`
+- 既存のブランチに切り替える: `git switch <branch-name>`


### PR DESCRIPTION
## 概要
Claude Code 関連の設定を 2 点更新する。CI のコードレビューを PR コメント形式で投稿するように変更し、CLAUDE.md にブランチ操作のルールを追記する。

## 変更内容
- `.github/workflows/claude-code-review.yml`: `/code-review:code-review` プロンプトに `--comment` フラグを追加し、レビュー結果を PR コメントとして投稿するようにした
- `CLAUDE.md`: 「Git ブランチ操作のルール」セクションを追加し、`git checkout` ではなく `git switch` を使用する方針を明記した

## テスト
- 本 PR 自体に対する Claude Code のレビューが PR コメントとして投稿されることを確認する