### PR TITLE
fix: dbtest の testcontainers 起動で待機戦略を明示的に指定

### DIFF
--- a/internal/platform/db/dbtest/dbtest.go
+++ b/internal/platform/db/dbtest/dbtest.go
@@ -36,6 +36,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
 
 	infradb "stock_backend/internal/platform/db"
 )
@@ -124,7 +125,13 @@ func setup(ctx context.Context) error {
 		tcpostgres.WithDatabase("postgres"),
 		tcpostgres.WithUsername("appuser"),
 		tcpostgres.WithPassword("apppass"),
-		testcontainers.WithWaitStrategyAndDeadline(60*time.Second),
+		// WithWaitStrategyAndDeadline は postgres モジュールのデフォルト待機戦略を
+		// 上書きするため、戦略を省略するとデフォルトが消えて
+		// "no wait strategy supplied" で起動に失敗する。
+		// デフォルトと同等（"ready to accept connections" を 2 回待つ）の戦略を明示的に渡す。
+		testcontainers.WithWaitStrategyAndDeadline(60*time.Second,
+			wait.ForLog("database system is ready to accept connections").WithOccurrence(2),
+		),
 	)
 	if err != nil {
 		return fmt.Errorf("dbtest: start postgres container: %w", err)


### PR DESCRIPTION
## 概要
ローカルで testcontainers 経由（`TEST_DB_DSN` 未設定）にリポジトリ層テストを実行すると、PostgreSQL コンテナの起動時に `no wait strategy supplied` で失敗していた問題を修正します。

## 変更内容
- `internal/platform/db/dbtest/dbtest.go` の `tcpostgres.Run` で、`WithWaitStrategyAndDeadline` に待機戦略を明示的に渡すよう修正
  - postgres モジュールのデフォルトと同等の `wait.ForLog("database system is ready to accept connections").WithOccurrence(2)` を指定

## 背景
`WithWaitStrategyAndDeadline(deadline, strategies...)` は既存（postgres モジュールのデフォルト）の待機戦略を**置き換える**仕様。これまでは `strategies` を渡しておらず、`wait.ForAll()` が空になり、postgres モジュールが本来設定するデフォルト待機戦略まで消えていたため、コンテナ起動時に `no wait strategy supplied` で落ちていた。

CI は `TEST_DB_DSN` でホストの PostgreSQL を使う分岐に入りこの経路を通らないため、CI では顕在化していなかった。

## テスト
- `TEST_DB_DSN` 未設定（testcontainers 経路）で `go test ./...` を実行し、これまで落ちていた auth / candles / symbollist / watchlist の各 adapters テストを含め全て pass（FAIL 0件）を確認