### PR TITLE
refactor: 認証ログのメールアドレスをハッシュ化して PII を削減

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,8 @@ linters:
               desc: "domain/usecase must not depend on platform packages"
             - pkg: "stock_backend/internal/platform/jwt"
               desc: "domain/usecase must not depend on platform packages"
+            - pkg: "stock_backend/internal/platform/logging"
+              desc: "domain/usecase must not depend on platform packages"
             - pkg: "stock_backend/internal/platform/redis"
               desc: "domain/usecase must not depend on platform packages"
             - pkg: "stock_backend/internal/platform/ratelimit"

--- a/internal/feature/auth/transport/handler/auth_handler.go
+++ b/internal/feature/auth/transport/handler/auth_handler.go
@@ -14,6 +14,7 @@ import (
 
 	"stock_backend/internal/api"
 	"stock_backend/internal/platform/csrf"
+	"stock_backend/internal/platform/logging"
 	"stock_backend/internal/platform/ratelimit"
 )
 
@@ -69,7 +70,7 @@ func (h *AuthHandler) Signup(c *gin.Context) {
 	userID, err := h.auth.Signup(c.Request.Context(), req.Email, req.Password)
 	if err != nil {
 		// ユーザー列挙攻撃を防止するため、実際のエラーを公開しない
-		slog.Warn("signup failed", "error", err, "email", req.Email, "remote_addr", c.ClientIP())
+		slog.Warn("signup failed", "error", err, "email_hash", logging.HashedEmail(req.Email), "remote_addr", c.ClientIP())
 		c.JSON(http.StatusConflict, api.ErrorResponse{Error: "signup failed"})
 		return
 	}
@@ -80,7 +81,7 @@ func (h *AuthHandler) Signup(c *gin.Context) {
 			return
 		}
 	}
-	slog.Info("user signup successful", "email", req.Email, "remote_addr", c.ClientIP())
+	slog.Info("user signup successful", "email_hash", logging.HashedEmail(req.Email), "remote_addr", c.ClientIP())
 	c.JSON(http.StatusCreated, api.MessageResponse{Message: "ok"})
 }
 
@@ -103,7 +104,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	if !result.Allowed {
 		slog.Warn("login rate limit exceeded",
 			"type", "email",
-			"email", req.Email,
+			"email_hash", logging.HashedEmail(req.Email),
 			"remote_addr", c.ClientIP(),
 		)
 		c.Header("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
@@ -114,7 +115,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	token, err := h.auth.Login(c.Request.Context(), req.Email, req.Password)
 	if err != nil {
 		// ユーザー列挙攻撃を防止するため、実際のエラーを公開しない
-		slog.Warn("login failed", "error", err, "email", req.Email, "remote_addr", c.ClientIP())
+		slog.Warn("login failed", "error", err, "email_hash", logging.HashedEmail(req.Email), "remote_addr", c.ClientIP())
 		c.JSON(http.StatusUnauthorized, api.ErrorResponse{Error: "invalid email or password"})
 		return
 	}
@@ -137,7 +138,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie("csrf_token", csrfToken, 3600, "/", "", h.secureCookie, false)
 
-	slog.Info("user login successful", "email", req.Email, "remote_addr", c.ClientIP())
+	slog.Info("user login successful", "email_hash", logging.HashedEmail(req.Email), "remote_addr", c.ClientIP())
 	c.JSON(http.StatusOK, api.MessageResponse{Message: "ok"})
 }
 

--- a/internal/platform/logging/email.go
+++ b/internal/platform/logging/email.go
@@ -1,0 +1,28 @@
+// Package logging は構造化ログ出力時の機密情報マスク用ヘルパーを提供します。
+package logging
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"strings"
+)
+
+// hashedEmailLen はログ出力するメールハッシュの文字数（hex）です。
+// 48 bit 相当で、同一性比較と PII 非可逆性のバランスを取った値です。
+const hashedEmailLen = 12
+
+// HashedEmail はメールアドレスを slog 出力時に SHA-256 ハッシュ（先頭12文字）に
+// 自動変換するラッパー型です。同一メールは同一ハッシュになるため、
+// PII を残さずに連続失敗・レート制限などの相関解析が可能です。
+type HashedEmail string
+
+// LogValue は slog による構造化ログ出力時にメールアドレスをハッシュ化します。
+// 空文字列はそのまま空文字列として出力します（誤判定回避のため）。
+func (e HashedEmail) LogValue() slog.Value {
+	if e == "" {
+		return slog.StringValue("")
+	}
+	sum := sha256.Sum256([]byte(strings.ToLower(string(e))))
+	return slog.StringValue(hex.EncodeToString(sum[:])[:hashedEmailLen])
+}

--- a/internal/platform/logging/email_test.go
+++ b/internal/platform/logging/email_test.go
@@ -1,0 +1,106 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestHashedEmail_LogValue は HashedEmail 型が slog 出力時に期待通りハッシュ化されることを検証します。
+func TestHashedEmail_LogValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     HashedEmail
+		wantEmpty bool
+	}{
+		{name: "通常のメールアドレス", input: "user@example.com"},
+		{name: "別のメールアドレス", input: "other@example.com"},
+		{name: "空文字列", input: "", wantEmpty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.input.LogValue().String()
+			if tt.wantEmpty {
+				if got != "" {
+					t.Errorf("LogValue() = %q, want empty", got)
+				}
+				return
+			}
+			if len(got) != hashedEmailLen {
+				t.Errorf("LogValue() length = %d, want %d (got %q)", len(got), hashedEmailLen, got)
+			}
+			if strings.Contains(got, string(tt.input)) {
+				t.Errorf("LogValue() leaked plaintext: %q", got)
+			}
+		})
+	}
+}
+
+// TestHashedEmail_CaseInsensitive は大文字小文字の違いを正規化して同一ハッシュを返すことを検証します。
+// レート制限キー（auth_handler.go 側で strings.ToLower 済み）との突き合わせを可能にするため。
+func TestHashedEmail_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	a := HashedEmail("User@Example.com").LogValue().String()
+	b := HashedEmail("user@example.com").LogValue().String()
+	if a != b {
+		t.Errorf("case mismatch: %q != %q", a, b)
+	}
+}
+
+// TestHashedEmail_Deterministic は同一入力が常に同一ハッシュを返すことを検証します。
+// 連続失敗・レート制限ログの相関解析が成立する前提条件。
+func TestHashedEmail_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	a := HashedEmail("user@example.com").LogValue().String()
+	b := HashedEmail("user@example.com").LogValue().String()
+	if a != b {
+		t.Errorf("non-deterministic: %q != %q", a, b)
+	}
+}
+
+// TestHashedEmail_Distinct は異なる入力が異なるハッシュを返すことを検証します。
+func TestHashedEmail_Distinct(t *testing.T) {
+	t.Parallel()
+
+	a := HashedEmail("user1@example.com").LogValue().String()
+	b := HashedEmail("user2@example.com").LogValue().String()
+	if a == b {
+		t.Errorf("collision: both produced %q", a)
+	}
+}
+
+// TestHashedEmail_SlogIntegration は実際に slog 経由で出力した際にハッシュが
+// JSON ハンドラの出力に現れ、平文が含まれないことを検証します。
+func TestHashedEmail_SlogIntegration(t *testing.T) {
+	t.Parallel()
+
+	const email = "leak@example.com"
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, nil))
+	logger.Info("test", "email_hash", HashedEmail(email))
+
+	var got map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("failed to parse log JSON: %v", err)
+	}
+
+	hash, ok := got["email_hash"].(string)
+	if !ok {
+		t.Fatalf("email_hash field missing or not string: %v", got["email_hash"])
+	}
+	if len(hash) != hashedEmailLen {
+		t.Errorf("hash length = %d, want %d", len(hash), hashedEmailLen)
+	}
+	if strings.Contains(buf.String(), email) {
+		t.Errorf("log output leaked plaintext email: %s", buf.String())
+	}
+}


### PR DESCRIPTION
## 概要

サーバーログに平文メールアドレスが残るのを防ぐため、認証ハンドラのログ出力フィールドをハッシュ化する。レート制限や連続失敗の相関解析のため完全に削除はせず、同一メールが同一ハッシュになる SHA-256 先頭 12 文字を出力する。

## 変更内容

- `internal/platform/logging` パッケージを新設し、`HashedEmail` 型を追加
  - `slog.LogValuer` を実装し、ログ出力時に自動で SHA-256 先頭 12 文字（hex）に変換
  - `strings.ToLower` で正規化し、`auth_handler.go` のレート制限キーと同じ正規化規則を採用
- `auth_handler.go` の signup/login 関連ログ 5 箇所のフィールドを `email` から `email_hash` に変更
  - signup failed / user signup successful / login rate limit exceeded / login failed / user login successful
- `.golangci.yml` の `layer-isolation` deny リストに `platform/logging` を追加（既存の platform パッケージと同じ扱い）

## レビューポイント

- ハッシュ長 12 文字（48 bit）は復元困難性と識別子としての衝突回避のバランスを取った値。ペッパーは付けていない（目的が暗号学的秘匿ではなくログ上の識別子化のため）
- ログフィールド名を `email` → `email_hash` に変更しているため、既存のログ集計クエリ・ダッシュボードがあれば追従が必要

## テスト

- `internal/platform/logging` のユニットテストを追加（カバレッジ 100%）
  - 決定性（同一入力→同一ハッシュ）
  - 大文字小文字非依存（正規化確認）
  - 異なる入力で衝突しない
  - slog 経由で実出力した際に平文が漏れない
- `go test ./internal/platform/logging/... ./internal/feature/auth/... -race -cover` 全パス
- `golangci-lint run --timeout=5m` 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)