### PR TITLE
Phase 2/6: 初版スキーママイグレーション追加

### DIFF
--- a/db/migrations/00001_init_schema.sql
+++ b/db/migrations/00001_init_schema.sql
@@ -1,0 +1,75 @@
+-- +goose Up
+
+CREATE TABLE users (
+    id              BIGSERIAL PRIMARY KEY,
+    email           VARCHAR(255) NOT NULL,
+    password        VARCHAR(255),
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX idx_users_email ON users (email);
+
+CREATE TABLE oauth_accounts (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT       NOT NULL,
+    provider        VARCHAR(32)  NOT NULL,
+    provider_uid    VARCHAR(255) NOT NULL,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    CONSTRAINT fk_oauth_accounts_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+CREATE INDEX        idx_oauth_accounts_user_id ON oauth_accounts (user_id);
+CREATE UNIQUE INDEX idx_oauth_provider_uid     ON oauth_accounts (provider, provider_uid);
+
+CREATE TABLE symbols (
+    id              BIGSERIAL PRIMARY KEY,
+    code            VARCHAR(20)  NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    market          VARCHAR(100) NOT NULL,
+    timezone        VARCHAR(64)  NOT NULL,
+    logo_url        TEXT,
+    logo_updated_at TIMESTAMPTZ,
+    is_active       BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE UNIQUE INDEX idx_symbols_code ON symbols (code);
+
+CREATE TABLE candles (
+    id              BIGSERIAL PRIMARY KEY,
+    symbol_code     VARCHAR(20)    NOT NULL,
+    "interval"      VARCHAR(16)    NOT NULL,
+    "time"          TIMESTAMPTZ    NOT NULL,
+    open            NUMERIC(15, 4) NOT NULL,
+    high            NUMERIC(15, 4) NOT NULL,
+    low             NUMERIC(15, 4) NOT NULL,
+    close           NUMERIC(15, 4) NOT NULL,
+    volume          BIGINT         NOT NULL DEFAULT 0,
+    CONSTRAINT fk_candles_symbol
+        FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT
+);
+CREATE UNIQUE INDEX candle_sym_int_time ON candles (symbol_code, "interval", "time");
+
+CREATE TABLE watchlists (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         BIGINT      NOT NULL,
+    symbol_code     VARCHAR(20) NOT NULL,
+    sort_key        BIGINT      NOT NULL DEFAULT 0,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT fk_watchlists_user
+        FOREIGN KEY (user_id)     REFERENCES users(id)     ON DELETE CASCADE,
+    CONSTRAINT fk_watchlists_symbol
+        FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT
+);
+CREATE UNIQUE INDEX idx_watchlist_user_symbol   ON watchlists (user_id, symbol_code);
+CREATE UNIQUE INDEX idx_watchlist_user_sort_key ON watchlists (user_id, sort_key);
+CREATE INDEX        idx_watchlists_symbol_code  ON watchlists (symbol_code);
+
+-- +goose Down
+
+DROP TABLE IF EXISTS watchlists;
+DROP TABLE IF EXISTS candles;
+DROP TABLE IF EXISTS symbols;
+DROP TABLE IF EXISTS oauth_accounts;
+DROP TABLE IF EXISTS users;


### PR DESCRIPTION
現状の GORM AutoMigrate + 各 feature の `migration.go` で生成されるスキーマと等価な
ベースライン SQL マイグレーションを追加する。

## このフェーズの変更
`db/migrations/00001_init_schema.sql` を追加。以下のテーブル・制約を初版で全て含める。

- `users`: email 一意制約、password は NULL 許容
- `oauth_accounts`: (provider, provider_uid) 複合一意、user_id → users.id (CASCADE)
- `symbols`: code 一意制約、logo_url/logo_updated_at は NULL 許容
- `candles`: (symbol_code, interval, time) 複合一意、symbol_code → symbols.code (RESTRICT)
- `watchlists`: (user_id, symbol_code) と (user_id, sort_key) の複合一意、両 FK

旧 `migration.go` で別途追加していた FK 制約・追加インデックス（`idx_watchlists_symbol_code` 等）も
すべて初版に統合している。

## スタック構造
- Phase 1/6
- **Phase 2/6** ← ここ (base: `phase1-setup`)
- Phase 3/6 〜 Phase 6/6

## 検証
ローカル PostgreSQL で以下を確認済み：
- `goose up` で全テーブル・FK・インデックスが作成される
- `goose down` で全テーブルが整合性を保ったまま削除できる
- `goose up → down → up` の往復で冪等性に問題なし

## レビューポイント
- `created_at` / `updated_at` に `DEFAULT now()` を付与（GORM は値を Go 側で設定していたが、
  SQL 直接 INSERT への対応のため）。アプリ側が値をセットするケースでは default は使われない

---
_Generated by [Claude Code](https://claude.ai/code/session_01REzVkkcqvaom3jirPH7P7o)_