### PR TITLE
chore: Go のバージョンを 1.26.3 に更新

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.6.2
+          version: v2.12.2
           args: --timeout=5m
 
   # ビルド確認とテスト実行

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v8
@@ -100,7 +100,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Run build
         run: go build ./...
@@ -137,7 +137,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.25.x"
+          go-version: "1.26.x"
 
       - name: Run migrations
         env:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 
 | カテゴリ        | 技術                                                                |
 | --------------- | ------------------------------------------------------------------- |
-| 言語            | Go (1.25.8)                                                          |
+| 言語            | Go (1.26.3)                                                          |
 | Webフレームワーク | Gin                                                                 |
 | DB アクセス     | sqlc + database/sql + pgx/v5 stdlib                                 |
 | DB マイグレーション | goose（埋め込み SQL ベース）                                      |
@@ -57,7 +57,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 | キャッシュ      | Redis                                                               |
 | AI / ML         | Cloud Vision API / Gemini API（Vertex AI）                          |
 | 認証・セキュリティ | JWT / bcrypt / CSRF（Double Submit Cookie）/ レートリミット       |
-| API仕様         | OpenAPI 3.0.3 / oapi-codegen（型生成）                              |
+| API仕様         | OpenAPI 3.0.4 / oapi-codegen（型生成）                              |
 | 設定管理        | **docker/.env.app（ローカル）/ Secret Manager（本番）+ os.Getenv()**|
 | コンテナ        | Docker / Docker Compose                                             |
 | クラウド        | Google Cloud Run / Cloud SQL / Secret Manager / Artifact Registry   |
@@ -68,7 +68,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 ```text
 .
 ├── api/
-│   ├── openapi.yaml            # OpenAPI 3.0.3 仕様（APIコントラクトの単一ソース）
+│   ├── openapi.yaml            # OpenAPI 3.0.4 仕様（APIコントラクトの単一ソース）
 │   └── oapi-codegen.cfg.yaml   # oapi-codegen設定（型のみ生成）
 │
 ├── cmd/
@@ -161,7 +161,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 
 ## API仕様（OpenAPI）
 
-API仕様は `api/openapi.yaml`（OpenAPI 3.0.3）で管理しています。
+API仕様は `api/openapi.yaml`（OpenAPI 3.0.4）で管理しています。
 この仕様ファイルから [oapi-codegen](https://github.com/oapi-codegen/oapi-codegen) を使って Go の型定義を自動生成しています。
 
 ### 仕様の確認（Swagger UI）

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/docker/Dockerfile.api.dev
+++ b/docker/Dockerfile.api.dev
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine
+FROM golang:1.26.3-alpine
 
 WORKDIR /app
 

--- a/docker/Dockerfile.batch
+++ b/docker/Dockerfile.batch
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docker/Dockerfile.migrate
+++ b/docker/Dockerfile.migrate
@@ -1,4 +1,4 @@
-FROM golang:1.25.8-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module stock_backend
 
-go 1.25.8
+go 1.26.3
 
 require (
 	cloud.google.com/go/vision/v2 v2.9.6


### PR DESCRIPTION
## 概要
プロジェクトの Go バージョンを 1.25.8 から 1.26.3 に更新します。ローカル開発環境がすでに 1.26.3 に更新済みのため、リポジトリ側のバージョン指定を揃えます。

## 変更内容
- `go.mod` の `go` ディレクティブを `1.26.3` に更新
- 各 Dockerfile（api / api.dev / batch / migrate）のベースイメージを `golang:1.26.3-alpine` に更新
- CI（`.github/workflows/ci.yaml`）の `setup-go` の `go-version` を `1.26.x` に更新
- README の Go 表記を `1.26.3` に更新し、あわせて OpenAPI 表記を `3.0.4` に同期（PR #183 でフォーマット版が更新済みだったが README が `3.0.3` のままだったため）

## テスト
- `go build ./...` が成功することを確認
- `go mod verify` が成功することを確認
- `go test ./...` を実行（DB を使わないテストは全て成功。testcontainers を使う一部 `adapters` テストはローカル環境固有の問題で失敗するが、これはバージョン変更前の HEAD でも再現する既存事象であり本変更とは無関係。CI は `TEST_DB_DSN` でホスト PostgreSQL を使うため影響なし）

## レビューポイント
- バージョン文字列の差し替えのみで、コードのロジック変更は含みません