### PR TITLE
refactor: テストモック名をインターフェース名ミラーに統一

### DIFF
--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -19,14 +19,14 @@ import (
 	"stock_backend/internal/platform/httpratelimit"
 )
 
-// mockAuthUsecase はUsecaseインターフェースのモック実装です。
-type mockAuthUsecase struct {
+// mockUsecase はUsecaseインターフェースのモック実装です。
+type mockUsecase struct {
 	SignupFunc func(ctx context.Context, email, password string) (int64, error)
 	LoginFunc  func(ctx context.Context, email, password string) (string, error)
 }
 
 // Signup はSignupメソッドのモック実装です。
-func (m *mockAuthUsecase) Signup(ctx context.Context, email, password string) (int64, error) {
+func (m *mockUsecase) Signup(ctx context.Context, email, password string) (int64, error) {
 	if m.SignupFunc != nil {
 		return m.SignupFunc(ctx, email, password)
 	}
@@ -34,7 +34,7 @@ func (m *mockAuthUsecase) Signup(ctx context.Context, email, password string) (i
 }
 
 // Login はLoginメソッドのモック実装です。
-func (m *mockAuthUsecase) Login(ctx context.Context, email, password string) (string, error) {
+func (m *mockUsecase) Login(ctx context.Context, email, password string) (string, error) {
 	if m.LoginFunc != nil {
 		return m.LoginFunc(ctx, email, password)
 	}
@@ -159,7 +159,7 @@ func TestAuthHandler_Signup(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockAuthUsecase{SignupFunc: tt.mockSignupFunc}
+			mockUC := &mockUsecase{SignupFunc: tt.mockSignupFunc}
 			h := authhttp.NewHandler(mockUC, nil, false)
 
 			router := gin.New()
@@ -187,7 +187,7 @@ func TestAuthHandler_Login_RateLimited(t *testing.T) {
 
 	limiter := httpratelimit.NewLimiter(rdb)
 	loginCalled := false
-	mockUC := &mockAuthUsecase{
+	mockUC := &mockUsecase{
 		LoginFunc: func(ctx context.Context, email, password string) (string, error) {
 			loginCalled = true
 			return "", errors.New("should not be called")
@@ -284,7 +284,7 @@ func TestAuthHandler_Login(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockAuthUsecase{LoginFunc: tt.mockLoginFunc}
+			mockUC := &mockUsecase{LoginFunc: tt.mockLoginFunc}
 			h := authhttp.NewHandler(mockUC, nil, tt.secureCookie)
 
 			router := gin.New()
@@ -315,7 +315,7 @@ func TestAuthHandler_Logout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			h := authhttp.NewHandler(&mockAuthUsecase{}, nil, tt.secureCookie)
+			h := authhttp.NewHandler(&mockUsecase{}, nil, tt.secureCookie)
 
 			router := gin.New()
 			router.DELETE("/logout", h.Logout)

--- a/internal/feature/candles/caching_repository.go
+++ b/internal/feature/candles/caching_repository.go
@@ -19,16 +19,16 @@ const maxCacheOutputSize = 5000
 // この値はフォールバックとしてのみ機能する。
 const DefaultCacheTTL = 7 * 24 * time.Hour
 
-// repository はCachingRepositoryが内部で必要とする読み書きインターフェースです。
-type repository interface {
-	Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error)
-	UpsertBatch(ctx context.Context, candles []Candle) error
+// readWriteRepository はCachingRepositoryが内部で必要とする読み書きインターフェースです。
+type readWriteRepository interface {
+	Repository      // usecase.go（Find）
+	WriteRepository // ingest.go（UpsertBatch）
 }
 
 // CachingRepository はRepositoryにRedisキャッシュをデコレータパターンで追加します。
 // 基盤となるリポジトリを変更せずに、透過的にキャッシュを追加します。
 type CachingRepository struct {
-	inner     repository
+	inner     readWriteRepository
 	rdb       *redis.Client
 	ttl       time.Duration
 	namespace string
@@ -36,7 +36,7 @@ type CachingRepository struct {
 
 // NewCachingRepository はRepositoryにRedisキャッシュを追加するデコレータを生成します。
 // ttlが0の場合はデフォルト5分、namespaceが空の場合は"candles"を使用します。
-func NewCachingRepository(rdb *redis.Client, ttl time.Duration, inner repository, namespace string) *CachingRepository {
+func NewCachingRepository(rdb *redis.Client, ttl time.Duration, inner readWriteRepository, namespace string) *CachingRepository {
 	if ttl <= 0 {
 		ttl = 5 * time.Minute
 	}

--- a/internal/feature/candles/caching_repository_test.go
+++ b/internal/feature/candles/caching_repository_test.go
@@ -10,14 +10,14 @@ import (
 	"github.com/go-redis/redismock/v9"
 )
 
-// mockCandleRepo はテスト用のRepositoryモック実装です。
-type mockCandleRepo struct {
+// mockReadWriteRepository はテスト用の readWriteRepository（読み書き）モック実装です。
+type mockReadWriteRepository struct {
 	findFn        func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error)
 	upsertBatchFn func(ctx context.Context, candles []Candle) error
 }
 
 // Find はモックのFind関数を呼び出します。
-func (m *mockCandleRepo) Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
+func (m *mockReadWriteRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 	if m.findFn != nil {
 		return m.findFn(ctx, symbol, interval, outputsize)
 	}
@@ -25,7 +25,7 @@ func (m *mockCandleRepo) Find(ctx context.Context, symbol, interval string, outp
 }
 
 // UpsertBatch はモックのUpsertBatch関数を呼び出します。
-func (m *mockCandleRepo) UpsertBatch(ctx context.Context, candles []Candle) error {
+func (m *mockReadWriteRepository) UpsertBatch(ctx context.Context, candles []Candle) error {
 	if m.upsertBatchFn != nil {
 		return m.upsertBatchFn(ctx, candles)
 	}
@@ -70,7 +70,7 @@ func TestNewCachingCandleRepository_Defaults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			repo := NewCachingRepository(nil, tt.ttl, &mockCandleRepo{}, tt.namespace)
+			repo := NewCachingRepository(nil, tt.ttl, &mockReadWriteRepository{}, tt.namespace)
 
 			if repo.ttl != tt.expectedTTL {
 				t.Errorf("expected TTL %v, got %v", tt.expectedTTL, repo.ttl)
@@ -90,7 +90,7 @@ func TestCachingCandleRepository_Find_NilRedis(t *testing.T) {
 		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
 	}
 
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 			return expectedCandles, nil
 		},
@@ -124,7 +124,7 @@ func TestCachingCandleRepository_Find_CacheHit(t *testing.T) {
 	mock.ExpectGet("candles:AAPL:1day").SetVal(string(cachedJSON))
 
 	innerCalled := false
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 			innerCalled = true
 			return nil, nil
@@ -166,7 +166,7 @@ func TestCachingCandleRepository_Find_CacheHit_Slices(t *testing.T) {
 
 	mock.ExpectGet("candles:AAPL:1day").SetVal(string(cachedJSON))
 
-	inner := &mockCandleRepo{}
+	inner := &mockReadWriteRepository{}
 	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
 
 	// outputsize=3 を指定 → 先頭3件のみ返る
@@ -199,7 +199,7 @@ func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 	// Set cache after fetching from inner (全データで保存)
 	mock.ExpectSet("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal("OK")
 
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 			// maxCacheOutputSize(5000) で呼ばれることを検証
 			if outputsize != maxCacheOutputSize {
@@ -233,7 +233,7 @@ func TestCachingCandleRepository_Find_InnerError(t *testing.T) {
 
 	mock.ExpectGet("candles:AAPL:1day").RedisNil()
 
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 			return nil, expectedErr
 		},
@@ -269,7 +269,7 @@ func TestCachingCandleRepository_Find_CorruptedCache(t *testing.T) {
 	// Set new cache after fetching from inner
 	mock.ExpectSet("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal("OK")
 
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 			return expectedCandles, nil
 		},
@@ -293,7 +293,7 @@ func TestCachingCandleRepository_UpsertBatch_NilRedis(t *testing.T) {
 	t.Parallel()
 
 	innerCalled := false
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
 			innerCalled = true
 			return nil
@@ -317,7 +317,7 @@ func TestCachingCandleRepository_UpsertBatch_InnerError(t *testing.T) {
 	t.Parallel()
 
 	expectedErr := errors.New("upsert error")
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
 			return expectedErr
 		},
@@ -340,7 +340,7 @@ func TestCachingCandleRepository_UpsertBatch_EmptyCandles(t *testing.T) {
 	rdb, _ := redismock.NewClientMock()
 	defer func() { _ = rdb.Close() }()
 
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
 			return nil
 		},
@@ -365,7 +365,7 @@ func TestCachingCandleRepository_UpsertBatch_CacheWarmUp(t *testing.T) {
 	}
 	warmJSON, _ := json.Marshal(warmCandles)
 
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
 			return nil
 		},
@@ -403,7 +403,7 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
 	warmJSON, _ := json.Marshal(warmCandles)
 
 	findCallCount := 0
-	inner := &mockCandleRepo{
+	inner := &mockReadWriteRepository{
 		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
 			return nil
 		},

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -17,12 +17,12 @@ import (
 	"stock_backend/internal/feature/candles/candleshttp"
 )
 
-// mockCandlesUsecase はusecaseインターフェースのモック実装です。
-type mockCandlesUsecase struct {
+// mockUsecase はusecaseインターフェースのモック実装です。
+type mockUsecase struct {
 	GetCandlesFunc func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error)
 }
 
-func (m *mockCandlesUsecase) GetCandles(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+func (m *mockUsecase) GetCandles(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
 	return m.GetCandlesFunc(ctx, symbol, interval, outputsize)
 }
 
@@ -87,7 +87,7 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// モックusecaseのインスタンスを生成
-			mockUC := &mockCandlesUsecase{
+			mockUC := &mockUsecase{
 				GetCandlesFunc: tt.mockGetCandles,
 			}
 

--- a/internal/feature/candles/ingest_test.go
+++ b/internal/feature/candles/ingest_test.go
@@ -14,13 +14,13 @@ var ErrDB = errors.New("database error")
 // ErrMarketAPI はマーケットAPIのセンチネルエラーです。
 var ErrMarketAPI = errors.New("market API error")
 
-// mockCandleWriteRepository はWriteRepositoryインターフェースのモック実装です。
-type mockCandleWriteRepository struct {
+// mockWriteRepository はWriteRepositoryインターフェースのモック実装です。
+type mockWriteRepository struct {
 	UpsertBatchFunc func(ctx context.Context, candles []Candle) error
 }
 
 // UpsertBatch はUpsertBatchFuncが設定されていればそれを呼び出します。
-func (m *mockCandleWriteRepository) UpsertBatch(ctx context.Context, candles []Candle) error {
+func (m *mockWriteRepository) UpsertBatch(ctx context.Context, candles []Candle) error {
 	if m.UpsertBatchFunc != nil {
 		return m.UpsertBatchFunc(ctx, candles)
 	}
@@ -261,7 +261,7 @@ func TestIngestUsecase_ingestOne(t *testing.T) {
 			mockMarket := &mockMarketRepository{
 				GetTimeSeriesFunc: tc.mockGetTimeSeriesFunc,
 			}
-			mockCandle := &mockCandleWriteRepository{
+			mockCandle := &mockWriteRepository{
 				UpsertBatchFunc: func(ctx context.Context, candles []Candle) error {
 					capturedCandles = candles
 					return tc.mockUpsertBatchFunc(ctx, candles)
@@ -427,7 +427,7 @@ func TestIngestUsecase_IngestAll(t *testing.T) {
 					return tc.mockGetTimeSeriesFunc(ctx, symbol, interval, outputsize, loc)
 				},
 			}
-			mockCandle := &mockCandleWriteRepository{
+			mockCandle := &mockWriteRepository{
 				UpsertBatchFunc: tc.mockUpsertBatchFunc,
 			}
 			mockSymbol := &mockSymbolRepository{
@@ -494,7 +494,7 @@ func TestIngestUsecase_IngestAll_MidLoopFatal(t *testing.T) {
 				return mockCandles, nil
 			},
 		}
-		mockCandle := &mockCandleWriteRepository{
+		mockCandle := &mockWriteRepository{
 			UpsertBatchFunc: func(ctx context.Context, candles []Candle) error { return nil },
 		}
 		mockSymbol := &mockSymbolRepository{
@@ -535,7 +535,7 @@ func TestIngestUsecase_IngestAll_MidLoopFatal(t *testing.T) {
 				return mockCandles, nil
 			},
 		}
-		mockCandle := &mockCandleWriteRepository{
+		mockCandle := &mockWriteRepository{
 			UpsertBatchFunc: func(ctx context.Context, candles []Candle) error { return nil },
 		}
 		mockSymbol := &mockSymbolRepository{
@@ -574,7 +574,7 @@ func TestIngestUsecase_IngestAll_MidLoopFatal(t *testing.T) {
 func TestIngestUsecase_ingestOne_InvalidTimezone(t *testing.T) {
 	ctx := context.Background()
 	mockMarket := &mockMarketRepository{}
-	mockCandle := &mockCandleWriteRepository{}
+	mockCandle := &mockWriteRepository{}
 	mockSymbol := &mockSymbolRepository{}
 	mockRL := &mockRateLimiter{}
 
@@ -601,7 +601,7 @@ func TestIngestUsecase_ingestOne_PassesLocation(t *testing.T) {
 			return nil, nil
 		},
 	}
-	mockCandle := &mockCandleWriteRepository{
+	mockCandle := &mockWriteRepository{
 		UpsertBatchFunc: func(ctx context.Context, candles []Candle) error { return nil },
 	}
 	mockSymbol := &mockSymbolRepository{}

--- a/internal/feature/candles/usecase_test.go
+++ b/internal/feature/candles/usecase_test.go
@@ -13,14 +13,14 @@ import (
 // ErrDB はモックと期待値の間で共有されるセンチネルエラーです。
 var ErrDB = errors.New("database error")
 
-// mockCandleRepository はRepositoryインターフェースのモック実装です。
-type mockCandleRepository struct {
+// mockRepository はRepositoryインターフェースのモック実装です。
+type mockRepository struct {
 	FindFunc  func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error)
 	FindCalls int
 }
 
 // Find はFindFuncが設定されていればそれを呼び出し、呼び出し回数を記録します。
-func (m *mockCandleRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+func (m *mockRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
 	m.FindCalls++
 	if m.FindFunc != nil {
 		return m.FindFunc(ctx, symbol, interval, outputsize)
@@ -115,7 +115,7 @@ func TestCandlesUsecase_GetCandles(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockRepo := &mockCandleRepository{
+			mockRepo := &mockRepository{
 				FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
 					// ユースケースが正しいパラメータでリポジトリを呼び出すことを検証
 					if symbol != tc.inputSymbol || interval != tc.expectedInterval || outputsize != tc.expectedOutputsize {

--- a/internal/feature/logodetection/logodetectionhttp/handler_test.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler_test.go
@@ -18,17 +18,17 @@ import (
 	"stock_backend/internal/feature/logodetection/logodetectionhttp"
 )
 
-// mockLogoDetectionUsecase はUsecaseインターフェースのモック実装です。
-type mockLogoDetectionUsecase struct {
+// mockUsecase はUsecaseインターフェースのモック実装です。
+type mockUsecase struct {
 	DetectLogosFunc    func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error)
 	AnalyzeCompanyFunc func(ctx context.Context, companyName string) (*logodetection.CompanyAnalysis, error)
 }
 
-func (m *mockLogoDetectionUsecase) DetectLogos(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error) {
+func (m *mockUsecase) DetectLogos(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error) {
 	return m.DetectLogosFunc(ctx, imageData)
 }
 
-func (m *mockLogoDetectionUsecase) AnalyzeCompany(ctx context.Context, companyName string) (*logodetection.CompanyAnalysis, error) {
+func (m *mockUsecase) AnalyzeCompany(ctx context.Context, companyName string) (*logodetection.CompanyAnalysis, error) {
 	return m.AnalyzeCompanyFunc(ctx, companyName)
 }
 
@@ -111,7 +111,7 @@ func TestLogoDetectionHandler_DetectLogos(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockUC := &mockLogoDetectionUsecase{
+			mockUC := &mockUsecase{
 				DetectLogosFunc: tt.mockFunc,
 			}
 
@@ -179,7 +179,7 @@ func TestLogoDetectionHandler_AnalyzeCompany(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mockUC := &mockLogoDetectionUsecase{
+			mockUC := &mockUsecase{
 				AnalyzeCompanyFunc: tt.mockFunc,
 			}
 

--- a/internal/feature/symbollist/symbollisthttp/handler_test.go
+++ b/internal/feature/symbollist/symbollisthttp/handler_test.go
@@ -18,13 +18,13 @@ func strPtr(s string) *string {
 	return &s
 }
 
-// mockSymbolUsecase はUsecaseインターフェースのモック実装です。
-type mockSymbolUsecase struct {
+// mockUsecase はUsecaseインターフェースのモック実装です。
+type mockUsecase struct {
 	ListActiveSymbolsFunc func(ctx context.Context) ([]symbollist.Symbol, error)
 }
 
 // ListActiveSymbols はモックのListActiveSymbols関数を呼び出します。
-func (m *mockSymbolUsecase) ListActiveSymbols(ctx context.Context) ([]symbollist.Symbol, error) {
+func (m *mockUsecase) ListActiveSymbols(ctx context.Context) ([]symbollist.Symbol, error) {
 	if m.ListActiveSymbolsFunc != nil {
 		return m.ListActiveSymbolsFunc(ctx)
 	}
@@ -35,7 +35,7 @@ func (m *mockSymbolUsecase) ListActiveSymbols(ctx context.Context) ([]symbollist
 func TestNewSymbolHandler(t *testing.T) {
 	t.Parallel()
 
-	mockUC := &mockSymbolUsecase{}
+	mockUC := &mockUsecase{}
 	h := symbollisthttp.NewHandler(mockUC)
 
 	assert.NotNil(t, h, "handler should not be nil")
@@ -102,7 +102,7 @@ func TestSymbolHandler_List(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockSymbolUsecase{
+			mockUC := &mockUsecase{
 				ListActiveSymbolsFunc: tt.mockListActiveFunc,
 			}
 			h := symbollisthttp.NewHandler(mockUC)
@@ -127,7 +127,7 @@ func TestSymbolHandler_List_DTOConversion(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	// レスポンスに公開DTOフィールドのみが含まれることを検証（ID、Market、IsActiveは含まれない）
-	mockUC := &mockSymbolUsecase{
+	mockUC := &mockUsecase{
 		ListActiveSymbolsFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 			return []symbollist.Symbol{
 				{

--- a/internal/feature/symbollist/usecase_test.go
+++ b/internal/feature/symbollist/usecase_test.go
@@ -10,13 +10,13 @@ import (
 	"stock_backend/internal/feature/symbollist"
 )
 
-// mockSymbolRepository はRepositoryインターフェースのモック実装です。
-type mockSymbolRepository struct {
+// mockRepository はRepositoryインターフェースのモック実装です。
+type mockRepository struct {
 	ListActiveFunc func(ctx context.Context) ([]symbollist.Symbol, error)
 }
 
 // ListActive はモックのListActive関数を呼び出します。
-func (m *mockSymbolRepository) ListActive(ctx context.Context) ([]symbollist.Symbol, error) {
+func (m *mockRepository) ListActive(ctx context.Context) ([]symbollist.Symbol, error) {
 	if m.ListActiveFunc != nil {
 		return m.ListActiveFunc(ctx)
 	}
@@ -27,7 +27,7 @@ func (m *mockSymbolRepository) ListActive(ctx context.Context) ([]symbollist.Sym
 func TestNewSymbolUsecase(t *testing.T) {
 	t.Parallel()
 
-	mockRepo := &mockSymbolRepository{}
+	mockRepo := &mockRepository{}
 	uc := symbollist.NewUsecase(mockRepo)
 
 	assert.NotNil(t, uc, "usecase should not be nil")
@@ -101,7 +101,7 @@ func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockRepo := &mockSymbolRepository{
+			mockRepo := &mockRepository{
 				ListActiveFunc: tt.mockListActive,
 			}
 			uc := symbollist.NewUsecase(mockRepo)
@@ -129,7 +129,7 @@ func TestSymbolUsecase_ListActiveSymbols_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel context immediately
 
-	mockRepo := &mockSymbolRepository{
+	mockRepo := &mockRepository{
 		ListActiveFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 			return nil, ctx.Err()
 		},

--- a/internal/feature/watchlist/usecase_test.go
+++ b/internal/feature/watchlist/usecase_test.go
@@ -1,0 +1,419 @@
+package watchlist_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"stock_backend/internal/feature/watchlist"
+)
+
+// mockRepository はRepositoryインターフェースのモック実装です。
+type mockRepository struct {
+	ListByUserFunc         func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error)
+	AddFunc                func(ctx context.Context, entry watchlist.UserSymbol) error
+	AddWithNextSortKeyFunc func(ctx context.Context, userID int64, symbolCode string) error
+	RemoveFunc             func(ctx context.Context, userID int64, symbolCode string) error
+	UpdateSortKeysFunc     func(ctx context.Context, userID int64, entries []watchlist.UserSymbol) error
+
+	AddedEntries     []watchlist.UserSymbol
+	UpdatedEntries   []watchlist.UserSymbol
+	AddWithNextCalls int
+	RemoveCalls      int
+}
+
+func (m *mockRepository) ListByUser(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+	if m.ListByUserFunc != nil {
+		return m.ListByUserFunc(ctx, userID)
+	}
+	return nil, nil
+}
+
+func (m *mockRepository) Add(ctx context.Context, entry watchlist.UserSymbol) error {
+	m.AddedEntries = append(m.AddedEntries, entry)
+	if m.AddFunc != nil {
+		return m.AddFunc(ctx, entry)
+	}
+	return nil
+}
+
+func (m *mockRepository) AddWithNextSortKey(ctx context.Context, userID int64, symbolCode string) error {
+	m.AddWithNextCalls++
+	if m.AddWithNextSortKeyFunc != nil {
+		return m.AddWithNextSortKeyFunc(ctx, userID, symbolCode)
+	}
+	return nil
+}
+
+func (m *mockRepository) Remove(ctx context.Context, userID int64, symbolCode string) error {
+	m.RemoveCalls++
+	if m.RemoveFunc != nil {
+		return m.RemoveFunc(ctx, userID, symbolCode)
+	}
+	return nil
+}
+
+func (m *mockRepository) UpdateSortKeys(ctx context.Context, userID int64, entries []watchlist.UserSymbol) error {
+	m.UpdatedEntries = entries
+	if m.UpdateSortKeysFunc != nil {
+		return m.UpdateSortKeysFunc(ctx, userID, entries)
+	}
+	return nil
+}
+
+// mockSymbolExistsChecker はSymbolExistsCheckerインターフェースのモック実装です。
+type mockSymbolExistsChecker struct {
+	ExistsFunc   func(ctx context.Context, code string) (bool, error)
+	CheckedCodes []string
+}
+
+func (m *mockSymbolExistsChecker) Exists(ctx context.Context, code string) (bool, error) {
+	m.CheckedCodes = append(m.CheckedCodes, code)
+	if m.ExistsFunc != nil {
+		return m.ExistsFunc(ctx, code)
+	}
+	return false, nil
+}
+
+func TestNewWatchlistUsecase(t *testing.T) {
+	t.Parallel()
+
+	uc := watchlist.NewUsecase(&mockRepository{}, &mockSymbolExistsChecker{})
+
+	assert.NotNil(t, uc, "usecase should not be nil")
+}
+
+func TestWatchlistUsecase_ListUserSymbols(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		listByUser  func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error)
+		wantSymbols []watchlist.UserSymbol
+		wantErr     bool
+		errMsg      string
+	}{
+		{
+			name: "success: returns user watchlist",
+			listByUser: func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+				return []watchlist.UserSymbol{
+					{ID: 1, UserID: userID, SymbolCode: "AAPL", SortKey: 0},
+					{ID: 2, UserID: userID, SymbolCode: "MSFT", SortKey: 1},
+				}, nil
+			},
+			wantSymbols: []watchlist.UserSymbol{
+				{ID: 1, UserID: 42, SymbolCode: "AAPL", SortKey: 0},
+				{ID: 2, UserID: 42, SymbolCode: "MSFT", SortKey: 1},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success: returns empty watchlist",
+			listByUser: func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+				return []watchlist.UserSymbol{}, nil
+			},
+			wantSymbols: []watchlist.UserSymbol{},
+			wantErr:     false,
+		},
+		{
+			name: "failure: repository returns error",
+			listByUser: func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+				return nil, errors.New("database connection failed")
+			},
+			wantSymbols: nil,
+			wantErr:     true,
+			errMsg:      "database connection failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &mockRepository{ListByUserFunc: tt.listByUser}
+			uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+			symbols, err := uc.ListUserSymbols(context.Background(), 42)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errMsg != "" {
+					assert.EqualError(t, err, tt.errMsg)
+				}
+				assert.Nil(t, symbols)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.wantSymbols, symbols)
+			}
+		})
+	}
+}
+
+func TestWatchlistUsecase_AddSymbol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		exists           func(ctx context.Context, code string) (bool, error)
+		addWithNext      func(ctx context.Context, userID int64, symbolCode string) error
+		wantErr          bool
+		wantErrIs        error
+		wantErrContains  string
+		wantAddWithCalls int
+	}{
+		{
+			name: "success: existing symbol is added",
+			exists: func(ctx context.Context, code string) (bool, error) {
+				return true, nil
+			},
+			wantErr:          false,
+			wantAddWithCalls: 1,
+		},
+		{
+			name: "failure: symbol does not exist returns ErrSymbolNotFound",
+			exists: func(ctx context.Context, code string) (bool, error) {
+				return false, nil
+			},
+			wantErr:          true,
+			wantErrIs:        watchlist.ErrSymbolNotFound,
+			wantAddWithCalls: 0,
+		},
+		{
+			name: "failure: existence check returns wrapped error",
+			exists: func(ctx context.Context, code string) (bool, error) {
+				return false, errors.New("checker down")
+			},
+			wantErr:          true,
+			wantErrContains:  "checking symbol existence",
+			wantAddWithCalls: 0,
+		},
+		{
+			name: "failure: repository add returns error",
+			exists: func(ctx context.Context, code string) (bool, error) {
+				return true, nil
+			},
+			addWithNext: func(ctx context.Context, userID int64, symbolCode string) error {
+				return errors.New("insert failed")
+			},
+			wantErr:          true,
+			wantErrContains:  "insert failed",
+			wantAddWithCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &mockRepository{AddWithNextSortKeyFunc: tt.addWithNext}
+			checker := &mockSymbolExistsChecker{ExistsFunc: tt.exists}
+			uc := watchlist.NewUsecase(repo, checker)
+
+			err := uc.AddSymbol(context.Background(), 42, "AAPL")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, err, tt.wantErrIs)
+				}
+				if tt.wantErrContains != "" {
+					assert.ErrorContains(t, err, tt.wantErrContains)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.wantAddWithCalls, repo.AddWithNextCalls)
+		})
+	}
+}
+
+func TestWatchlistUsecase_RemoveSymbol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		remove  func(ctx context.Context, userID int64, symbolCode string) error
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "success: symbol is removed",
+			remove:  func(ctx context.Context, userID int64, symbolCode string) error { return nil },
+			wantErr: false,
+		},
+		{
+			name: "failure: repository returns error",
+			remove: func(ctx context.Context, userID int64, symbolCode string) error {
+				return errors.New("delete failed")
+			},
+			wantErr: true,
+			errMsg:  "delete failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := &mockRepository{RemoveFunc: tt.remove}
+			uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+			err := uc.RemoveSymbol(context.Background(), 42, "AAPL")
+
+			if tt.wantErr {
+				assert.EqualError(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, 1, repo.RemoveCalls)
+		})
+	}
+}
+
+func TestWatchlistUsecase_ReorderSymbols(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: assigns sequential sort keys in order", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{"MSFT", "AAPL", "GOOGL"})
+
+		require.NoError(t, err)
+		assert.Equal(t, []watchlist.UserSymbol{
+			{UserID: 42, SymbolCode: "MSFT", SortKey: 0},
+			{UserID: 42, SymbolCode: "AAPL", SortKey: 1},
+			{UserID: 42, SymbolCode: "GOOGL", SortKey: 2},
+		}, repo.UpdatedEntries)
+	})
+
+	t.Run("success: empty order produces empty entries", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{})
+
+		require.NoError(t, err)
+		assert.Empty(t, repo.UpdatedEntries)
+	})
+
+	t.Run("failure: repository returns error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{
+			UpdateSortKeysFunc: func(ctx context.Context, userID int64, entries []watchlist.UserSymbol) error {
+				return errors.New("update failed")
+			},
+		}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{"AAPL"})
+
+		assert.EqualError(t, err, "update failed")
+	})
+}
+
+func TestWatchlistUsecase_InitializeDefaults(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: adds all default symbols when they exist", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{}
+		checker := &mockSymbolExistsChecker{
+			ExistsFunc: func(ctx context.Context, code string) (bool, error) { return true, nil },
+		}
+		uc := watchlist.NewUsecase(repo, checker)
+
+		err := uc.InitializeDefaults(context.Background(), 7)
+
+		require.NoError(t, err)
+		assert.Equal(t, []watchlist.UserSymbol{
+			{UserID: 7, SymbolCode: "AAPL", SortKey: 0},
+			{UserID: 7, SymbolCode: "MSFT", SortKey: 1},
+			{UserID: 7, SymbolCode: "GOOGL", SortKey: 2},
+		}, repo.AddedEntries)
+	})
+
+	t.Run("success: skips symbols that do not exist", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{}
+		checker := &mockSymbolExistsChecker{
+			ExistsFunc: func(ctx context.Context, code string) (bool, error) {
+				return code == "MSFT", nil
+			},
+		}
+		uc := watchlist.NewUsecase(repo, checker)
+
+		err := uc.InitializeDefaults(context.Background(), 7)
+
+		require.NoError(t, err)
+		assert.Equal(t, []watchlist.UserSymbol{
+			{UserID: 7, SymbolCode: "MSFT", SortKey: 1},
+		}, repo.AddedEntries)
+	})
+
+	t.Run("failure: existence check returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{}
+		checker := &mockSymbolExistsChecker{
+			ExistsFunc: func(ctx context.Context, code string) (bool, error) {
+				return false, errors.New("checker down")
+			},
+		}
+		uc := watchlist.NewUsecase(repo, checker)
+
+		err := uc.InitializeDefaults(context.Background(), 7)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "checking symbol AAPL")
+		assert.Empty(t, repo.AddedEntries)
+	})
+
+	t.Run("failure: repository add returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{
+			AddFunc: func(ctx context.Context, entry watchlist.UserSymbol) error {
+				return errors.New("insert failed")
+			},
+		}
+		checker := &mockSymbolExistsChecker{
+			ExistsFunc: func(ctx context.Context, code string) (bool, error) { return true, nil },
+		}
+		uc := watchlist.NewUsecase(repo, checker)
+
+		err := uc.InitializeDefaults(context.Background(), 7)
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "adding default symbol AAPL")
+	})
+}
+
+func TestWatchlistUsecase_OnUserCreated(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockRepository{}
+	checker := &mockSymbolExistsChecker{
+		ExistsFunc: func(ctx context.Context, code string) (bool, error) { return true, nil },
+	}
+	uc := watchlist.NewUsecase(repo, checker)
+
+	err := uc.OnUserCreated(context.Background(), 7)
+
+	require.NoError(t, err)
+	assert.Equal(t, []watchlist.UserSymbol{
+		{UserID: 7, SymbolCode: "AAPL", SortKey: 0},
+		{UserID: 7, SymbolCode: "MSFT", SortKey: 1},
+		{UserID: 7, SymbolCode: "GOOGL", SortKey: 2},
+	}, repo.AddedEntries)
+}

--- a/internal/feature/watchlist/watchlisthttp/handler_test.go
+++ b/internal/feature/watchlist/watchlisthttp/handler_test.go
@@ -19,36 +19,36 @@ import (
 
 const testUserID int64 = 1
 
-// mockWatchlistUsecase は Usecase インターフェースのモック実装です。
-type mockWatchlistUsecase struct {
+// mockUsecase は Usecase インターフェースのモック実装です。
+type mockUsecase struct {
 	ListUserSymbolsFunc func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error)
 	AddSymbolFunc       func(ctx context.Context, userID int64, symbolCode string) error
 	RemoveSymbolFunc    func(ctx context.Context, userID int64, symbolCode string) error
 	ReorderSymbolsFunc  func(ctx context.Context, userID int64, orderedCodes []string) error
 }
 
-func (m *mockWatchlistUsecase) ListUserSymbols(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+func (m *mockUsecase) ListUserSymbols(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
 	if m.ListUserSymbolsFunc != nil {
 		return m.ListUserSymbolsFunc(ctx, userID)
 	}
 	return nil, nil
 }
 
-func (m *mockWatchlistUsecase) AddSymbol(ctx context.Context, userID int64, symbolCode string) error {
+func (m *mockUsecase) AddSymbol(ctx context.Context, userID int64, symbolCode string) error {
 	if m.AddSymbolFunc != nil {
 		return m.AddSymbolFunc(ctx, userID, symbolCode)
 	}
 	return nil
 }
 
-func (m *mockWatchlistUsecase) RemoveSymbol(ctx context.Context, userID int64, symbolCode string) error {
+func (m *mockUsecase) RemoveSymbol(ctx context.Context, userID int64, symbolCode string) error {
 	if m.RemoveSymbolFunc != nil {
 		return m.RemoveSymbolFunc(ctx, userID, symbolCode)
 	}
 	return nil
 }
 
-func (m *mockWatchlistUsecase) ReorderSymbols(ctx context.Context, userID int64, orderedCodes []string) error {
+func (m *mockUsecase) ReorderSymbols(ctx context.Context, userID int64, orderedCodes []string) error {
 	if m.ReorderSymbolsFunc != nil {
 		return m.ReorderSymbolsFunc(ctx, userID, orderedCodes)
 	}
@@ -110,7 +110,7 @@ func TestWatchlistHandler_List(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockWatchlistUsecase{ListUserSymbolsFunc: tt.mockList}
+			mockUC := &mockUsecase{ListUserSymbolsFunc: tt.mockList}
 			h := watchlisthttp.NewHandler(mockUC)
 			router := newRouter(t, func(r *gin.Engine) {
 				r.GET("/watchlist", h.List)
@@ -187,7 +187,7 @@ func TestWatchlistHandler_Add(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockWatchlistUsecase{AddSymbolFunc: tt.mockAdd}
+			mockUC := &mockUsecase{AddSymbolFunc: tt.mockAdd}
 			h := watchlisthttp.NewHandler(mockUC)
 			router := newRouter(t, func(r *gin.Engine) {
 				r.POST("/watchlist", h.Add)
@@ -251,7 +251,7 @@ func TestWatchlistHandler_Remove(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockWatchlistUsecase{RemoveSymbolFunc: tt.mockRemove}
+			mockUC := &mockUsecase{RemoveSymbolFunc: tt.mockRemove}
 			h := watchlisthttp.NewHandler(mockUC)
 			router := newRouter(t, func(r *gin.Engine) {
 				r.DELETE("/watchlist/:code", h.Remove)
@@ -312,7 +312,7 @@ func TestWatchlistHandler_Reorder(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			mockUC := &mockWatchlistUsecase{ReorderSymbolsFunc: tt.mockReorder}
+			mockUC := &mockUsecase{ReorderSymbolsFunc: tt.mockReorder}
 			h := watchlisthttp.NewHandler(mockUC)
 			router := newRouter(t, func(r *gin.Engine) {
 				r.PUT("/watchlist/reorder", h.Reorder)


### PR DESCRIPTION
## 概要

`internal/feature` 全体のテストモック命名を横断監査し、Go 慣例である **インターフェース名ミラー（`mock<Interface>`）** に統一しました。あわせて candles の公開/非公開インターフェースの大文字小文字衝突を解消しています。

## 背景

`refactor/feature-package-naming`（stutter 解消）の流れでモック命名を確認したところ、前置トークンの基準が混在していました。

- candles 内で `Candle`(repo系) と `Candles`(usecase系) の単複混在
- `mockSymbolRepository` が candles(`SymbolRepository`用) と symbollist(`Repository`用) で同名・別物
- candles の公開 `Repository` と非公開 `repository` が**大文字小文字違いだけ**で共存（`mockCandleRepo` 略記の遠因）

フィーチャー名を前置する案は、package がスコープを与えるため識別子にパッケージ名を重ねる stutter となり Go 慣例・本ブランチの目的と矛盾します。そこで **インターフェース名をそのままミラーする** 方針に統一しました。

## 変更内容

### プロダクションコード
- `candles/caching_repository.go`: 非公開 `repository` を `Repository` + `WriteRepository` 合成の `readWriteRepository` にリネーム（メソッド集合は不変）。公開 `Repository` との case 衝突を解消。

### テストコード（`mock<Interface>` に統一）
| 変更前 | 変更後 |
|---|---|
| `mockCandleRepository` / `mockSymbolRepository`(symbollist) | `mockRepository` |
| `mockCandleRepo` | `mockReadWriteRepository` |
| `mockCandleWriteRepository` | `mockWriteRepository` |
| `mockCandlesUsecase` / `mockSymbolUsecase` / `mockAuthUsecase` / `mockLogoDetectionUsecase` / `mockWatchlistUsecase` | `mockUsecase` |

固有名インターフェースのミラー（`mockUserRepository` / `mockMarketRepository` / candles の `mockSymbolRepository` 等）は据え置き。同名衝突は symbollist 側が `mockRepository` になることで自然解消しました。

> すべてテストコード＋candles 非公開インターフェースに閉じており、公開 API・プロダクション挙動は不変です。

## 検証

- `go build ./...` ✅
- `go vet ./internal/feature/...` ✅
- `go tool go-arch-lint check` ✅ No warnings
- `go test ./internal/feature/... -race` ✅ 全パッケージ green（DB 込み candles / symbollist も通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)