### PR TITLE
refactor: logo バッチサービスを candles と同じ dev スタイルに統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps candles
 ### バッチプロセスの起動（ロゴURL取得）
 
 ```bash
-docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --rm logo
+docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps logo
 ```
 
 ### ER 図・テーブル定義書の生成（tbls）

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -84,6 +84,22 @@ services:
       redis:
         condition: service_healthy
 
+  logo:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api.dev
+    env_file:
+      - ./.env.app
+    volumes:
+      - ..:/app
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+    command: ["go", "run", "./cmd/batch", "logo"]
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+
   # マイグレーション専用バイナリ。本番では同 Dockerfile を Cloud Run Job 等にデプロイ。
   # backend 起動時に依存として自動実行される。
   # 個別実行: docker compose -f docker/docker-compose.yml -p stock run --rm migrate [up|status|down|...]
@@ -128,18 +144,6 @@ services:
     volumes:
       - ../api/openapi.yaml:/app/openapi.yaml:ro
     restart: unless-stopped
-
-  logo:
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile.batch
-    image: stock-logo
-    container_name: stock-logo
-    env_file:
-      - ./.env.app
-    command: ["logo"]
-    restart: "no"
-    profiles: ["on-demand"]
 
   tbls:
     # CI の k1LoW/setup-tbls がインストールするバージョンと揃えること


### PR DESCRIPTION
## 概要
docker-compose の `candles` と `logo` で定義スタイル・起動コマンドが食い違っていたため、`logo` を `candles` と同じ dev スタイルに揃え、ローカル起動コマンドを統一しました。

## 変更内容
- `logo` サービスを dev スタイルに変更（`Dockerfile.api.dev` + ソースマウント + `go run ./cmd/batch logo`）
- `image` / `container_name` / `profiles: ["on-demand"]` を削除し、`depends_on` を `db` のみに（logo は redis 不使用）
- compose 内の定義順を `candles` の直下へ移動
- README のロゴ取得コマンドを `run --rm --no-deps logo` に統一（candles と同じ書式）

## 補足
- 本番 Cloud Run ビルドが使う `docker/Dockerfile.batch` と cd-batch.yaml は変更なし（compose からの参照のみ解消）
- profile を外したことで `docker compose up`（引数なし）の起動対象に `logo` も入る（`candles` と同じ挙動）

## テスト
- `docker compose config --services` で `logo` が profile なしで列挙されることを確認
- 旧設定（`stock-logo` / `Dockerfile.batch` / logo の profiles）の残存なしを grep で確認