### PR TITLE
Phase 5/6: GORM 依存を完全に除去

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,6 +132,18 @@ linters:
             - pkg: "stock_backend/internal/feature/watchlist"
               desc: "platform must not depend on feature"
 
+        # GORM は sqlc + database/sql に移行済み。再混入を防止する。
+        no-gorm:
+          files:
+            - "$all"
+          deny:
+            - pkg: "gorm.io/gorm"
+              desc: "GORM is removed; use sqlc-generated queries on database/sql instead"
+            - pkg: "gorm.io/driver/postgres"
+              desc: "use github.com/jackc/pgx/v5/stdlib (database/sql driver) instead"
+            - pkg: "gorm.io/driver/sqlite"
+              desc: "use testcontainers-go for real PostgreSQL in tests instead"
+
 formatters:
   enable:
     - gofmt

--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,6 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.36.0
 	google.golang.org/genai v1.46.0
-	gorm.io/driver/postgres v1.6.0
-	gorm.io/driver/sqlite v1.6.0
-	gorm.io/gorm v1.30.1
 )
 
 require (
@@ -95,7 +92,6 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
-	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -107,7 +103,6 @@ require (
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
 	github.com/mfridman/interpolate v0.0.2 // indirect
 	github.com/mfridman/xflag v0.1.0 // indirect
 	github.com/microsoft/go-mssqldb v1.9.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -252,8 +252,6 @@ github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFr
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
-github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
-github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901/go.mod h1:Z86h9688Y0wesXCyonoVr47MasHilkuLMqGhRZ4Hpak=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
@@ -288,8 +286,6 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
 github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
-github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
-github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=
 github.com/mdelapenya/tlscert v0.2.0/go.mod h1:O4njj3ELLnJjGdkN7M/vIVCpZ+Cf0L6muqOG4tLSl8o=
 github.com/mfridman/interpolate v0.0.2 h1:pnuTK7MQIxxFz1Gr+rjSIx9u7qVjf5VOoM/u6BbAxPY=
@@ -677,12 +673,6 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/driver/postgres v1.6.0 h1:2dxzU8xJ+ivvqTRph34QX+WrRaJlmfyPqXmoGVjMBa4=
-gorm.io/driver/postgres v1.6.0/go.mod h1:vUw0mrGgrTK+uPHEhAdV4sfFELrByKVGnaVRkXDhtWo=
-gorm.io/driver/sqlite v1.6.0 h1:WHRRrIiulaPiPFmDcod6prc4l2VGVWHz80KspNsxSfQ=
-gorm.io/driver/sqlite v1.6.0/go.mod h1:AO9V1qIQddBESngQUKWL9yoH93HIeA1X6V633rBwyT8=
-gorm.io/gorm v1.30.1 h1:lSHg33jJTBxs2mgJRfRZeLDG+WZaHYCk3Wtfl6Ngzo4=
-gorm.io/gorm v1.30.1/go.mod h1:8Z33v652h4//uMA76KjeDH8mJXPm1QNCYrMeatR0DOE=
 gotest.tools/v3 v3.5.2 h1:7koQfIKdy+I8UTetycgUqXWSDwpgv193Ka+qRsmBY8Q=
 gotest.tools/v3 v3.5.2/go.mod h1:LtdLGcnqToBH83WByAAi/wiwSFCArdFIUV/xxN4pcjA=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/platform/db/config.go
+++ b/internal/platform/db/config.go
@@ -2,16 +2,10 @@
 package db
 
 import (
-	"database/sql"
 	"fmt"
 	"log/slog"
 	"os"
 	"strings"
-	"time"
-
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 // Password はログ出力・文字列化・JSONシリアライズ時に値をマスクする機密文字列型です。
@@ -112,84 +106,4 @@ func BuildDSN(cfg Config) string {
 		quotePGValue(cfg.User),
 		quotePGValue(string(cfg.Password)),
 		quotePGValue(cfg.Name))
-}
-
-// Opener はデータベース接続を開くための関数型です。
-type Opener func(dsn string) (*gorm.DB, error)
-
-// DefaultOpener はGORMを使用してPostgreSQLデータベースを開きます。
-func DefaultOpener(dsn string) (*gorm.DB, error) {
-	return gorm.Open(postgres.Open(dsn), &gorm.Config{
-		Logger: logger.Default.LogMode(gormLogLevel()),
-	})
-}
-
-// gormLogLevel は環境変数 DB_LOG_LEVEL からGORMのログレベルを返します。
-// 未設定または不明な値の場合は Silent を返します。
-func gormLogLevel() logger.LogLevel {
-	switch os.Getenv("DB_LOG_LEVEL") {
-	case "info":
-		return logger.Info
-	case "warn":
-		return logger.Warn
-	case "error":
-		return logger.Error
-	default:
-		return logger.Silent
-	}
-}
-
-// ConnectWithRetry はリトライロジック付きでデータベース接続を試みます。
-// 指定されたタイムアウト期間中、3秒間隔でリトライします。
-// データベース接続を返すか、すべてのリトライが失敗した場合はエラーを返します。
-func ConnectWithRetry(dsn string, timeout time.Duration, opener Opener) (*gorm.DB, error) {
-	deadline := time.Now().Add(timeout)
-	for {
-		db, err := opener(dsn)
-		if err == nil {
-			return db, nil
-		}
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("DB connect failed after %v: %w", timeout, err)
-		}
-		slog.Warn("DB connect failed, retrying", "error", err)
-		time.Sleep(3 * time.Second)
-	}
-}
-
-// RunMigrations は指定されたモデルのデータベースマイグレーションを実行します。
-func RunMigrations(db *gorm.DB, models ...any) error {
-	return db.AutoMigrate(models...)
-}
-
-// OpenDB は環境設定を使用してデータベース接続を開きます。
-// リトライロジックを含み、失敗時はプロセスを終了します（本番環境用）。
-func OpenDB() *gorm.DB {
-	cfg := LoadConfigFromEnv()
-	if err := cfg.Validate(); err != nil {
-		slog.Error("invalid DB config", "error", err)
-		os.Exit(1)
-	}
-	if cfg.InstanceName != "" && (cfg.Host != "" || cfg.Port != "") {
-		slog.Warn("DB_HOST and DB_PORT are ignored when INSTANCE_CONNECTION_NAME is set",
-			"host", cfg.Host, "port", cfg.Port, "instance", cfg.InstanceName)
-	}
-	dsn := BuildDSN(cfg)
-
-	db, err := ConnectWithRetry(dsn, 60*time.Second, DefaultOpener)
-	if err != nil {
-		slog.Error("DB connect failed", "error", err)
-		os.Exit(1)
-	}
-
-	return db
-}
-
-// NewGORMFromSQL は既存の *sql.DB をベースに *gorm.DB を生成します。
-// 既存の GORM ベース feature と新しい sqlc ベース feature を同一の接続プールで
-// 共存させるためのブリッジで、全 feature が sqlc 化されたら本関数ごと削除します。
-func NewGORMFromSQL(sqlDB *sql.DB) (*gorm.DB, error) {
-	return gorm.Open(postgres.New(postgres.Config{Conn: sqlDB}), &gorm.Config{
-		Logger: logger.Default.LogMode(gormLogLevel()),
-	})
 }

--- a/internal/platform/db/config_test.go
+++ b/internal/platform/db/config_test.go
@@ -2,14 +2,11 @@ package db
 
 import (
 	"bytes"
-	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
-	"time"
 )
 
 // TestBuildDSN_TCP はTCP接続用のDSN文字列が正しく生成されることを検証します。
@@ -195,65 +192,6 @@ func TestPassword_Masking(t *testing.T) {
 			t.Errorf("string(p) = %q, want %q", string(p), secret)
 		}
 	})
-}
-
-// TestConnectSQLWithRetry_SuccessOnFirstTry は初回接続成功時にリトライせず DB を返すことを検証します。
-func TestConnectSQLWithRetry_SuccessOnFirstTry(t *testing.T) {
-	t.Parallel()
-
-	mockDB := &sql.DB{}
-	opener := func(dsn string) (*sql.DB, error) { return mockDB, nil }
-
-	db, err := ConnectSQLWithRetry("test-dsn", 5*time.Second, opener)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if db != mockDB {
-		t.Error("expected mock DB to be returned")
-	}
-}
-
-// TestConnectSQLWithRetry_RetriesOnFailure は接続失敗時にリトライして最終的に成功することを検証します。
-func TestConnectSQLWithRetry_RetriesOnFailure(t *testing.T) {
-	mockDB := &sql.DB{}
-	attemptCount := 0
-	opener := func(dsn string) (*sql.DB, error) {
-		attemptCount++
-		if attemptCount < 3 {
-			return nil, errors.New("connection refused")
-		}
-		return mockDB, nil
-	}
-
-	db, err := ConnectSQLWithRetry("test-dsn", 10*time.Second, opener)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if db != mockDB {
-		t.Error("expected mock DB to be returned")
-	}
-	if attemptCount != 3 {
-		t.Errorf("expected 3 attempts, got %d", attemptCount)
-	}
-}
-
-// TestConnectSQLWithRetry_TimeoutAfterRetries はタイムアウト後にエラーが返されることを検証します。
-func TestConnectSQLWithRetry_TimeoutAfterRetries(t *testing.T) {
-	t.Parallel()
-
-	attemptCount := 0
-	opener := func(dsn string) (*sql.DB, error) {
-		attemptCount++
-		return nil, errors.New("connection refused")
-	}
-
-	_, err := ConnectSQLWithRetry("test-dsn", 100*time.Millisecond, opener)
-	if err == nil {
-		t.Fatal("expected error after timeout, got nil")
-	}
-	if attemptCount == 0 {
-		t.Error("expected at least one connection attempt")
-	}
 }
 
 // TestConfig_Validate_TCP_Success は TCP 接続で必須項目が揃っていればエラーにならないことを検証します。

--- a/internal/platform/db/config_test.go
+++ b/internal/platform/db/config_test.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,8 +10,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"gorm.io/gorm"
 )
 
 // TestBuildDSN_TCP はTCP接続用のDSN文字列が正しく生成されることを検証します。
@@ -56,7 +55,6 @@ func TestBuildDSN_CloudSQL(t *testing.T) {
 func TestBuildDSN_CloudSQLTakesPrecedence(t *testing.T) {
 	t.Parallel()
 
-	// When both InstanceName and Host/Port are set, InstanceName takes precedence
 	cfg := Config{
 		User:         "testuser",
 		Password:     "testpass",
@@ -68,7 +66,6 @@ func TestBuildDSN_CloudSQLTakesPrecedence(t *testing.T) {
 
 	dsn := BuildDSN(cfg)
 
-	// Should use Cloud SQL format, not TCP
 	if dsn == "host=localhost port=5432 user=testuser password=testpass dbname=testdb sslmode=disable" {
 		t.Error("expected Cloud SQL DSN format, but got TCP format")
 	}
@@ -91,44 +88,28 @@ func TestBuildDSN_EscapesSpecialCharacters(t *testing.T) {
 		{
 			name: "password with space",
 			cfg: Config{
-				User:     "u",
-				Password: "p@ss word",
-				Name:     "d",
-				Host:     "h",
-				Port:     "5432",
+				User: "u", Password: "p@ss word", Name: "d", Host: "h", Port: "5432",
 			},
 			expected: "host=h port=5432 user=u password='p@ss word' dbname=d sslmode=disable",
 		},
 		{
 			name: "password with single quote and backslash",
 			cfg: Config{
-				User:     "u",
-				Password: `p'a\ss`,
-				Name:     "d",
-				Host:     "h",
-				Port:     "5432",
+				User: "u", Password: `p'a\ss`, Name: "d", Host: "h", Port: "5432",
 			},
 			expected: `host=h port=5432 user=u password='p\'a\\ss' dbname=d sslmode=disable`,
 		},
 		{
 			name: "empty password is quoted",
 			cfg: Config{
-				User:     "u",
-				Password: "",
-				Name:     "d",
-				Host:     "h",
-				Port:     "5432",
+				User: "u", Password: "", Name: "d", Host: "h", Port: "5432",
 			},
 			expected: "host=h port=5432 user=u password='' dbname=d sslmode=disable",
 		},
 		{
 			name: "user with equals sign",
 			cfg: Config{
-				User:     "us=er",
-				Password: "p",
-				Name:     "d",
-				Host:     "h",
-				Port:     "5432",
+				User: "us=er", Password: "p", Name: "d", Host: "h", Port: "5432",
 			},
 			expected: "host=h port=5432 user='us=er' password=p dbname=d sslmode=disable",
 		},
@@ -210,23 +191,20 @@ func TestPassword_Masking(t *testing.T) {
 
 	t.Run("explicit string conversion still exposes value", func(t *testing.T) {
 		t.Parallel()
-		// DSN 構築など実値が必要な場面では明示的変換で取得できる
 		if string(p) != secret {
 			t.Errorf("string(p) = %q, want %q", string(p), secret)
 		}
 	})
 }
 
-// TestConnectWithRetry_SuccessOnFirstTry は初回接続成功時にリトライせずDBを返すことを検証します。
-func TestConnectWithRetry_SuccessOnFirstTry(t *testing.T) {
+// TestConnectSQLWithRetry_SuccessOnFirstTry は初回接続成功時にリトライせず DB を返すことを検証します。
+func TestConnectSQLWithRetry_SuccessOnFirstTry(t *testing.T) {
 	t.Parallel()
 
-	mockDB := &gorm.DB{}
-	opener := func(dsn string) (*gorm.DB, error) {
-		return mockDB, nil
-	}
+	mockDB := &sql.DB{}
+	opener := func(dsn string) (*sql.DB, error) { return mockDB, nil }
 
-	db, err := ConnectWithRetry("test-dsn", 5*time.Second, opener)
+	db, err := ConnectSQLWithRetry("test-dsn", 5*time.Second, opener)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -235,14 +213,11 @@ func TestConnectWithRetry_SuccessOnFirstTry(t *testing.T) {
 	}
 }
 
-// TestConnectWithRetry_RetriesOnFailure は接続失敗時にリトライして最終的に成功することを検証します。
-func TestConnectWithRetry_RetriesOnFailure(t *testing.T) {
-	// Not parallel because this test takes time due to retry sleeps
-
-	mockDB := &gorm.DB{}
+// TestConnectSQLWithRetry_RetriesOnFailure は接続失敗時にリトライして最終的に成功することを検証します。
+func TestConnectSQLWithRetry_RetriesOnFailure(t *testing.T) {
+	mockDB := &sql.DB{}
 	attemptCount := 0
-
-	opener := func(dsn string) (*gorm.DB, error) {
+	opener := func(dsn string) (*sql.DB, error) {
 		attemptCount++
 		if attemptCount < 3 {
 			return nil, errors.New("connection refused")
@@ -250,8 +225,7 @@ func TestConnectWithRetry_RetriesOnFailure(t *testing.T) {
 		return mockDB, nil
 	}
 
-	// Use a timeout that allows for 2 retries (retry interval is 3 seconds)
-	db, err := ConnectWithRetry("test-dsn", 10*time.Second, opener)
+	db, err := ConnectSQLWithRetry("test-dsn", 10*time.Second, opener)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -263,19 +237,17 @@ func TestConnectWithRetry_RetriesOnFailure(t *testing.T) {
 	}
 }
 
-// TestConnectWithRetry_TimeoutAfterRetries はタイムアウト後にエラーが返されることを検証します。
-func TestConnectWithRetry_TimeoutAfterRetries(t *testing.T) {
+// TestConnectSQLWithRetry_TimeoutAfterRetries はタイムアウト後にエラーが返されることを検証します。
+func TestConnectSQLWithRetry_TimeoutAfterRetries(t *testing.T) {
 	t.Parallel()
 
 	attemptCount := 0
-	opener := func(dsn string) (*gorm.DB, error) {
+	opener := func(dsn string) (*sql.DB, error) {
 		attemptCount++
 		return nil, errors.New("connection refused")
 	}
 
-	// Very short timeout - should fail quickly
-	_, err := ConnectWithRetry("test-dsn", 100*time.Millisecond, opener)
-
+	_, err := ConnectSQLWithRetry("test-dsn", 100*time.Millisecond, opener)
 	if err == nil {
 		t.Fatal("expected error after timeout, got nil")
 	}
@@ -287,14 +259,7 @@ func TestConnectWithRetry_TimeoutAfterRetries(t *testing.T) {
 // TestConfig_Validate_TCP_Success は TCP 接続で必須項目が揃っていればエラーにならないことを検証します。
 func TestConfig_Validate_TCP_Success(t *testing.T) {
 	t.Parallel()
-
-	cfg := Config{
-		User:     "u",
-		Password: "p",
-		Name:     "d",
-		Host:     "h",
-		Port:     "5432",
-	}
+	cfg := Config{User: "u", Password: "p", Name: "d", Host: "h", Port: "5432"}
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -303,12 +268,7 @@ func TestConfig_Validate_TCP_Success(t *testing.T) {
 // TestConfig_Validate_CloudSQL_Success は Cloud SQL 接続で Host/Port が空でもエラーにならないことを検証します。
 func TestConfig_Validate_CloudSQL_Success(t *testing.T) {
 	t.Parallel()
-
-	cfg := Config{
-		User:         "u",
-		Name:         "d",
-		InstanceName: "project:region:instance",
-	}
+	cfg := Config{User: "u", Name: "d", InstanceName: "project:region:instance"}
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
@@ -317,21 +277,13 @@ func TestConfig_Validate_CloudSQL_Success(t *testing.T) {
 // TestConfig_Validate_EmptyPasswordAllowed はパスワード未設定でもエラーにならないことを検証します。
 func TestConfig_Validate_EmptyPasswordAllowed(t *testing.T) {
 	t.Parallel()
-
-	cfg := Config{
-		User: "u",
-		Name: "d",
-		Host: "h",
-		Port: "5432",
-	}
+	cfg := Config{User: "u", Name: "d", Host: "h", Port: "5432"}
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("expected no error, got %v", err)
 	}
 }
 
 // TestConfig_Validate_MissingRequired は必須項目が欠けている場合にエラーが返ることを検証します。
-// wantVars: エラーメッセージに含まれるべき変数名
-// notWantVars: エラーメッセージに含まれてはいけない変数名
 func TestConfig_Validate_MissingRequired(t *testing.T) {
 	t.Parallel()
 
@@ -342,10 +294,9 @@ func TestConfig_Validate_MissingRequired(t *testing.T) {
 		notWantVars []string
 	}{
 		{
-			name:        "all empty (TCP)",
-			cfg:         Config{},
-			wantVars:    []string{"DB_USER", "DB_NAME", "DB_HOST", "DB_PORT"},
-			notWantVars: nil,
+			name:     "all empty (TCP)",
+			cfg:      Config{},
+			wantVars: []string{"DB_USER", "DB_NAME", "DB_HOST", "DB_PORT"},
 		},
 		{
 			name:        "missing user",
@@ -397,13 +348,7 @@ func TestConfig_Validate_MissingRequired(t *testing.T) {
 // TestConfig_Validate_WhitespaceOnly は空白文字のみの値が未設定と同じく弾かれることを検証します。
 func TestConfig_Validate_WhitespaceOnly(t *testing.T) {
 	t.Parallel()
-
-	cfg := Config{
-		User: "   ",
-		Name: "\t",
-		Host: "h",
-		Port: "5432",
-	}
+	cfg := Config{User: "   ", Name: "\t", Host: "h", Port: "5432"}
 	err := cfg.Validate()
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -417,8 +362,6 @@ func TestConfig_Validate_WhitespaceOnly(t *testing.T) {
 
 // TestLoadConfigFromEnv は環境変数からデータベース設定が正しく読み込まれることを検証します。
 func TestLoadConfigFromEnv(t *testing.T) {
-	// Note: Not running in parallel since we're modifying environment variables
-	// Set environment variables for the test
 	t.Setenv("DB_USER", "envuser")
 	t.Setenv("DB_PASSWORD", "envpass")
 	t.Setenv("DB_NAME", "envdb")
@@ -427,7 +370,6 @@ func TestLoadConfigFromEnv(t *testing.T) {
 	t.Setenv("INSTANCE_CONNECTION_NAME", "")
 
 	cfg := LoadConfigFromEnv()
-
 	if cfg.User != "envuser" {
 		t.Errorf("expected User 'envuser', got %q", cfg.User)
 	}


### PR DESCRIPTION
全 feature が sqlc + database/sql に移行済みのため、GORM をプロジェクトから完全に取り除く。

## このフェーズの変更
- `internal/platform/db/gorm.go` を削除し、純粋な設定／DSN 構築ロジックは
  `config.go` として再配置（`Password` / `Config` / `LoadConfigFromEnv` / `Validate` / `BuildDSN`）
- `gorm_test.go` を `config_test.go` として書き直し、`ConnectWithRetry` のテストは
  `ConnectSQLWithRetry (*sql.DB)` ベースに移植
- `go.mod` から `gorm.io/gorm`, `gorm.io/driver/postgres`, `gorm.io/driver/sqlite` を除去
- `.golangci.yml` に `no-gorm` depguard ルールを追加し、`gorm.io/*` の再混入を防止

## スタック構造
- Phase 1/6 → 2/6 → 3/6 → 4a/6 → 4b/6 → 4c/6 → 4d/6
- **Phase 5/6** ← ここ (base: `phase4d-watchlist-sqlc`)
- Phase 6/6

## 検証
- `go build ./...` ✅
- `go test ./... -race` ✅
- `golangci-lint run` ✅（`no-gorm` ルール含む）
- `go.mod` から `gorm.io/*` が完全に消えたことを確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01REzVkkcqvaom3jirPH7P7o)_