### PR TITLE
refactor: OAuth ハンドラー構築を di ファクトリへ切り出し

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 
 	redisv9 "github.com/redis/go-redis/v9"
 
 	"stock_backend/internal/app/config"
+	"stock_backend/internal/app/di"
 	"stock_backend/internal/app/router"
 	"stock_backend/internal/feature/auth"
 	"stock_backend/internal/feature/auth/authhttp"
@@ -29,114 +29,6 @@ import (
 	"stock_backend/internal/transport/httpratelimit"
 	"stock_backend/internal/transport/jwt"
 )
-
-// oauthProviderConfig は OAuth プロバイダ1社分の検証済み認証情報。
-type oauthProviderConfig struct {
-	clientID     string
-	clientSecret string
-	redirectURL  string
-}
-
-// oauthConfig は OAuth 機能の検証済み設定。いずれかのプロバイダが設定された場合のみ生成される。
-type oauthConfig struct {
-	frontendURL string
-	google      *oauthProviderConfig // 未設定なら nil
-	github      *oauthProviderConfig // 未設定なら nil
-}
-
-// serverConfig は環境変数から読み込んだ検証済みのサーバー設定。
-type serverConfig struct {
-	jwtSecret      string
-	passwordPepper string
-	secureCookie   bool
-	corsOrigins    []string
-	oauth          *oauthConfig // OAuth 無効なら nil
-}
-
-// loadServerConfig は環境変数を読み込んで検証し、検証済みの設定を返す。
-// 外部接続（DB/Redis/GCP）に依存しない純粋関数なのでユニットテスト可能。
-// 必須項目の欠落や OAuth 設定の不整合があればエラーを返す。
-func loadServerConfig() (serverConfig, error) {
-	jwtSecret := os.Getenv(jwt.EnvKeyJWTSecret)
-	if jwtSecret == "" {
-		return serverConfig{}, fmt.Errorf("%s is required", jwt.EnvKeyJWTSecret)
-	}
-
-	passwordPepper := os.Getenv(auth.EnvKeyPasswordPepper)
-	if passwordPepper == "" {
-		return serverConfig{}, fmt.Errorf("%s is required", auth.EnvKeyPasswordPepper)
-	}
-
-	// COOKIE_SECURE を優先し、未設定なら APP_ENV=production をフォールバックとして使用
-	cookieSecureRaw := os.Getenv("COOKIE_SECURE")
-	defaultSecure := os.Getenv("APP_ENV") == "production"
-	secureCookie, ok := config.ParseBoolString(cookieSecureRaw, defaultSecure)
-	if !ok {
-		slog.Warn("invalid COOKIE_SECURE value, falling back to default", "value", cookieSecureRaw, "default", secureCookie)
-	}
-
-	// CORS許可オリジン（デフォルト: http://localhost:3000）
-	corsOrigins := config.ParseCORSOrigins(os.Getenv("CORS_ALLOWED_ORIGINS"))
-	if corsOrigins == nil {
-		corsOrigins = []string{"http://localhost:3000"}
-	}
-
-	oauth, err := loadOAuthConfig()
-	if err != nil {
-		return serverConfig{}, err
-	}
-
-	return serverConfig{
-		jwtSecret:      jwtSecret,
-		passwordPepper: passwordPepper,
-		secureCookie:   secureCookie,
-		corsOrigins:    corsOrigins,
-		oauth:          oauth,
-	}, nil
-}
-
-// loadOAuthConfig は OAuth 関連の環境変数を検証する。
-// GOOGLE_CLIENT_ID / GITHUB_CLIENT_ID のいずれも未設定なら OAuth 無効として nil を返す。
-func loadOAuthConfig() (*oauthConfig, error) {
-	googleClientID := os.Getenv("GOOGLE_CLIENT_ID")
-	githubClientID := os.Getenv("GITHUB_CLIENT_ID")
-	if googleClientID == "" && githubClientID == "" {
-		return nil, nil
-	}
-
-	frontendURL := os.Getenv("OAUTH_FRONTEND_REDIRECT_URL")
-	if frontendURL == "" {
-		return nil, fmt.Errorf("OAUTH_FRONTEND_REDIRECT_URL is required when OAuth is enabled")
-	}
-
-	cfg := &oauthConfig{frontendURL: frontendURL}
-
-	if googleClientID != "" {
-		secret := os.Getenv("GOOGLE_CLIENT_SECRET")
-		if secret == "" {
-			return nil, fmt.Errorf("GOOGLE_CLIENT_SECRET is required when GOOGLE_CLIENT_ID is set")
-		}
-		redirectURL := os.Getenv("GOOGLE_REDIRECT_URL")
-		if redirectURL == "" {
-			return nil, fmt.Errorf("GOOGLE_REDIRECT_URL is required when GOOGLE_CLIENT_ID is set")
-		}
-		cfg.google = &oauthProviderConfig{clientID: googleClientID, clientSecret: secret, redirectURL: redirectURL}
-	}
-
-	if githubClientID != "" {
-		secret := os.Getenv("GITHUB_CLIENT_SECRET")
-		if secret == "" {
-			return nil, fmt.Errorf("GITHUB_CLIENT_SECRET is required when GITHUB_CLIENT_ID is set")
-		}
-		redirectURL := os.Getenv("GITHUB_REDIRECT_URL")
-		if redirectURL == "" {
-			return nil, fmt.Errorf("GITHUB_REDIRECT_URL is required when GITHUB_CLIENT_ID is set")
-		}
-		cfg.github = &oauthProviderConfig{clientID: githubClientID, clientSecret: secret, redirectURL: redirectURL}
-	}
-
-	return cfg, nil
-}
 
 // main は run の戻り値で os.Exit するだけのラッパー。
 // os.Exit は defer を実行しないため、DB / Redis / Vision クライアントの
@@ -234,37 +126,11 @@ func run() int {
 	// OAuth ハンドラー（cfg.oauth が nil の場合はOAuth機能なしで起動）
 	var oauthH *authhttp.OAuthHandler
 	if cfg.oauth != nil {
-		if rdb == nil {
-			slog.Error("OAuth requires Redis but Redis is unavailable")
+		oauthH, err = di.NewOAuthHandler(cfg.oauth, sqlDB, rdb, userRepo, jwtGen, watchlistUC, cfg.secureCookie)
+		if err != nil {
+			slog.Error("failed to set up OAuth", "error", err)
 			return 1
 		}
-		oauthProviders := map[string]auth.OAuthProvider{}
-		if cfg.oauth.google != nil {
-			oauthProviders["google"] = auth.NewGoogleProvider(
-				cfg.oauth.google.clientID,
-				cfg.oauth.google.clientSecret,
-				cfg.oauth.google.redirectURL,
-				&http.Client{Timeout: 10 * time.Second},
-			)
-		}
-		if cfg.oauth.github != nil {
-			oauthProviders["github"] = auth.NewGitHubProvider(
-				cfg.oauth.github.clientID,
-				cfg.oauth.github.clientSecret,
-				cfg.oauth.github.redirectURL,
-				&http.Client{Timeout: 10 * time.Second},
-			)
-		}
-		oauthUC := auth.NewOAuthUsecase(
-			userRepo,
-			auth.NewOAuthAccountRepository(sqlDB),
-			userRepo,
-			auth.NewRedisOAuthStateStore(rdb),
-			jwtGen,
-			oauthProviders,
-			watchlistUC,
-		)
-		oauthH = authhttp.NewOAuthHandler(oauthUC, cfg.secureCookie, cfg.oauth.frontendURL)
 	}
 
 	// ハンドラー
@@ -283,4 +149,98 @@ func run() int {
 		return 1
 	}
 	return 0
+}
+
+// serverConfig は環境変数から読み込んだ検証済みのサーバー設定。
+type serverConfig struct {
+	jwtSecret      string
+	passwordPepper string
+	secureCookie   bool
+	corsOrigins    []string
+	oauth          *di.OAuthConfig // OAuth 無効なら nil
+}
+
+// loadServerConfig は環境変数を読み込んで検証し、検証済みの設定を返す。
+// 外部接続（DB/Redis/GCP）に依存しない純粋関数なのでユニットテスト可能。
+// 必須項目の欠落や OAuth 設定の不整合があればエラーを返す。
+func loadServerConfig() (serverConfig, error) {
+	jwtSecret := os.Getenv(jwt.EnvKeyJWTSecret)
+	if jwtSecret == "" {
+		return serverConfig{}, fmt.Errorf("%s is required", jwt.EnvKeyJWTSecret)
+	}
+
+	passwordPepper := os.Getenv(auth.EnvKeyPasswordPepper)
+	if passwordPepper == "" {
+		return serverConfig{}, fmt.Errorf("%s is required", auth.EnvKeyPasswordPepper)
+	}
+
+	// COOKIE_SECURE を優先し、未設定なら APP_ENV=production をフォールバックとして使用
+	cookieSecureRaw := os.Getenv("COOKIE_SECURE")
+	defaultSecure := os.Getenv("APP_ENV") == "production"
+	secureCookie, ok := config.ParseBoolString(cookieSecureRaw, defaultSecure)
+	if !ok {
+		slog.Warn("invalid COOKIE_SECURE value, falling back to default", "value", cookieSecureRaw, "default", secureCookie)
+	}
+
+	// CORS許可オリジン（デフォルト: http://localhost:3000）
+	corsOrigins := config.ParseCORSOrigins(os.Getenv("CORS_ALLOWED_ORIGINS"))
+	if corsOrigins == nil {
+		corsOrigins = []string{"http://localhost:3000"}
+	}
+
+	oauth, err := loadOAuthConfig()
+	if err != nil {
+		return serverConfig{}, err
+	}
+
+	return serverConfig{
+		jwtSecret:      jwtSecret,
+		passwordPepper: passwordPepper,
+		secureCookie:   secureCookie,
+		corsOrigins:    corsOrigins,
+		oauth:          oauth,
+	}, nil
+}
+
+// loadOAuthConfig は OAuth 関連の環境変数を検証する。
+// GOOGLE_CLIENT_ID / GITHUB_CLIENT_ID のいずれも未設定なら OAuth 無効として nil を返す。
+func loadOAuthConfig() (*di.OAuthConfig, error) {
+	googleClientID := os.Getenv("GOOGLE_CLIENT_ID")
+	githubClientID := os.Getenv("GITHUB_CLIENT_ID")
+	if googleClientID == "" && githubClientID == "" {
+		return nil, nil
+	}
+
+	frontendURL := os.Getenv("OAUTH_FRONTEND_REDIRECT_URL")
+	if frontendURL == "" {
+		return nil, fmt.Errorf("OAUTH_FRONTEND_REDIRECT_URL is required when OAuth is enabled")
+	}
+
+	cfg := &di.OAuthConfig{FrontendURL: frontendURL}
+
+	if googleClientID != "" {
+		secret := os.Getenv("GOOGLE_CLIENT_SECRET")
+		if secret == "" {
+			return nil, fmt.Errorf("GOOGLE_CLIENT_SECRET is required when GOOGLE_CLIENT_ID is set")
+		}
+		redirectURL := os.Getenv("GOOGLE_REDIRECT_URL")
+		if redirectURL == "" {
+			return nil, fmt.Errorf("GOOGLE_REDIRECT_URL is required when GOOGLE_CLIENT_ID is set")
+		}
+		cfg.Google = &di.ProviderCredentials{ClientID: googleClientID, ClientSecret: secret, RedirectURL: redirectURL}
+	}
+
+	if githubClientID != "" {
+		secret := os.Getenv("GITHUB_CLIENT_SECRET")
+		if secret == "" {
+			return nil, fmt.Errorf("GITHUB_CLIENT_SECRET is required when GITHUB_CLIENT_ID is set")
+		}
+		redirectURL := os.Getenv("GITHUB_REDIRECT_URL")
+		if redirectURL == "" {
+			return nil, fmt.Errorf("GITHUB_REDIRECT_URL is required when GITHUB_CLIENT_ID is set")
+		}
+		cfg.GitHub = &di.ProviderCredentials{ClientID: githubClientID, ClientSecret: secret, RedirectURL: redirectURL}
+	}
+
+	return cfg, nil
 }

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -81,6 +81,14 @@ func TestLoadServerConfig(t *testing.T) {
 	})
 }
 
+func TestRun_ReturnsTwoWhenConfigInvalid(t *testing.T) {
+	clearEnv(t) // JWT_SECRET 未設定 → loadServerConfig が失敗する
+
+	if got := run(); got != 2 {
+		t.Errorf("run() = %d, want 2", got)
+	}
+}
+
 func TestRun_ReturnsOneWhenDBConfigInvalid(t *testing.T) {
 	clearEnv(t)
 	t.Setenv(jwt.EnvKeyJWTSecret, "secret")

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -143,10 +143,10 @@ func TestLoadOAuthConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg == nil || cfg.google == nil {
+		if cfg == nil || cfg.Google == nil {
 			t.Fatalf("expected google config, got %+v", cfg)
 		}
-		if cfg.github != nil {
+		if cfg.GitHub != nil {
 			t.Error("github should be nil when not configured")
 		}
 	})
@@ -175,7 +175,7 @@ func TestLoadOAuthConfig(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if cfg == nil || cfg.google == nil || cfg.github == nil {
+		if cfg == nil || cfg.Google == nil || cfg.GitHub == nil {
 			t.Fatalf("expected both providers, got %+v", cfg)
 		}
 	})

--- a/internal/app/di/oauth.go
+++ b/internal/app/di/oauth.go
@@ -1,0 +1,84 @@
+package di
+
+import (
+	"database/sql"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"stock_backend/internal/feature/auth"
+	"stock_backend/internal/feature/auth/authhttp"
+)
+
+// oauthHTTPTimeout は OAuth プロバイダ（Google/GitHub）への HTTP 呼び出しに用いるタイムアウト。
+const oauthHTTPTimeout = 10 * time.Second
+
+// ProviderCredentials は OAuth プロバイダ1社分の検証済み認証情報。
+type ProviderCredentials struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+}
+
+// OAuthConfig は OAuth 機能の検証済み設定。いずれかのプロバイダが設定された場合のみ生成される。
+type OAuthConfig struct {
+	FrontendURL string
+	Google      *ProviderCredentials // 未設定なら nil
+	GitHub      *ProviderCredentials // 未設定なら nil
+}
+
+// OAuthUserStore は OAuth ユースケースが必要とするユーザー永続化操作をまとめた合成インターフェース。
+// NewOAuthUsecase の users / creator 両引数へ同一の実装を渡すために用いる。
+type OAuthUserStore interface {
+	auth.UserRepository
+	auth.OAuthUserCreator
+}
+
+// NewOAuthHandler は OAuth 機能一式（プロバイダ・ユースケース・ハンドラー）を組み立てる。
+// OAuth は state 保存に Redis を必須とするため、rdb が nil の場合はエラーを返す。
+func NewOAuthHandler(
+	cfg *OAuthConfig,
+	db *sql.DB,
+	rdb *redis.Client,
+	userStore OAuthUserStore,
+	jwtGen auth.JWTGenerator,
+	onUserCreated auth.UserCreatedHook,
+	secureCookie bool,
+) (*authhttp.OAuthHandler, error) {
+	if rdb == nil {
+		return nil, fmt.Errorf("OAuth requires Redis but Redis is unavailable")
+	}
+
+	hc := &http.Client{Timeout: oauthHTTPTimeout}
+	providers := map[string]auth.OAuthProvider{}
+	if cfg.Google != nil {
+		providers["google"] = auth.NewGoogleProvider(
+			cfg.Google.ClientID,
+			cfg.Google.ClientSecret,
+			cfg.Google.RedirectURL,
+			hc,
+		)
+	}
+	if cfg.GitHub != nil {
+		providers["github"] = auth.NewGitHubProvider(
+			cfg.GitHub.ClientID,
+			cfg.GitHub.ClientSecret,
+			cfg.GitHub.RedirectURL,
+			hc,
+		)
+	}
+
+	oauthUC := auth.NewOAuthUsecase(
+		userStore,
+		auth.NewOAuthAccountRepository(db),
+		userStore,
+		auth.NewRedisOAuthStateStore(rdb),
+		jwtGen,
+		providers,
+		onUserCreated,
+	)
+
+	return authhttp.NewOAuthHandler(oauthUC, secureCookie, cfg.FrontendURL), nil
+}

--- a/internal/app/di/oauth_test.go
+++ b/internal/app/di/oauth_test.go
@@ -1,0 +1,78 @@
+package di
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/redis/go-redis/v9"
+
+	"stock_backend/internal/feature/auth"
+)
+
+// stubOAuthUserStore は OAuthUserStore（UserRepository + OAuthUserCreator）の最小実装。
+type stubOAuthUserStore struct{}
+
+func (s *stubOAuthUserStore) Create(ctx context.Context, user *auth.User) error { return nil }
+func (s *stubOAuthUserStore) FindByEmail(ctx context.Context, email string) (*auth.User, error) {
+	return nil, nil
+}
+func (s *stubOAuthUserStore) FindByID(ctx context.Context, id int64) (*auth.User, error) {
+	return nil, nil
+}
+func (s *stubOAuthUserStore) CreateUserWithOAuthAccount(ctx context.Context, user *auth.User, account *auth.OAuthAccount) error {
+	return nil
+}
+
+// stubJWTGenerator は auth.JWTGenerator の最小実装。
+type stubJWTGenerator struct{}
+
+func (s *stubJWTGenerator) GenerateToken(userID int64, email string) (string, error) {
+	return "", nil
+}
+
+// stubUserCreatedHook は auth.UserCreatedHook の最小実装。
+type stubUserCreatedHook struct{}
+
+func (s *stubUserCreatedHook) OnUserCreated(ctx context.Context, userID int64) error { return nil }
+
+func TestNewOAuthHandler_RequiresRedis(t *testing.T) {
+	t.Parallel()
+
+	cfg := &OAuthConfig{
+		FrontendURL: "http://localhost:3000",
+		Google:      &ProviderCredentials{ClientID: "id", ClientSecret: "secret", RedirectURL: "http://localhost/cb"},
+	}
+
+	h, err := NewOAuthHandler(cfg, nil, nil, &stubOAuthUserStore{}, &stubJWTGenerator{}, &stubUserCreatedHook{}, false)
+	if err == nil {
+		t.Fatal("expected error when Redis is unavailable, got nil")
+	}
+	if h != nil {
+		t.Errorf("expected nil handler on error, got %v", h)
+	}
+}
+
+func TestNewOAuthHandler_BuildsHandler(t *testing.T) {
+	t.Parallel()
+
+	cfg := &OAuthConfig{
+		FrontendURL: "http://localhost:3000",
+		Google:      &ProviderCredentials{ClientID: "gid", ClientSecret: "gsecret", RedirectURL: "http://localhost/google/cb"},
+		GitHub:      &ProviderCredentials{ClientID: "hid", ClientSecret: "hsecret", RedirectURL: "http://localhost/github/cb"},
+	}
+
+	// 接続はせず構築のみを検証するため、ダミーの DB / Redis クライアントを渡す。
+	db := sql.OpenDB(nil)
+	t.Cleanup(func() { _ = db.Close() })
+	rdb := redis.NewClient(&redis.Options{})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	h, err := NewOAuthHandler(cfg, db, rdb, &stubOAuthUserStore{}, &stubJWTGenerator{}, &stubUserCreatedHook{}, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}


### PR DESCRIPTION
## 概要
`cmd/api/main.go` の `run()` 内で唯一ロジック密度が高かった OAuth ハンドラー構築ブロックを `internal/app/di` のファクトリへ切り出し、`main` を配線に専念させました。あわせて Go 慣例（トップダウン順）に沿って関数の並び順を整理しています。

## 変更内容
- OAuth 構築ブロック（プロバイダ map 構築・リポジトリ生成・Redis 必須チェック）を `di.NewOAuthHandler` へ移動し、`run()` の該当箇所を 35 行 → 7 行に縮小
- OAuth 設定型を `di.OAuthConfig` / `di.ProviderCredentials` として公開化（旧 `main` の非公開型を置き換え）
- `userRepo` を `NewOAuthUsecase` の `users` / `creator` 両引数へ渡すための合成インターフェース `di.OAuthUserStore` を追加
- Redis 必須チェックを exit code 直書きから error 返却へ変更し、ファクトリ単体でテスト可能に
- `main.go` の関数を `main` → `run` → 設定ヘルパーのトップダウン順に並べ替え

## テスト
- `internal/app/di/oauth_test.go` を追加（Redis 不在時のエラー / プロバイダ設定時のハンドラー生成）
- `go build ./...` / `go vet ./cmd/api/...` / `go tool go-arch-lint check`（ルール変更なしで通過）/ `golangci-lint run` / `go test ./... -race` すべてパス

## レビューポイント
- 設定型を `config` ではなく `di` へ置いた点（ファクトリと設定の形を同居させる方針）
- 環境変数・API・DB スキーマは不変で破壊的変更なし