### PR TITLE
Phase 3/6: goose ベース接続層と Dockerfile.migrate / cmd/server からの廃止

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -14,7 +14,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"maps"
 	"os"
+	"slices"
 	"time"
 
 	infradb "stock_backend/internal/platform/db"
@@ -49,7 +51,7 @@ func run(args []string) int {
 		extra = args[1:]
 	}
 	if _, ok := allowedCommands[cmd]; !ok {
-		slog.Error("unsupported goose command", "command", cmd, "allowed", keys(allowedCommands))
+		slog.Error("unsupported goose command", "command", cmd, "allowed", slices.Sorted(maps.Keys(allowedCommands)))
 		return 2
 	}
 
@@ -73,12 +75,4 @@ func run(args []string) int {
 	}
 	slog.Info("migration ok", "command", cmd)
 	return 0
-}
-
-func keys(m map[string]struct{}) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	return out
 }

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -1,56 +1,84 @@
-// cmd/migrate はスキーマのマイグレーションだけを実行するバイナリ。
+// cmd/migrate はスキーママイグレーションだけを実行するバイナリです。
 //
-// cmd/server も RUN_MIGRATIONS=true でマイグレーションを実行できるが、
-// サーバー本体は GCP (Vision / Gemini) クライアント初期化も伴うため、
-// 認証情報のない CI 環境や Cloud Run の pre-deploy ジョブでは実行できない。
-// このバイナリは DB 接続と AutoMigrate + FK 制約追加のみを行って終了する。
+// 本番デプロイでは Cloud Run pre-deploy ジョブ等で本バイナリを起動して
+// goose によるマイグレーションを適用し、その後 cmd/server をデプロイします。
+//
+// 使い方:
+//
+//	migrate [up|down|down-to|status|version|reset|redo|up-by-one|up-to] [arg]
+//
+// 引数なしで実行した場合は up を適用します。
 package main
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"os"
+	"time"
 
-	authadapters "stock_backend/internal/feature/auth/adapters"
-	authentity "stock_backend/internal/feature/auth/domain/entity"
-	candlesadapters "stock_backend/internal/feature/candles/adapters"
-	symbolentity "stock_backend/internal/feature/symbollist/domain/entity"
-	watchlistadapters "stock_backend/internal/feature/watchlist/adapters"
-	watchlistentity "stock_backend/internal/feature/watchlist/domain/entity"
 	infradb "stock_backend/internal/platform/db"
 )
 
+// allowedCommands は本バイナリから実行を許容する goose サブコマンドです。
+// create / fix のような開発者ローカル専用の操作は除外し、デプロイで使うものに限定します。
+var allowedCommands = map[string]struct{}{
+	"up":        {},
+	"up-by-one": {},
+	"up-to":     {},
+	"down":      {},
+	"down-to":   {},
+	"redo":      {},
+	"reset":     {},
+	"status":    {},
+	"version":   {},
+}
+
 func main() {
+	os.Exit(run(os.Args[1:]))
+}
+
+func run(args []string) int {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
 
-	db := infradb.OpenDB()
-
-	if err := infradb.RunMigrations(db,
-		&authentity.User{},
-		&authentity.OAuthAccount{},
-		&candlesadapters.CandleModel{},
-		&symbolentity.Symbol{},
-		&watchlistentity.UserSymbol{},
-	); err != nil {
-		slog.Error("failed to migrate", "error", err)
-		os.Exit(1)
+	cmd := "up"
+	var extra []string
+	if len(args) > 0 {
+		cmd = args[0]
+		extra = args[1:]
 	}
-	if err := authadapters.MakePasswordNullable(db); err != nil {
-		slog.Error("failed to make password nullable", "error", err)
-		os.Exit(1)
-	}
-	if err := authadapters.AddOAuthAccountsFKConstraints(db); err != nil {
-		slog.Error("failed to add oauth_accounts FK constraints", "error", err)
-		os.Exit(1)
-	}
-	if err := watchlistadapters.AddFKConstraints(db); err != nil {
-		slog.Error("failed to add watchlist FK constraints", "error", err)
-		os.Exit(1)
-	}
-	if err := candlesadapters.AddFKConstraints(db); err != nil {
-		slog.Error("failed to add candles FK constraints", "error", err)
-		os.Exit(1)
+	if _, ok := allowedCommands[cmd]; !ok {
+		slog.Error("unsupported goose command", "command", cmd, "allowed", keys(allowedCommands))
+		return 2
 	}
 
-	slog.Info("migrate ok")
+	db := infradb.OpenSQL()
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Warn("failed to close DB", "error", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if err := infradb.RunGoose(ctx, db, cmd, extra...); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			slog.Error("migration timed out", "error", err)
+		} else {
+			slog.Error("migration failed", "command", cmd, "error", err)
+		}
+		return 1
+	}
+	slog.Info("migration ok", "command", cmd)
+	return 0
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestRun_RejectsUnsupportedCommand は allowedCommands に含まれないサブコマンドを
+// run() が拒否し、終了コード 2 を返すことを検証します。
+// OpenSQL を呼ぶ前に弾かれるため、DB なしで実行可能です。
+func TestRun_RejectsUnsupportedCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "create (developer-only)", args: []string{"create", "foo", "sql"}},
+		{name: "fix (developer-only)", args: []string{"fix"}},
+		{name: "unknown command", args: []string{"no-such"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := run(tt.args)
+			if got != 2 {
+				t.Errorf("run(%v) = %d, want 2", tt.args, got)
+			}
+		})
+	}
+}
+
+// TestAllowedCommands_ContainsExpectedSet は本バイナリが受け付けるべき
+// サブコマンドの集合を固定化します（誤って広げない / 狭めないため）。
+func TestAllowedCommands_ContainsExpectedSet(t *testing.T) {
+	t.Parallel()
+
+	want := []string{
+		"up", "up-by-one", "up-to",
+		"down", "down-to",
+		"redo", "reset",
+		"status", "version",
+	}
+	if len(allowedCommands) != len(want) {
+		t.Errorf("allowedCommands size = %d, want %d", len(allowedCommands), len(want))
+	}
+	for _, c := range want {
+		if _, ok := allowedCommands[c]; !ok {
+			t.Errorf("allowedCommands missing %q", c)
+		}
+	}
+
+	// 開発者ローカル専用コマンドが含まれていないことを検証
+	for _, banned := range []string{"create", "fix"} {
+		if _, ok := allowedCommands[banned]; ok {
+			t.Errorf("allowedCommands must not include %q (developer-only)", banned)
+		}
+	}
+}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,7 +12,6 @@ import (
 	"stock_backend/internal/app/config"
 	"stock_backend/internal/app/router"
 	authadapters "stock_backend/internal/feature/auth/adapters"
-	authentity "stock_backend/internal/feature/auth/domain/entity"
 	authhandler "stock_backend/internal/feature/auth/transport/handler"
 	authusecase "stock_backend/internal/feature/auth/usecase"
 	candlesadapters "stock_backend/internal/feature/candles/adapters"
@@ -23,11 +22,9 @@ import (
 	logohandler "stock_backend/internal/feature/logodetection/transport/handler"
 	logousecase "stock_backend/internal/feature/logodetection/usecase"
 	symbollistadapters "stock_backend/internal/feature/symbollist/adapters"
-	symbolentity "stock_backend/internal/feature/symbollist/domain/entity"
 	symbollisthandler "stock_backend/internal/feature/symbollist/transport/handler"
 	symbollistusecase "stock_backend/internal/feature/symbollist/usecase"
 	watchlistadapters "stock_backend/internal/feature/watchlist/adapters"
-	watchlistentity "stock_backend/internal/feature/watchlist/domain/entity"
 	watchlisthandler "stock_backend/internal/feature/watchlist/transport/handler"
 	watchlistusecase "stock_backend/internal/feature/watchlist/usecase"
 	infradb "stock_backend/internal/platform/db"
@@ -48,38 +45,8 @@ func main() {
 	}))
 	slog.SetDefault(logger)
 
-	// データベース接続
+	// データベース接続。スキーマ適用は cmd/migrate バイナリ（goose）で別途実施する。
 	db := infradb.OpenDB()
-
-	// マイグレーション
-	if os.Getenv("RUN_MIGRATIONS") == "true" {
-		if err := infradb.RunMigrations(db,
-			&authentity.User{},
-			&authentity.OAuthAccount{},
-			&candlesadapters.CandleModel{},
-			&symbolentity.Symbol{},
-			&watchlistentity.UserSymbol{},
-		); err != nil {
-			slog.Error("failed to migrate", "error", err)
-			os.Exit(1)
-		}
-		if err := authadapters.MakePasswordNullable(db); err != nil {
-			slog.Error("failed to make password nullable", "error", err)
-			os.Exit(1)
-		}
-		if err := authadapters.AddOAuthAccountsFKConstraints(db); err != nil {
-			slog.Error("failed to add oauth_accounts FK constraints", "error", err)
-			os.Exit(1)
-		}
-		if err := watchlistadapters.AddFKConstraints(db); err != nil {
-			slog.Error("failed to add watchlist FK constraints", "error", err)
-			os.Exit(1)
-		}
-		if err := candlesadapters.AddFKConstraints(db); err != nil {
-			slog.Error("failed to add candles FK constraints", "error", err)
-			os.Exit(1)
-		}
-	}
 
 	// Redis接続
 	var rdb *redisv9.Client

--- a/db/README.md
+++ b/db/README.md
@@ -8,48 +8,68 @@
 db/
 ├── migrations/                  # goose 管理の SQL マイグレーションファイル
 │   └── NNNNN_<name>.sql         # `-- +goose Up` と `-- +goose Down` を含む単一ファイル
+├── embed.go                     # *.sql を go:embed で取り込み、cmd/migrate などに提供
 └── README.md
 ```
 
 ファイル名は `NNNNN_<snake_case_name>.sql`（5桁連番）で統一します。
 
-## ローカル環境でのコマンド
+## マイグレーションの実行方法
 
-すべて `goose` CLI を `go tool` 経由で実行します（`tools.go` 不要、`go.mod` の `tool` ディレクティブで管理）。
+### 1. cmd/migrate バイナリ（推奨・本番ジョブと同じ経路）
 
-接続情報は `goose` の DSN 形式（例: `postgres://appuser:apppass@localhost:5432/app?sslmode=disable`）を `GOOSE_DBSTRING` 環境変数で指定します。
+埋め込み済み migrations を使うので、SQL ファイルを別途配布する必要がありません。
 
 ```bash
-# 環境変数
+# ローカル
+DB_USER=appuser DB_PASSWORD=apppass DB_NAME=app DB_HOST=localhost DB_PORT=5432 \
+  go run ./cmd/migrate            # 引数省略時は `up`
+go run ./cmd/migrate status
+go run ./cmd/migrate down
+go run ./cmd/migrate up-to 3
+
+# Docker（本番 Cloud Run Job と同等のイメージ）
+docker compose -f docker/docker-compose.yml -p stock run --rm migrate         # up
+docker compose -f docker/docker-compose.yml -p stock run --rm migrate status
+```
+
+サポートするサブコマンド: `up` / `up-by-one` / `up-to` / `down` / `down-to` / `redo` / `reset` / `status` / `version`
+
+`create` / `fix` は開発者ローカルでの SQL ファイル作成・整理用なので、後述の `go tool goose` を使ってください。
+
+### 2. goose CLI（新しいマイグレーション作成・開発時の検証）
+
+`go tool goose` で実行できます（`tools.go` 不要、`go.mod` の `tool` ディレクティブで管理）。
+
+```bash
 export GOOSE_DRIVER=postgres
 export GOOSE_DBSTRING="postgres://appuser:apppass@localhost:5432/app?sslmode=disable"
 export GOOSE_MIGRATION_DIR=db/migrations
 
-# 適用済みマイグレーション状況の確認
-go tool goose status
-
-# 最新まで適用
-go tool goose up
-
-# 1つロールバック
-go tool goose down
-
 # 新しいマイグレーションファイル作成（NNNNN_<name>.sql）
 go tool goose create <snake_case_name> sql
+
+# ローカル DB で適用・確認
+go tool goose status
+go tool goose up
+go tool goose down
 ```
 
-## 本番・ステージング環境での適用
-
-`docker/Dockerfile.migrate` でビルドしたコンテナを使い、デプロイの前段ジョブで実行します。
-詳細は Phase 3 で `cmd/migrate` を `goose` ベースに書き換えた後にこの節を更新します。
-
-## 新規マイグレーションの作成
+## 新規マイグレーションの作成手順
 
 1. `go tool goose create <name> sql` で雛形を作成
 2. `-- +goose Up` セクションに `CREATE` / `ALTER` 等を記述
 3. `-- +goose Down` セクションに**必ず**ロールバック SQL を記述
 4. ローカル PostgreSQL で `go tool goose up` → `go tool goose down` → `go tool goose up` を試し、可逆性を確認
 5. PR に含める
+
+## 本番・ステージング環境での適用
+
+`docker/Dockerfile.migrate` でビルドした `migrate` バイナリを Cloud Run Job などで起動し、
+デプロイの前段で `migrate up` を実行してから `cmd/server` のデプロイへ進みます。
+
+接続情報はサーバーと同じ環境変数（`DB_USER` / `DB_PASSWORD` / `DB_NAME` / `DB_HOST` / `DB_PORT` /
+`INSTANCE_CONNECTION_NAME`）から読み取ります。
 
 ## sqlc コード生成
 
@@ -59,4 +79,5 @@ go tool goose create <snake_case_name> sql
 go tool sqlc generate
 ```
 
-各 feature の `internal/feature/<name>/adapters/sqlc/queries.sql` を編集 → 同ディレクトリに型安全コードが生成されます。
+各 feature の `internal/feature/<name>/adapters/sqlc/queries.sql` を編集 →
+同ディレクトリに型安全コードが生成されます。

--- a/db/embed.go
+++ b/db/embed.go
@@ -1,0 +1,18 @@
+// Package db はマイグレーション SQL ファイルを Go バイナリに埋め込むためのパッケージです。
+// 実行時のファイル配置に依存せず、cmd/migrate などから embed.FS 経由でマイグレーションを参照します。
+package db
+
+import "embed"
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// MigrationsFS は db/migrations/*.sql を含む embed.FS を返します。
+// goose.SetBaseFS に渡して使用します。
+func MigrationsFS() embed.FS {
+	return migrationsFS
+}
+
+// MigrationsDir は embed.FS 内のマイグレーションディレクトリパスです。
+// goose の dir 引数に渡します。
+const MigrationsDir = "migrations"

--- a/docker/Dockerfile.migrate
+++ b/docker/Dockerfile.migrate
@@ -1,0 +1,25 @@
+FROM golang:1.25.8-alpine AS builder
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+# goose 埋め込みマイグレーション専用バイナリ
+RUN CGO_ENABLED=0 GOOS=linux go build -o migrate ./cmd/migrate
+
+FROM alpine:3.21
+WORKDIR /app
+
+RUN apk add --no-cache tzdata ca-certificates
+ENV TZ=Asia/Tokyo
+
+COPY --from=builder /app/migrate .
+RUN addgroup -S app && adduser -S app -G app && chown app:app /app/migrate
+USER app
+
+# デフォルトは `up`（pending を全適用）。
+# Cloud Run Job 等から `status` / `down` / `up-to N` 等を args で渡せる。
+ENTRYPOINT ["./migrate"]
+CMD ["up"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -78,6 +78,20 @@ services:
       redis:
         condition: service_healthy
 
+  # マイグレーション専用バイナリ。本番では同 Dockerfile を Cloud Run Job 等にデプロイ。
+  # ローカル: docker compose -f docker/docker-compose.yml -p stock run --rm migrate [up|status|down|...]
+  migrate:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.migrate
+    env_file:
+      - ./.env.app
+    restart: "no"
+    profiles: ["on-demand"]
+    depends_on:
+      db:
+        condition: service_healthy
+
   swagger-ui:
     image: swaggerapi/swagger-ui
     container_name: stock-swagger-ui

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -6,8 +6,8 @@
 | ---- | ------- | ------- | ---- |
 | [public.users](public.users.md) | 5 |  | BASE TABLE |
 | [public.oauth_accounts](public.oauth_accounts.md) | 5 |  | BASE TABLE |
-| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
 | [public.symbols](public.symbols.md) | 10 |  | BASE TABLE |
+| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
 | [public.watchlists](public.watchlists.md) | 6 |  | BASE TABLE |
 
 ## Relations
@@ -34,17 +34,6 @@ erDiagram
   varchar_255_ provider_uid ""
   timestamp_with_time_zone created_at ""
 }
-"public.candles" {
-  bigint id ""
-  varchar_20_ symbol_code FK ""
-  varchar_16_ interval ""
-  timestamp_with_time_zone time ""
-  numeric_15_4_ open ""
-  numeric_15_4_ high ""
-  numeric_15_4_ low ""
-  numeric_15_4_ close ""
-  bigint volume ""
-}
 "public.symbols" {
   bigint id ""
   varchar_20_ code ""
@@ -56,6 +45,17 @@ erDiagram
   boolean is_active ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
+}
+"public.candles" {
+  bigint id ""
+  varchar_20_ symbol_code FK ""
+  varchar_16_ interval ""
+  timestamp_with_time_zone time ""
+  numeric_15_4_ open ""
+  numeric_15_4_ high ""
+  numeric_15_4_ low ""
+  numeric_15_4_ close ""
+  bigint volume ""
 }
 "public.watchlists" {
   bigint id ""

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -18,8 +18,8 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
-| candles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 | fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
+| candles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
 

--- a/docs/schema/public.oauth_accounts.md
+++ b/docs/schema/public.oauth_accounts.md
@@ -8,7 +8,7 @@
 | user_id | bigint |  | false |  | [public.users](public.users.md) |  |
 | provider | varchar(32) |  | false |  |  |  |
 | provider_uid | varchar(255) |  | false |  |  |  |
-| created_at | timestamp with time zone |  | false |  |  |  |
+| created_at | timestamp with time zone | now() | false |  |  |  |
 
 ## Constraints
 
@@ -22,8 +22,8 @@
 | Name | Definition |
 | ---- | ---------- |
 | oauth_accounts_pkey | CREATE UNIQUE INDEX oauth_accounts_pkey ON public.oauth_accounts USING btree (id) |
-| idx_oauth_provider_uid | CREATE UNIQUE INDEX idx_oauth_provider_uid ON public.oauth_accounts USING btree (provider, provider_uid) |
 | idx_oauth_accounts_user_id | CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (user_id) |
+| idx_oauth_provider_uid | CREATE UNIQUE INDEX idx_oauth_provider_uid ON public.oauth_accounts USING btree (provider, provider_uid) |
 
 ## Relations
 

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -12,8 +12,8 @@
 | logo_url | text |  | true |  |  |  |
 | logo_updated_at | timestamp with time zone |  | true |  |  |  |
 | is_active | boolean | true | false |  |  |  |
-| created_at | timestamp with time zone |  | false |  |  |  |
-| updated_at | timestamp with time zone |  | false |  |  |  |
+| created_at | timestamp with time zone | now() | false |  |  |  |
+| updated_at | timestamp with time zone | now() | false |  |  |  |
 
 ## Constraints
 

--- a/docs/schema/public.users.md
+++ b/docs/schema/public.users.md
@@ -7,8 +7,8 @@
 | id | bigint | nextval('users_id_seq'::regclass) | false | [public.oauth_accounts](public.oauth_accounts.md) [public.watchlists](public.watchlists.md) |  |  |
 | email | varchar(255) |  | false |  |  |  |
 | password | varchar(255) |  | true |  |  |  |
-| created_at | timestamp with time zone |  | false |  |  |  |
-| updated_at | timestamp with time zone |  | false |  |  |  |
+| created_at | timestamp with time zone | now() | false |  |  |  |
+| updated_at | timestamp with time zone | now() | false |  |  |  |
 
 ## Constraints
 

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -8,8 +8,8 @@
 | user_id | bigint |  | false |  | [public.users](public.users.md) |  |
 | symbol_code | varchar(20) |  | false |  | [public.symbols](public.symbols.md) |  |
 | sort_key | bigint | 0 | false |  |  |  |
-| created_at | timestamp with time zone |  | false |  |  |  |
-| updated_at | timestamp with time zone |  | false |  |  |  |
+| created_at | timestamp with time zone | now() | false |  |  |  |
+| updated_at | timestamp with time zone | now() | false |  |  |  |
 
 ## Constraints
 
@@ -24,8 +24,8 @@
 | Name | Definition |
 | ---- | ---------- |
 | watchlists_pkey | CREATE UNIQUE INDEX watchlists_pkey ON public.watchlists USING btree (id) |
-| idx_watchlist_user_sort_key | CREATE UNIQUE INDEX idx_watchlist_user_sort_key ON public.watchlists USING btree (user_id, sort_key) |
 | idx_watchlist_user_symbol | CREATE UNIQUE INDEX idx_watchlist_user_symbol ON public.watchlists USING btree (user_id, symbol_code) |
+| idx_watchlist_user_sort_key | CREATE UNIQUE INDEX idx_watchlist_user_sort_key ON public.watchlists USING btree (user_id, sort_key) |
 | idx_watchlists_symbol_code | CREATE INDEX idx_watchlists_symbol_code ON public.watchlists USING btree (symbol_code) |
 
 ## Relations

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -24,12 +24,14 @@
         {
           "name": "created_at",
           "type": "timestamp with time zone",
-          "nullable": false
+          "nullable": false,
+          "default": "now()"
         },
         {
           "name": "updated_at",
           "type": "timestamp with time zone",
-          "nullable": false
+          "nullable": false,
+          "default": "now()"
         }
       ],
       "indexes": [
@@ -91,7 +93,8 @@
         {
           "name": "created_at",
           "type": "timestamp with time zone",
-          "nullable": false
+          "nullable": false,
+          "default": "now()"
         }
       ],
       "indexes": [
@@ -104,20 +107,20 @@
           ]
         },
         {
+          "name": "idx_oauth_accounts_user_id",
+          "def": "CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (user_id)",
+          "table": "public.oauth_accounts",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
           "name": "idx_oauth_provider_uid",
           "def": "CREATE UNIQUE INDEX idx_oauth_provider_uid ON public.oauth_accounts USING btree (provider, provider_uid)",
           "table": "public.oauth_accounts",
           "columns": [
             "provider",
             "provider_uid"
-          ]
-        },
-        {
-          "name": "idx_oauth_accounts_user_id",
-          "def": "CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (user_id)",
-          "table": "public.oauth_accounts",
-          "columns": [
-            "user_id"
           ]
         }
       ],
@@ -140,6 +143,96 @@
           "type": "PRIMARY KEY",
           "def": "PRIMARY KEY (id)",
           "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "public.symbols",
+      "type": "BASE TABLE",
+      "columns": [
+        {
+          "name": "id",
+          "type": "bigint",
+          "nullable": false,
+          "default": "nextval('symbols_id_seq'::regclass)"
+        },
+        {
+          "name": "code",
+          "type": "varchar(20)",
+          "nullable": false
+        },
+        {
+          "name": "name",
+          "type": "varchar(255)",
+          "nullable": false
+        },
+        {
+          "name": "market",
+          "type": "varchar(100)",
+          "nullable": false
+        },
+        {
+          "name": "timezone",
+          "type": "varchar(64)",
+          "nullable": false
+        },
+        {
+          "name": "logo_url",
+          "type": "text",
+          "nullable": true
+        },
+        {
+          "name": "logo_updated_at",
+          "type": "timestamp with time zone",
+          "nullable": true
+        },
+        {
+          "name": "is_active",
+          "type": "boolean",
+          "nullable": false,
+          "default": "true"
+        },
+        {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
+        }
+      ],
+      "indexes": [
+        {
+          "name": "symbols_pkey",
+          "def": "CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (id)",
+          "table": "public.symbols",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "idx_symbols_code",
+          "def": "CREATE UNIQUE INDEX idx_symbols_code ON public.symbols USING btree (code)",
+          "table": "public.symbols",
+          "columns": [
+            "code"
+          ]
+        }
+      ],
+      "constraints": [
+        {
+          "name": "symbols_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.symbols",
           "referenced_table": "",
           "columns": [
             "id"
@@ -221,16 +314,6 @@
       ],
       "constraints": [
         {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "id"
-          ]
-        },
-        {
           "name": "fk_candles_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -242,90 +325,12 @@
           "referenced_columns": [
             "code"
           ]
-        }
-      ]
-    },
-    {
-      "name": "public.symbols",
-      "type": "BASE TABLE",
-      "columns": [
-        {
-          "name": "id",
-          "type": "bigint",
-          "nullable": false,
-          "default": "nextval('symbols_id_seq'::regclass)"
         },
         {
-          "name": "code",
-          "type": "varchar(20)",
-          "nullable": false
-        },
-        {
-          "name": "name",
-          "type": "varchar(255)",
-          "nullable": false
-        },
-        {
-          "name": "market",
-          "type": "varchar(100)",
-          "nullable": false
-        },
-        {
-          "name": "timezone",
-          "type": "varchar(64)",
-          "nullable": false
-        },
-        {
-          "name": "logo_url",
-          "type": "text",
-          "nullable": true
-        },
-        {
-          "name": "logo_updated_at",
-          "type": "timestamp with time zone",
-          "nullable": true
-        },
-        {
-          "name": "is_active",
-          "type": "boolean",
-          "nullable": false,
-          "default": "true"
-        },
-        {
-          "name": "created_at",
-          "type": "timestamp with time zone",
-          "nullable": false
-        },
-        {
-          "name": "updated_at",
-          "type": "timestamp with time zone",
-          "nullable": false
-        }
-      ],
-      "indexes": [
-        {
-          "name": "symbols_pkey",
-          "def": "CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (id)",
-          "table": "public.symbols",
-          "columns": [
-            "id"
-          ]
-        },
-        {
-          "name": "idx_symbols_code",
-          "def": "CREATE UNIQUE INDEX idx_symbols_code ON public.symbols USING btree (code)",
-          "table": "public.symbols",
-          "columns": [
-            "code"
-          ]
-        }
-      ],
-      "constraints": [
-        {
-          "name": "symbols_pkey",
+          "name": "candles_pkey",
           "type": "PRIMARY KEY",
           "def": "PRIMARY KEY (id)",
-          "table": "public.symbols",
+          "table": "public.candles",
           "referenced_table": "",
           "columns": [
             "id"
@@ -362,12 +367,14 @@
         {
           "name": "created_at",
           "type": "timestamp with time zone",
-          "nullable": false
+          "nullable": false,
+          "default": "now()"
         },
         {
           "name": "updated_at",
           "type": "timestamp with time zone",
-          "nullable": false
+          "nullable": false,
+          "default": "now()"
         }
       ],
       "indexes": [
@@ -380,21 +387,21 @@
           ]
         },
         {
-          "name": "idx_watchlist_user_sort_key",
-          "def": "CREATE UNIQUE INDEX idx_watchlist_user_sort_key ON public.watchlists USING btree (user_id, sort_key)",
-          "table": "public.watchlists",
-          "columns": [
-            "user_id",
-            "sort_key"
-          ]
-        },
-        {
           "name": "idx_watchlist_user_symbol",
           "def": "CREATE UNIQUE INDEX idx_watchlist_user_symbol ON public.watchlists USING btree (user_id, symbol_code)",
           "table": "public.watchlists",
           "columns": [
             "user_id",
             "symbol_code"
+          ]
+        },
+        {
+          "name": "idx_watchlist_user_sort_key",
+          "def": "CREATE UNIQUE INDEX idx_watchlist_user_sort_key ON public.watchlists USING btree (user_id, sort_key)",
+          "table": "public.watchlists",
+          "columns": [
+            "user_id",
+            "sort_key"
           ]
         },
         {
@@ -502,7 +509,7 @@
   ],
   "driver": {
     "name": "postgres",
-    "database_version": "PostgreSQL 16.13 (Debian 16.13-1.pgdg13+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit",
+    "database_version": "PostgreSQL 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, 64-bit",
     "meta": {
       "current_schema": "public",
       "search_paths": [

--- a/docs/tbls.yml
+++ b/docs/tbls.yml
@@ -13,8 +13,9 @@ er:
   comment: true
   hideDef: false
 
-# AutoMigrate で作られるが通常 ER 図に載せる必要がないテーブルがあれば除外する
-exclude: []
+# goose のバージョン管理テーブルなど、ER 図に載せる必要がないものを除外する
+exclude:
+  - goose_db_version
 
 # テーブル・カラムに注釈を付けたい場合はここに追記する
 comments: []

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/oapi-codegen/runtime v1.1.2
+	github.com/pressly/goose/v3 v3.27.1
 	github.com/redis/go-redis/v9 v9.14.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
@@ -109,7 +110,6 @@ require (
 	github.com/pingcap/log v1.1.0 // indirect
 	github.com/pingcap/tidb/pkg/parser v0.0.0-20260418072757-ce92298d1124 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/pressly/goose/v3 v3.27.1 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.59.0 // indirect

--- a/internal/platform/db/migrate.go
+++ b/internal/platform/db/migrate.go
@@ -1,0 +1,28 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+
+	dbmigrations "stock_backend/db"
+)
+
+// RunGoose は埋め込みマイグレーションに対して goose コマンドを実行します。
+// cmd は goose のサブコマンド名（"up", "down", "status", "version" 等）です。
+// args は各サブコマンドへの追加引数（例: "up-to 5"）です。
+//
+// 内部で SetDialect / SetBaseFS を都度設定するため、複数回呼び出しても安全です。
+func RunGoose(ctx context.Context, db *sql.DB, cmd string, args ...string) error {
+	if err := goose.SetDialect("postgres"); err != nil {
+		return fmt.Errorf("set goose dialect: %w", err)
+	}
+	migrationsFS := dbmigrations.MigrationsFS()
+	goose.SetBaseFS(migrationsFS)
+	if err := goose.RunContext(ctx, cmd, db, dbmigrations.MigrationsDir, args...); err != nil {
+		return fmt.Errorf("goose %s: %w", cmd, err)
+	}
+	return nil
+}

--- a/internal/platform/db/migrate_test.go
+++ b/internal/platform/db/migrate_test.go
@@ -1,0 +1,75 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// openParkedDB は接続を開かない *sql.DB を返します。
+// goose のコマンドディスパッチに渡す目的で使用し、実際の DB アクセスは伴いません。
+func openParkedDB(t *testing.T) *sql.DB {
+	t.Helper()
+	// sql.Open は遅延接続のためここでは接続しない。
+	db, err := sql.Open("pgx", "host=127.0.0.1 port=1 user=nouser dbname=nodb sslmode=disable")
+	if err != nil {
+		t.Fatalf("sql.Open failed: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// TestRunGoose_UnknownCommand は未知のサブコマンドが渡された場合に
+// goose のエラーが "goose <cmd>:" 形式でラップされることを検証します。
+//
+// goose は SetDialect / SetBaseFS でパッケージレベルのグローバル変数を書き換えるため、
+// 本ファイル内のテストは t.Parallel() を呼びません。
+func TestRunGoose_UnknownCommand(t *testing.T) {
+	db := openParkedDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := RunGoose(ctx, db, "no-such-command")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.HasPrefix(err.Error(), "goose no-such-command:") {
+		t.Errorf("expected error to be wrapped with 'goose no-such-command:', got %q", err.Error())
+	}
+}
+
+// TestRunGoose_UpToRequiresVersion は up-to が引数なしで呼ばれた場合に
+// goose 側のエラーが返ることを検証します（DB アクセス前に弾かれる）。
+func TestRunGoose_UpToRequiresVersion(t *testing.T) {
+	db := openParkedDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := RunGoose(ctx, db, "up-to")
+	if err == nil {
+		t.Fatal("expected error for up-to without version, got nil")
+	}
+	if !strings.Contains(err.Error(), "up-to") {
+		t.Errorf("expected error to mention 'up-to', got %q", err.Error())
+	}
+}
+
+// TestRunGoose_DownToRequiresNumericVersion は down-to に数値以外を渡した場合に
+// goose 側のバリデーションエラーが返ることを検証します。
+func TestRunGoose_DownToRequiresNumericVersion(t *testing.T) {
+	db := openParkedDB(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	err := RunGoose(ctx, db, "down-to", "not-a-number")
+	if err == nil {
+		t.Fatal("expected error for non-numeric version, got nil")
+	}
+	if !strings.Contains(err.Error(), "must be a number") {
+		t.Errorf("expected numeric-version error, got %q", err.Error())
+	}
+}

--- a/internal/platform/db/sql.go
+++ b/internal/platform/db/sql.go
@@ -1,0 +1,69 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx" の登録
+)
+
+// SQLOpener は database/sql のコネクションを開く関数型です。
+// テストでモック化するために関数型として定義します。
+type SQLOpener func(dsn string) (*sql.DB, error)
+
+// DefaultSQLOpener は pgx/v5/stdlib driver で PostgreSQL に接続する SQLOpener です。
+// 接続プールのデフォルト値はそのままで、必要に応じて呼び出し側で SetMaxOpenConns 等を調整します。
+func DefaultSQLOpener(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, err
+	}
+	// sql.Open はコネクション確立を遅延するため、Ping で疎通確認する。
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
+}
+
+// ConnectSQLWithRetry はリトライ付きで *sql.DB を取得します。
+// timeout 期間中、3秒間隔で再試行します。
+func ConnectSQLWithRetry(dsn string, timeout time.Duration, opener SQLOpener) (*sql.DB, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		db, err := opener(dsn)
+		if err == nil {
+			return db, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("DB connect failed after %v: %w", timeout, err)
+		}
+		slog.Warn("DB connect failed, retrying", "error", err)
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// OpenSQL は環境変数から設定を読み取り *sql.DB を返します。
+// リトライロジックを含み、失敗時は os.Exit します（本番環境用）。
+func OpenSQL() *sql.DB {
+	cfg := LoadConfigFromEnv()
+	if err := cfg.Validate(); err != nil {
+		slog.Error("invalid DB config", "error", err)
+		os.Exit(1)
+	}
+	if cfg.InstanceName != "" && (cfg.Host != "" || cfg.Port != "") {
+		slog.Warn("DB_HOST and DB_PORT are ignored when INSTANCE_CONNECTION_NAME is set",
+			"host", cfg.Host, "port", cfg.Port, "instance", cfg.InstanceName)
+	}
+	dsn := BuildDSN(cfg)
+
+	db, err := ConnectSQLWithRetry(dsn, 60*time.Second, DefaultSQLOpener)
+	if err != nil {
+		slog.Error("DB connect failed", "error", err)
+		os.Exit(1)
+	}
+	return db
+}

--- a/internal/platform/db/sql_test.go
+++ b/internal/platform/db/sql_test.go
@@ -1,0 +1,93 @@
+package db
+
+import (
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestConnectSQLWithRetry_SuccessOnFirstTry は初回接続成功時にリトライせず DB を返すことを検証します。
+func TestConnectSQLWithRetry_SuccessOnFirstTry(t *testing.T) {
+	t.Parallel()
+
+	mockDB := &sql.DB{}
+	calls := 0
+	opener := func(dsn string) (*sql.DB, error) {
+		calls++
+		return mockDB, nil
+	}
+
+	db, err := ConnectSQLWithRetry("test-dsn", 5*time.Second, opener)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if db != mockDB {
+		t.Error("expected mock DB to be returned")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt, got %d", calls)
+	}
+}
+
+// TestConnectSQLWithRetry_RetriesOnFailure は接続失敗時にリトライして最終的に成功することを検証します。
+func TestConnectSQLWithRetry_RetriesOnFailure(t *testing.T) {
+	// retry interval が 3 秒固定のため Parallel にしない
+	mockDB := &sql.DB{}
+	attemptCount := 0
+	opener := func(dsn string) (*sql.DB, error) {
+		attemptCount++
+		if attemptCount < 3 {
+			return nil, errors.New("connection refused")
+		}
+		return mockDB, nil
+	}
+
+	db, err := ConnectSQLWithRetry("test-dsn", 10*time.Second, opener)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if db != mockDB {
+		t.Error("expected mock DB to be returned")
+	}
+	if attemptCount != 3 {
+		t.Errorf("expected 3 attempts, got %d", attemptCount)
+	}
+}
+
+// TestConnectSQLWithRetry_TimeoutAfterRetries はタイムアウト後にエラーが返されることを検証します。
+func TestConnectSQLWithRetry_TimeoutAfterRetries(t *testing.T) {
+	t.Parallel()
+
+	attemptCount := 0
+	opener := func(dsn string) (*sql.DB, error) {
+		attemptCount++
+		return nil, errors.New("connection refused")
+	}
+
+	_, err := ConnectSQLWithRetry("test-dsn", 100*time.Millisecond, opener)
+	if err == nil {
+		t.Fatal("expected error after timeout, got nil")
+	}
+	if attemptCount == 0 {
+		t.Error("expected at least one connection attempt")
+	}
+}
+
+// TestConnectSQLWithRetry_ErrorWrapped はタイムアウト時のエラーが最後の opener エラーをラップしていることを検証します。
+func TestConnectSQLWithRetry_ErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	sentinel := errors.New("driver-specific failure")
+	opener := func(dsn string) (*sql.DB, error) {
+		return nil, sentinel
+	}
+
+	_, err := ConnectSQLWithRetry("test-dsn", 50*time.Millisecond, opener)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+}


### PR DESCRIPTION
マイグレーション実行基盤を GORM AutoMigrate から goose に切り替え、`cmd/server` 起動時の
マイグレーション実行を廃止する。同時に *sql.DB ベースの接続層を新設する。

## このフェーズの変更

### 接続層
- `db/embed.go`: `db/migrations/*.sql` を `embed.FS` に取り込み
- `internal/platform/db/sql.go`: `database/sql` + `pgx/v5/stdlib` driver による接続層
  - `OpenSQL` / `ConnectSQLWithRetry` / `DefaultSQLOpener`
  - 既存の `Config` / `Validate` / `BuildDSN` はそのまま流用
- `internal/platform/db/migrate.go`: 埋め込みマイグレーションを使う `RunGoose` ヘルパー

### マイグレーションバイナリ
- `cmd/migrate`: GORM `AutoMigrate` + FK 追加ロジックを廃止、goose ベースに書き換え
  - `up` / `up-by-one` / `up-to` / `down` / `down-to` / `redo` / `reset` / `status` / `version` をサポート
- `docker/Dockerfile.migrate`: 新規のスリムな専用コンテナ
  - 本番では Cloud Run Job 等で `cmd/migrate up` を実行する想定
- `docker-compose.yml`: `profiles: ["on-demand"]` で migrate サービスを追加

### サーバー
- `cmd/server`: `RUN_MIGRATIONS=true` ブロックを完全削除
  - サーバー起動とマイグレーションを明確に分離

### ドキュメント
- `db/README.md`: 新しい運用手順を反映

## スタック構造
- Phase 1/6 → Phase 2/6
- **Phase 3/6** ← ここ (base: `phase2-baseline`)
- Phase 4a-d/6 〜 Phase 6/6

## 検証
- ローカル PostgreSQL で `cmd/migrate` の up/status/down を端から端まで確認
- 既存テストは継続してパス（`go test ./internal/platform/db/...` OK）
- `golangci-lint run` ✅

## 注意点
- **デプロイフローの変更が必要**: マイグレーションは `cmd/server` のデプロイ前段で
  `cmd/migrate` ジョブを別途実行する運用に変更します。CD ワークフローへの組み込みが
  別途必要です。
- 旧 `migration.go` (各 feature の FK 追加ロジック) はこのフェーズではまだ残します
  （ビルド互換のため）。Phase 4a-d で個別 feature 移行時に削除します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01REzVkkcqvaom3jirPH7P7o)_