### PR TITLE
refactor: OpenSQL の終了処理を呼び出し元へ移動

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -170,7 +170,11 @@ func run() int {
 	}
 
 	// データベース接続。スキーマ適用は cmd/migrate バイナリ（goose）で別途実施する。
-	sqlDB := infradb.OpenSQL()
+	sqlDB, err := infradb.OpenSQL()
+	if err != nil {
+		slog.Error("DB open failed", "error", err)
+		return 1
+	}
 	defer func() {
 		if err := sqlDB.Close(); err != nil {
 			slog.Warn("failed to close sqlDB", "error", err)

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -81,6 +81,17 @@ func TestLoadServerConfig(t *testing.T) {
 	})
 }
 
+func TestRun_ReturnsOneWhenDBConfigInvalid(t *testing.T) {
+	clearEnv(t)
+	t.Setenv(jwtmw.EnvKeyJWTSecret, "secret")
+	t.Setenv(authusecase.EnvKeyPasswordPepper, "pepper")
+	t.Setenv("DB_USER", "")
+
+	if got := run(); got != 1 {
+		t.Errorf("run() = %d, want 1", got)
+	}
+}
+
 func TestLoadOAuthConfig(t *testing.T) {
 	t.Run("プロバイダ未設定は無効(nil)", func(t *testing.T) {
 		clearEnv(t)

--- a/cmd/batch/main.go
+++ b/cmd/batch/main.go
@@ -83,7 +83,11 @@ func run(args []string) int {
 
 // runCandleIngest は TwelveData から株価データを取り込み、終了コード（0 or 1）を返す。
 func runCandleIngest() int {
-	sqlDB := db.OpenSQL()
+	sqlDB, err := db.OpenSQL()
+	if err != nil {
+		slog.Error("DB open failed", "error", err)
+		return 1
+	}
 	defer func() {
 		if err := sqlDB.Close(); err != nil {
 			slog.Warn("failed to close sqlDB", "error", err)
@@ -148,7 +152,11 @@ func runCandleIngest() int {
 
 // runLogoIngest は TwelveData からロゴURLを取り込み、終了コード（0 or 1）を返す。
 func runLogoIngest() int {
-	sqlDB := db.OpenSQL()
+	sqlDB, err := db.OpenSQL()
+	if err != nil {
+		slog.Error("DB open failed", "error", err)
+		return 1
+	}
 	defer func() {
 		if err := sqlDB.Close(); err != nil {
 			slog.Warn("failed to close sqlDB", "error", err)

--- a/cmd/batch/main_test.go
+++ b/cmd/batch/main_test.go
@@ -114,3 +114,15 @@ func TestRunInvalidJobID(t *testing.T) {
 		})
 	}
 }
+
+func TestRun_ReturnsOneWhenDBConfigInvalid(t *testing.T) {
+	t.Setenv("DB_USER", "")
+
+	for _, jobID := range []string{"candles", "logo"} {
+		t.Run(jobID, func(t *testing.T) {
+			if got := run([]string{jobID}); got != 1 {
+				t.Errorf("run(%q) = %d, want 1", jobID, got)
+			}
+		})
+	}
+}

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -55,7 +55,11 @@ func run(args []string) int {
 		return 2
 	}
 
-	db := infradb.OpenSQL()
+	db, err := infradb.OpenSQL()
+	if err != nil {
+		slog.Error("DB open failed", "error", err)
+		return 1
+	}
 	defer func() {
 		if err := db.Close(); err != nil {
 			slog.Warn("failed to close DB", "error", err)

--- a/cmd/migrate/main_test.go
+++ b/cmd/migrate/main_test.go
@@ -54,3 +54,11 @@ func TestAllowedCommands_ContainsExpectedSet(t *testing.T) {
 		}
 	}
 }
+
+func TestRun_ReturnsOneWhenDBConfigInvalid(t *testing.T) {
+	t.Setenv("DB_USER", "")
+
+	if got := run(nil); got != 1 {
+		t.Errorf("run(nil) = %d, want 1", got)
+	}
+}

--- a/internal/platform/db/sql.go
+++ b/internal/platform/db/sql.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
-	"os"
 	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx" の登録
@@ -47,12 +46,17 @@ func ConnectSQLWithRetry(dsn string, timeout time.Duration, opener SQLOpener) (*
 }
 
 // OpenSQL は環境変数から設定を読み取り *sql.DB を返します。
-// リトライロジックを含み、失敗時は os.Exit します（本番環境用）。
-func OpenSQL() *sql.DB {
+// リトライロジックを含み、設定不正や接続失敗は呼び出し元へ返します。
+func OpenSQL() (*sql.DB, error) {
+	return openSQLWithRetry(60*time.Second, DefaultSQLOpener)
+}
+
+// openSQLWithRetry は OpenSQL の設定読み込みと接続処理を実行します。
+// timeout と opener を受け取り、異常系を短時間でテストできるようにします。
+func openSQLWithRetry(timeout time.Duration, opener SQLOpener) (*sql.DB, error) {
 	cfg := LoadConfigFromEnv()
 	if err := cfg.Validate(); err != nil {
-		slog.Error("invalid DB config", "error", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("invalid DB config: %w", err)
 	}
 	if cfg.InstanceName != "" && (cfg.Host != "" || cfg.Port != "") {
 		slog.Warn("DB_HOST and DB_PORT are ignored when INSTANCE_CONNECTION_NAME is set",
@@ -60,10 +64,5 @@ func OpenSQL() *sql.DB {
 	}
 	dsn := BuildDSN(cfg)
 
-	db, err := ConnectSQLWithRetry(dsn, 60*time.Second, DefaultSQLOpener)
-	if err != nil {
-		slog.Error("DB connect failed", "error", err)
-		os.Exit(1)
-	}
-	return db
+	return ConnectSQLWithRetry(dsn, timeout, opener)
 }

--- a/internal/platform/db/sql_test.go
+++ b/internal/platform/db/sql_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"database/sql"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -89,5 +90,44 @@ func TestConnectSQLWithRetry_ErrorWrapped(t *testing.T) {
 	}
 	if !errors.Is(err, sentinel) {
 		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+}
+
+func TestOpenSQL_InvalidConfig(t *testing.T) {
+	t.Setenv("DB_USER", "")
+
+	_, err := OpenSQL()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid DB config") {
+		t.Errorf("expected invalid config error, got %v", err)
+	}
+}
+
+func TestOpenSQLWithRetry_ConnectionFailure(t *testing.T) {
+	t.Setenv("DB_USER", "appuser")
+	t.Setenv("DB_PASSWORD", "apppass")
+	t.Setenv("DB_NAME", "app")
+	t.Setenv("DB_HOST", "localhost")
+	t.Setenv("DB_PORT", "5432")
+	t.Setenv("INSTANCE_CONNECTION_NAME", "")
+
+	sentinel := errors.New("connection refused")
+	calls := 0
+	opener := func(dsn string) (*sql.DB, error) {
+		calls++
+		return nil, sentinel
+	}
+
+	_, err := openSQLWithRetry(0, opener)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected wrapped sentinel error, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 attempt, got %d", calls)
 	}
 }


### PR DESCRIPTION
## 概要
`internal/platform/db.OpenSQL` が直接 `os.Exit(1)` を呼んでいたため、設定不正や接続失敗を呼び出し元で扱えませんでした。
`OpenSQL` を `(*sql.DB, error)` 返却へ変更し、プロセス終了の判断を各バイナリへ移します。

## 変更内容
- `OpenSQL` から `os.Exit` を撤廃し、設定不正と接続失敗をエラーとして返却
- テスト用に timeout と opener を注入できる内部ヘルパーを追加
- `cmd/api`、`cmd/migrate`、`cmd/batch` で DB オープン失敗をログ出力し、終了コード `1` に変換
- 設定不正、接続失敗、各バイナリの異常系テストを追加

## 破壊的変更
- `internal/platform/db.OpenSQL` のシグネチャを `func OpenSQL() *sql.DB` から `func OpenSQL() (*sql.DB, error)` へ変更
- リポジトリ内の既存呼び出し元はすべて更新済み

## 関連issue
- closes #176

## テスト
- `go test ./... -race -cover -count=1`
- `go build ./...`
- `golangci-lint run --timeout=5m`
- `git diff --check`

## レビューポイント
- DB 接続失敗時の責務が platform 層から各エントリーポイントへ適切に移っているか
- `cmd/batch` の candles / logo 両ジョブが同じ失敗処理になっているか