### PR TITLE
docs: tbls 生成手順の README を現行 compose 構成に合わせて更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,9 +381,9 @@ docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --r
 `db/migrations/` 配下のスキーマを変更したときは以下の手順で再生成します。
 
 ```bash
-# 1) dev コンテナを起動 + マイグレーションを適用
-docker compose -f docker/docker-compose.yml -p stock up -d db
-docker compose -f docker/docker-compose.yml -p stock run --rm migrate
+# 1) backend を起動（依存する db / migrate / seed が順に立ち上がり、最新スキーマが適用される）
+#    フォアグラウンドで起動し続けるので、手順 2)・3) は別ターミナルで実行する
+docker compose -f docker/docker-compose.yml -p stock up backend
 
 # 2) ER 図・テーブル定義書を再生成（docs/schema/ を上書き）
 docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --rm tbls doc --config /work/docs/tbls.yml --force
@@ -392,10 +392,10 @@ docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --r
 docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --rm tbls diff --config /work/docs/tbls.yml
 ```
 
-GCP 認証情報を持たない環境などで `backend` の起動が難しい場合は、手順 1) を以下の軽量バイナリ (`cmd/migrate`) に置き換えられます。
+`backend` は `.env.app` や GCP ADC 等の環境が必要です。認証情報を持たない環境では、手順 1) を以下の軽量バイナリ (`cmd/migrate`) に置き換えられます（引数なしで `up` が適用されます）。
 
 ```bash
-# 1') db だけ起動して cmd/migrate でスキーマを反映（GCP 認証不要）
+# 1') db だけ起動してローカルの cmd/migrate でスキーマを反映（GCP 認証不要）
 docker compose -f docker/docker-compose.yml -p stock up -d db
 DB_HOST=localhost DB_PORT=5432 DB_USER=appuser DB_PASSWORD=apppass DB_NAME=app \
   go run ./cmd/migrate


### PR DESCRIPTION
## 概要

README の「ER 図・テーブル定義書の生成（tbls）」手順が、現行の docker-compose 構成と食い違っていたため更新しました。

## 背景

- コミット `d14fba1` で GCP 認証不要の専用 `migrate` サービス（`docker/Dockerfile.migrate` = `cmd/migrate` のみ）が追加され、`backend` は `depends_on` で `migrate`（完了待ち）・`seed` を起動するようになった。
- それ以前の名残で、README には「`backend` の起動が難しい場合は…」という旧前提の説明が残っていた。

## 変更内容

- 手順 1) を `up -d db` + `run --rm migrate` から `docker compose ... up backend` に変更（`-d` なし）。backend の依存で db → migrate → seed が自動実行され、スキーマが適用される。フォアグラウンド起動で専有するため、手順 2)・3) は別ターミナルで実行する旨を明記。
- `backend` は `.env.app` / GCP ADC 等が必要なため、手順 1')（`cmd/migrate` をローカル実行）を「認証情報を持たない環境向けの軽量手順」として位置づけ直した。

ドキュメントのみの変更で、コード・compose 設定の変更はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)