### PR TITLE
fix: migrate の logger 初期化を main に移動

### DIFF
--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -37,13 +37,13 @@ var allowedCommands = map[string]struct{}{
 }
 
 func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	slog.SetDefault(logger)
+
 	os.Exit(run(os.Args[1:]))
 }
 
 func run(args []string) int {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	slog.SetDefault(logger)
-
 	cmd := "up"
 	var extra []string
 	if len(args) > 0 {

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 )
 
@@ -24,6 +26,23 @@ func TestRun_RejectsUnsupportedCommand(t *testing.T) {
 				t.Errorf("run(%v) = %d, want 2", tt.args, got)
 			}
 		})
+	}
+}
+
+func TestRun_DoesNotChangeDefaultLogger(t *testing.T) {
+	original := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(original)
+	})
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	slog.SetDefault(logger)
+
+	if got := run([]string{"no-such"}); got != 2 {
+		t.Fatalf("run() = %d, want 2", got)
+	}
+	if got := slog.Default(); got != logger {
+		t.Errorf("slog.Default() = %p, want %p", got, logger)
 	}
 }
 


### PR DESCRIPTION
## 概要
`cmd/migrate` の `run()` がプロセス全体の default logger を書き換えていたため、logger 初期化を `main()` に移動しました。
これにより、`run()` を直接呼び出すテストが同じテストプロセス内の他テストへ影響しなくなります。

## 変更内容
- `slog.New` / `slog.SetDefault` を `cmd/migrate/main.go` の `main()` に移動
- `run()` が default logger を変更しないことを確認する回帰テストを追加

## 関連issue
- closes #177

## テスト
- `GOCACHE=/private/tmp/stock-backend-go-build go test ./cmd/migrate`
- `GOCACHE=/private/tmp/stock-backend-go-build go test -race ./cmd/migrate`
- `git diff --check`