### PR TITLE
chore: PostgreSQL を 16 から 18 に更新

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
       # GitHub Actions の Ryuk 周辺挙動が不安定なため、サービスコンテナで直接 PostgreSQL を提供する。
       # ユーザーは superuser として作成され CREATEDB 権限を持つので dbtest の CREATE DATABASE が通る。
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_DB: postgres
           POSTGRES_USER: appuser
@@ -118,7 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_DB: app
           POSTGRES_USER: appuser

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@
 # ローカル開発用 compose 定義（本番デプロイは GitHub Actions から Cloud Run に直接デプロイされる）
 services:
   db:
-    image: postgres:16
+    image: postgres:18
     container_name: stock-postgres
     environment:
       POSTGRES_DB: app
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: apppass
       TZ: Asia/Tokyo
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     ports:
       - "5432:5432"
     restart: unless-stopped

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -18,6 +18,15 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| candles_close_not_null | n | NOT NULL close |
+| candles_high_not_null | n | NOT NULL high |
+| candles_id_not_null | n | NOT NULL id |
+| candles_interval_not_null | n | NOT NULL "interval" |
+| candles_low_not_null | n | NOT NULL low |
+| candles_open_not_null | n | NOT NULL open |
+| candles_symbol_code_not_null | n | NOT NULL symbol_code |
+| candles_time_not_null | n | NOT NULL "time" |
+| candles_volume_not_null | n | NOT NULL volume |
 | fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | candles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 

--- a/docs/schema/public.oauth_accounts.md
+++ b/docs/schema/public.oauth_accounts.md
@@ -14,6 +14,11 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| oauth_accounts_created_at_not_null | n | NOT NULL created_at |
+| oauth_accounts_id_not_null | n | NOT NULL id |
+| oauth_accounts_provider_not_null | n | NOT NULL provider |
+| oauth_accounts_provider_uid_not_null | n | NOT NULL provider_uid |
+| oauth_accounts_user_id_not_null | n | NOT NULL user_id |
 | fk_oauth_accounts_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
 | oauth_accounts_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -19,6 +19,14 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| symbols_code_not_null | n | NOT NULL code |
+| symbols_created_at_not_null | n | NOT NULL created_at |
+| symbols_id_not_null | n | NOT NULL id |
+| symbols_is_active_not_null | n | NOT NULL is_active |
+| symbols_market_not_null | n | NOT NULL market |
+| symbols_name_not_null | n | NOT NULL name |
+| symbols_timezone_not_null | n | NOT NULL timezone |
+| symbols_updated_at_not_null | n | NOT NULL updated_at |
 | symbols_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes

--- a/docs/schema/public.users.md
+++ b/docs/schema/public.users.md
@@ -14,6 +14,10 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| users_created_at_not_null | n | NOT NULL created_at |
+| users_email_not_null | n | NOT NULL email |
+| users_id_not_null | n | NOT NULL id |
+| users_updated_at_not_null | n | NOT NULL updated_at |
 | users_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -15,6 +15,12 @@
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
+| watchlists_created_at_not_null | n | NOT NULL created_at |
+| watchlists_id_not_null | n | NOT NULL id |
+| watchlists_sort_key_not_null | n | NOT NULL sort_key |
+| watchlists_symbol_code_not_null | n | NOT NULL symbol_code |
+| watchlists_updated_at_not_null | n | NOT NULL updated_at |
+| watchlists_user_id_not_null | n | NOT NULL user_id |
 | fk_watchlists_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
 | fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -54,6 +54,46 @@
       ],
       "constraints": [
         {
+          "name": "users_created_at_not_null",
+          "type": "n",
+          "def": "NOT NULL created_at",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "created_at"
+          ]
+        },
+        {
+          "name": "users_email_not_null",
+          "type": "n",
+          "def": "NOT NULL email",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "email"
+          ]
+        },
+        {
+          "name": "users_id_not_null",
+          "type": "n",
+          "def": "NOT NULL id",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "users_updated_at_not_null",
+          "type": "n",
+          "def": "NOT NULL updated_at",
+          "table": "public.users",
+          "referenced_table": "",
+          "columns": [
+            "updated_at"
+          ]
+        },
+        {
           "name": "users_pkey",
           "type": "PRIMARY KEY",
           "def": "PRIMARY KEY (id)",
@@ -125,6 +165,56 @@
         }
       ],
       "constraints": [
+        {
+          "name": "oauth_accounts_created_at_not_null",
+          "type": "n",
+          "def": "NOT NULL created_at",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "created_at"
+          ]
+        },
+        {
+          "name": "oauth_accounts_id_not_null",
+          "type": "n",
+          "def": "NOT NULL id",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "oauth_accounts_provider_not_null",
+          "type": "n",
+          "def": "NOT NULL provider",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "provider"
+          ]
+        },
+        {
+          "name": "oauth_accounts_provider_uid_not_null",
+          "type": "n",
+          "def": "NOT NULL provider_uid",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "provider_uid"
+          ]
+        },
+        {
+          "name": "oauth_accounts_user_id_not_null",
+          "type": "n",
+          "def": "NOT NULL user_id",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "user_id"
+          ]
+        },
         {
           "name": "fk_oauth_accounts_user",
           "type": "FOREIGN KEY",
@@ -229,6 +319,86 @@
       ],
       "constraints": [
         {
+          "name": "symbols_code_not_null",
+          "type": "n",
+          "def": "NOT NULL code",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "code"
+          ]
+        },
+        {
+          "name": "symbols_created_at_not_null",
+          "type": "n",
+          "def": "NOT NULL created_at",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "created_at"
+          ]
+        },
+        {
+          "name": "symbols_id_not_null",
+          "type": "n",
+          "def": "NOT NULL id",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "symbols_is_active_not_null",
+          "type": "n",
+          "def": "NOT NULL is_active",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "is_active"
+          ]
+        },
+        {
+          "name": "symbols_market_not_null",
+          "type": "n",
+          "def": "NOT NULL market",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "market"
+          ]
+        },
+        {
+          "name": "symbols_name_not_null",
+          "type": "n",
+          "def": "NOT NULL name",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "name"
+          ]
+        },
+        {
+          "name": "symbols_timezone_not_null",
+          "type": "n",
+          "def": "NOT NULL timezone",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "timezone"
+          ]
+        },
+        {
+          "name": "symbols_updated_at_not_null",
+          "type": "n",
+          "def": "NOT NULL updated_at",
+          "table": "public.symbols",
+          "referenced_table": "",
+          "columns": [
+            "updated_at"
+          ]
+        },
+        {
           "name": "symbols_pkey",
           "type": "PRIMARY KEY",
           "def": "PRIMARY KEY (id)",
@@ -313,6 +483,96 @@
         }
       ],
       "constraints": [
+        {
+          "name": "candles_close_not_null",
+          "type": "n",
+          "def": "NOT NULL close",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "close"
+          ]
+        },
+        {
+          "name": "candles_high_not_null",
+          "type": "n",
+          "def": "NOT NULL high",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "high"
+          ]
+        },
+        {
+          "name": "candles_id_not_null",
+          "type": "n",
+          "def": "NOT NULL id",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "candles_interval_not_null",
+          "type": "n",
+          "def": "NOT NULL \"interval\"",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "interval"
+          ]
+        },
+        {
+          "name": "candles_low_not_null",
+          "type": "n",
+          "def": "NOT NULL low",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "low"
+          ]
+        },
+        {
+          "name": "candles_open_not_null",
+          "type": "n",
+          "def": "NOT NULL open",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "open"
+          ]
+        },
+        {
+          "name": "candles_symbol_code_not_null",
+          "type": "n",
+          "def": "NOT NULL symbol_code",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "symbol_code"
+          ]
+        },
+        {
+          "name": "candles_time_not_null",
+          "type": "n",
+          "def": "NOT NULL \"time\"",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "time"
+          ]
+        },
+        {
+          "name": "candles_volume_not_null",
+          "type": "n",
+          "def": "NOT NULL volume",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "volume"
+          ]
+        },
         {
           "name": "fk_candles_symbol",
           "type": "FOREIGN KEY",
@@ -415,6 +675,66 @@
       ],
       "constraints": [
         {
+          "name": "watchlists_created_at_not_null",
+          "type": "n",
+          "def": "NOT NULL created_at",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "created_at"
+          ]
+        },
+        {
+          "name": "watchlists_id_not_null",
+          "type": "n",
+          "def": "NOT NULL id",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
+          "name": "watchlists_sort_key_not_null",
+          "type": "n",
+          "def": "NOT NULL sort_key",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "sort_key"
+          ]
+        },
+        {
+          "name": "watchlists_symbol_code_not_null",
+          "type": "n",
+          "def": "NOT NULL symbol_code",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "symbol_code"
+          ]
+        },
+        {
+          "name": "watchlists_updated_at_not_null",
+          "type": "n",
+          "def": "NOT NULL updated_at",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "updated_at"
+          ]
+        },
+        {
+          "name": "watchlists_user_id_not_null",
+          "type": "n",
+          "def": "NOT NULL user_id",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "user_id"
+          ]
+        },
+        {
           "name": "fk_watchlists_user",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE",
@@ -509,7 +829,7 @@
   ],
   "driver": {
     "name": "postgres",
-    "database_version": "PostgreSQL 16.13 (Ubuntu 16.13-0ubuntu0.24.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 13.3.0-6ubuntu2~24.04.1) 13.3.0, 64-bit",
+    "database_version": "PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1) on aarch64-unknown-linux-gnu, compiled by gcc (Debian 14.2.0-19) 14.2.0, 64-bit",
     "meta": {
       "current_schema": "public",
       "search_paths": [

--- a/internal/platform/db/dbtest/dbtest.go
+++ b/internal/platform/db/dbtest/dbtest.go
@@ -120,7 +120,7 @@ func setup(ctx context.Context) error {
 	}
 
 	pgC, err := tcpostgres.Run(ctx,
-		"postgres:16-alpine",
+		"postgres:18-alpine",
 		tcpostgres.WithDatabase("postgres"),
 		tcpostgres.WithUsername("appuser"),
 		tcpostgres.WithPassword("apppass"),


### PR DESCRIPTION
## 概要
開発・CI・テスト環境で使用する PostgreSQL を 16 から 18 に更新する。PG18 ではデータディレクトリの仕様が変更されたため、ローカル compose のボリュームマウント先も合わせて変更する。

## 変更内容
- docker-compose / CI（build-test・schema-doc-check）/ testcontainers のイメージを `postgres:18` に更新
- PG18 のデータディレクトリ仕様変更に合わせ、ローカル DB のボリュームマウント先を `/var/lib/postgresql/data` → `/var/lib/postgresql` に変更
- `tbls doc` を再生成し、スキーマドキュメント（docs/schema/）を更新
  - `database_version` が 18.4 に更新
  - PG18 では NOT NULL 制約が名前付き制約としてカタログ管理されるようになったため、各テーブル定義書に NOT NULL 制約が表示されるようになった（スキーマ構造自体に変更はない）

## 破壊的変更
- ローカル開発環境では PG16 のデータボリュームと互換性がないため、既存の `stock_postgres_data` ボリュームを削除して作り直す必要がある（取り込み済みの株価データはローカルのみで再取得可能）
- 本番（Cloud SQL）の PostgreSQL バージョンアップは本PRの対象外。別途マネージドサービス側での対応が必要

## テスト
- ローカルで PG18 を起動し、`cmd/migrate` でマイグレーションが正常適用されることを確認
- `tbls doc` 再生成後、全テーブルが正しく生成されることを確認
- CI（build-test / schema-doc-check）が postgres:18 で通ることを確認