### PR TITLE
chore: backend 起動時に migrate・seed・swagger-ui を自動起動

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ API仕様は `api/openapi.yaml`（OpenAPI 3.0.3）で管理しています。
 
 ### 仕様の確認（Swagger UI）
 
-開発環境の起動時に Swagger UI も自動で立ち上がります：
+`backend` の起動時に Swagger UI も依存として自動で立ち上がります：
 
 ```bash
-docker compose -f docker/docker-compose.yml -p stock up backend swagger-ui
+docker compose -f docker/docker-compose.yml -p stock up backend
 ```
 
 ブラウザで http://localhost:8081 を開くとAPI仕様を確認できます。
@@ -351,9 +351,15 @@ GOOGLE_CLOUD_LOCATION=asia-northeast1
 
 ### APIサーバーの起動
 
+`backend` を起動すると、依存として `migrate`（マイグレーション適用）→ `seed`（初期データ投入）が
+順に実行され、`swagger-ui`（http://localhost:8081 ）も並行起動します。
+
 ```bash
 docker compose -f docker/docker-compose.yml -p stock up backend
 ```
+
+`seed.sql` は冪等（`INSERT ... ON CONFLICT` による upsert のみ）なので、再起動のたびに
+再実行されても既存の candles / watchlists 等は削除されません。
 
 ### バッチプロセスの起動（株式データ取り込み）
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -50,6 +50,12 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+      seed:
+        condition: service_completed_successfully
+      swagger-ui:
+        condition: service_started
     ports:
       - "8080:8080"
     restart: unless-stopped
@@ -79,7 +85,8 @@ services:
         condition: service_healthy
 
   # マイグレーション専用バイナリ。本番では同 Dockerfile を Cloud Run Job 等にデプロイ。
-  # ローカル: docker compose -f docker/docker-compose.yml -p stock run --rm migrate [up|status|down|...]
+  # backend 起動時に依存として自動実行される。
+  # 個別実行: docker compose -f docker/docker-compose.yml -p stock run --rm migrate [up|status|down|...]
   migrate:
     build:
       context: ..
@@ -87,10 +94,29 @@ services:
     env_file:
       - ./.env.app
     restart: "no"
-    profiles: ["on-demand"]
     depends_on:
       db:
         condition: service_healthy
+
+  # 初期データ投入（symbols の upsert）。migrate 完了後に seed.sql を流す。
+  # seed.sql は冪等なので起動のたびに再実行されても既存データを消さない。
+  seed:
+    image: postgres:18
+    container_name: stock-seed
+    env_file:
+      - ./.env.app
+    volumes:
+      - ./postgres/seed.sql:/seed.sql:ro
+    command:
+      - sh
+      - -c
+      - 'PGPASSWORD="$$DB_PASSWORD" psql -h "$$DB_HOST" -p "$$DB_PORT" -U "$$DB_USER" -d "$$DB_NAME" -v ON_ERROR_STOP=1 -f /seed.sql'
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
 
   swagger-ui:
     image: swaggerapi/swagger-ui

--- a/docker/postgres/seed.sql
+++ b/docker/postgres/seed.sql
@@ -1,7 +1,5 @@
--- 警告: このスクリプトは symbols を参照する全テーブル（candles, watchlists 等）を CASCADE で全削除します。
--- ローカル開発環境専用です。本番・staging 環境では絶対に実行しないでください。
-TRUNCATE TABLE symbols CASCADE;
-
+-- symbols の初期データ投入。INSERT ... ON CONFLICT による upsert のみで冪等。
+-- candles / watchlists 等の既存データは削除しないため、起動のたびに安全に再実行できる。
 INSERT INTO symbols (code, name, market, timezone, created_at, updated_at) VALUES
 -- 時価総額上位（メガキャップ）
 ('NVDA', 'NVIDIA Corp', 'NASDAQ', 'America/New_York', NOW(), NOW()),


### PR DESCRIPTION
## 概要
ローカル開発の DX 向上のため、`docker compose up backend` 一発で DB マイグレーション・初期データ投入・Swagger UI までまとめて立ち上がるよう compose の依存関係を再構成しました。

## 変更内容
- `backend` の `depends_on` に `migrate`（完了待ち）・`seed`（完了待ち）・`swagger-ui`（起動）を追加し、`db → migrate → seed → backend` の順で自動起動するようにした
- `migrate` から `on-demand` プロファイルを外し、依存として自動実行されるようにした（`run --rm migrate <cmd>` での個別実行は従来どおり可能）
- `seed` サービスを新規追加し、migrate 完了後に `postgres:18` の psql で `seed.sql` を投入
- `seed.sql` から `TRUNCATE TABLE symbols CASCADE` を削除し、`INSERT ... ON CONFLICT` による upsert のみの冪等な内容に変更（起動のたびに再実行しても既存の candles / watchlists を消さない）
- README の起動手順を更新

## テスト
- `docker compose -f docker/docker-compose.yml -p stock config` で構文を検証
- 手動確認手順:
  - `docker compose -f docker/docker-compose.yml -p stock up backend` で db → migrate(exit 0) → seed(exit 0) → backend の順に起動すること
  - http://localhost:8081 で Swagger UI、http://localhost:8080/healthz で 200 が返ること
  - `SELECT count(*) FROM symbols;` で初期データが投入されていること
  - 再起動しても既存データが削除されないこと（冪等性）

## レビューポイント
- 本変更はローカルの `docker-compose.yml` と `seed.sql` のみが対象で、CI・本番（Cloud Run, Dockerfile.migrate）には影響しません
- `seed.sql` の `TRUNCATE` 削除に伴い、`scripts/seed.sh` も「全削除→投入」から「upsert のみ」に挙動が変わります