### PR TITLE
chore: OpenAPI仕様のバージョンを3.0.4に更新

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: "3.0.3"
+openapi: "3.0.4"
 info:
   title: Stock Backend API
   description: 株価データを提供するREST API


### PR DESCRIPTION
## 概要

OpenAPI 仕様自体のバージョンを `3.0.3` から `3.0.4`（3.0系の最新パッチ）に更新しました。

## 変更内容

- `api/openapi.yaml` の `openapi` フィールドを `"3.0.3"` → `"3.0.4"` に変更

## 補足

当初は OpenAPI 3.1.1 への移行を検討しましたが、コード生成に使用している `oapi-codegen` v2.5.1 が 3.1 系に未対応（[oapi-codegen#373](https://github.com/oapi-codegen/oapi-codegen/issues/373)）のため、型生成が失敗します。そのため 3.0 系の最新パッチである 3.0.4 に留めています。

将来 oapi-codegen が 3.1 に対応するか、ogen 等の別ツールへ切り替えれば 3.1 への移行が可能です。

## 確認事項

- `go generate ./internal/api/...` で型再生成 → `types.gen.go` に差分なし
- `go build ./...` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)