### PR TITLE
feat: アクセスログを slog 化し Cloud Logging 対応とフォーマット切替を追加

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/watchlist"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/watchlist/watchlisthttp"
 	infradb "github.com/UCHIDAnobuhiro/stock-backend/internal/infra/db"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/infra/logging"
 	infraredis "github.com/UCHIDAnobuhiro/stock-backend/internal/infra/redis"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
@@ -45,10 +46,12 @@ func run() int {
 	if os.Getenv("LOG_LEVEL") == "DEBUG" {
 		logLevel = slog.LevelDebug
 	}
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
-		Level: logLevel,
-	}))
+	useJSON, formatOK := config.ParseLogFormat(os.Getenv("LOG_FORMAT"), os.Getenv("APP_ENV"))
+	logger := slog.New(logging.NewHandler(os.Stdout, logLevel, useJSON))
 	slog.SetDefault(logger)
+	if !formatOK {
+		slog.Warn("invalid LOG_FORMAT value, using default", "value", os.Getenv("LOG_FORMAT"))
+	}
 
 	// 環境変数を外部接続前に検証する
 	cfg, err := loadServerConfig()
@@ -141,7 +144,7 @@ func run() int {
 	watchlistH := watchlisthttp.NewHandler(watchlistUC)
 
 	// ルーター作成
-	r := router.NewRouter(authH, oauthH, candlesH, symbolH, logoH, watchlistH, rateLimiter, cfg.corsOrigins)
+	r := router.NewRouter(authH, oauthH, candlesH, symbolH, logoH, watchlistH, rateLimiter, cfg.corsOrigins, cfg.gcpProjectID)
 
 	slog.Info("Starting server", "port", 8080)
 	if err := r.Run(":8080"); err != nil {
@@ -157,6 +160,7 @@ type serverConfig struct {
 	passwordPepper string
 	secureCookie   bool
 	corsOrigins    []string
+	gcpProjectID   string          // GOOGLE_CLOUD_PROJECT。未設定可（トレース相関に使用）
 	oauth          *di.OAuthConfig // OAuth 無効なら nil
 }
 
@@ -198,6 +202,7 @@ func loadServerConfig() (serverConfig, error) {
 		passwordPepper: passwordPepper,
 		secureCookie:   secureCookie,
 		corsOrigins:    corsOrigins,
+		gcpProjectID:   os.Getenv("GOOGLE_CLOUD_PROJECT"),
 		oauth:          oauth,
 	}, nil
 }

--- a/cmd/batch/main.go
+++ b/cmd/batch/main.go
@@ -5,12 +5,15 @@ import (
 	"os"
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/app/batch"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/app/config"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/infra/logging"
 )
 
 // main はロガーを設定し、batch.Run の戻り値で os.Exit するだけの薄いラッパー。
 // os.Exit は defer を実行しないため、後処理が走るよう実体は internal/app/batch に分離している。
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	useJSON, _ := config.ParseLogFormat(os.Getenv("LOG_FORMAT"), os.Getenv("APP_ENV"))
+	logger := slog.New(logging.NewHandler(os.Stdout, slog.LevelInfo, useJSON))
 	slog.SetDefault(logger)
 
 	os.Exit(batch.Run(os.Args[1:]))

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -4,13 +4,16 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/app/config"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/app/migrate"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/infra/logging"
 )
 
 // main はロガーを設定し、migrate.Run の戻り値で os.Exit するだけの薄いラッパー。
 // os.Exit は defer を実行しないため、後処理が走るよう実体は internal/app/migrate に分離している。
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	useJSON, _ := config.ParseLogFormat(os.Getenv("LOG_FORMAT"), os.Getenv("APP_ENV"))
+	logger := slog.New(logging.NewHandler(os.Stdout, slog.LevelInfo, useJSON))
 	slog.SetDefault(logger)
 
 	os.Exit(migrate.Run(os.Args[1:]))

--- a/docker/example.env.app
+++ b/docker/example.env.app
@@ -4,6 +4,10 @@ APP_ENV=docker
 # ログレベル（任意。DEBUG を指定した場合のみ slog のレベルを下げる。未設定時は INFO 相当）
 # LOG_LEVEL=DEBUG
 
+# ログ出力フォーマット（任意。text | json）
+# 未設定時は APP_ENV で判定: production → json、それ以外（docker-dev 等）→ text
+# LOG_FORMAT=text
+
 # DB
 DB_HOST=db
 DB_PORT=5432

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -43,3 +43,26 @@ func ParseBoolString(raw string, fallback bool) (value bool, ok bool) {
 	}
 	return parsed, true
 }
+
+// ParseLogFormat はログ出力を JSON にするか Text にするかを決定する。
+//   - logFormatRaw が "json" / "text"（大小文字・前後空白は無視）の場合は
+//     その指定に従い (useJSON, true) を返す。
+//   - logFormatRaw が空文字の場合は appEnv にフォールバックし、
+//     appEnv が "production" のとき JSON とする ((useJSON, true))。
+//   - 上記以外の不正値の場合は appEnv ベースの既定値 + ok=false を返す。
+//     呼び出し側で警告ログなどの判断に利用する。
+//
+// env を直接読まず純粋な文字列を受け取るため、呼び出し側は os.Getenv 等で取得した値を渡す。
+func ParseLogFormat(logFormatRaw, appEnv string) (useJSON bool, ok bool) {
+	defaultJSON := appEnv == "production"
+	switch strings.ToLower(strings.TrimSpace(logFormatRaw)) {
+	case "":
+		return defaultJSON, true
+	case "json":
+		return true, true
+	case "text":
+		return false, true
+	default:
+		return defaultJSON, false
+	}
+}

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -150,3 +150,78 @@ func TestParseBoolString(t *testing.T) {
 		})
 	}
 }
+
+// TestParseLogFormat は LOG_FORMAT 明示指定と APP_ENV フォールバックの組み合わせを検証します。
+func TestParseLogFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		logFormatRaw string
+		appEnv       string
+		wantUseJSON  bool
+		wantOK       bool
+	}{
+		{
+			name:         "json 明示",
+			logFormatRaw: "json",
+			appEnv:       "docker-dev",
+			wantUseJSON:  true,
+			wantOK:       true,
+		},
+		{
+			name:         "text 明示は production でも text",
+			logFormatRaw: "text",
+			appEnv:       "production",
+			wantUseJSON:  false,
+			wantOK:       true,
+		},
+		{
+			name:         "大文字・前後空白は無視する",
+			logFormatRaw: "  JSON  ",
+			appEnv:       "docker-dev",
+			wantUseJSON:  true,
+			wantOK:       true,
+		},
+		{
+			name:         "未設定 + production は JSON",
+			logFormatRaw: "",
+			appEnv:       "production",
+			wantUseJSON:  true,
+			wantOK:       true,
+		},
+		{
+			name:         "未設定 + docker-dev は Text",
+			logFormatRaw: "",
+			appEnv:       "docker-dev",
+			wantUseJSON:  false,
+			wantOK:       true,
+		},
+		{
+			name:         "不正値は production フォールバックで JSON + ok=false",
+			logFormatRaw: "yaml",
+			appEnv:       "production",
+			wantUseJSON:  true,
+			wantOK:       false,
+		},
+		{
+			name:         "不正値は dev フォールバックで Text + ok=false",
+			logFormatRaw: "yaml",
+			appEnv:       "docker-dev",
+			wantUseJSON:  false,
+			wantOK:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotUseJSON, gotOK := ParseLogFormat(tt.logFormatRaw, tt.appEnv)
+			if gotUseJSON != tt.wantUseJSON || gotOK != tt.wantOK {
+				t.Errorf("ParseLogFormat(%q, %q) = (%v, %v), want (%v, %v)",
+					tt.logFormatRaw, tt.appEnv, gotUseJSON, gotOK, tt.wantUseJSON, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -28,8 +28,14 @@ func NewRouter(authHandler *authhttp.Handler, oauthHandler *authhttp.OAuthHandle
 	watchlist *watchlisthttp.Handler,
 	limiter *httpratelimit.Limiter,
 	allowedOrigins []string,
+	gcpProjectID string,
 ) *gin.Engine {
-	r := gin.Default()
+	// gin.Default() の代わりに gin.New() を使い、アクセスログを slog（構造化）で出力する。
+	// AccessLog を外側、Recovery を内側に置くことで、panic を 500 に変換した結果も
+	// アクセスログに記録される。
+	r := gin.New()
+	r.Use(httpmw.AccessLog(gcpProjectID))
+	r.Use(gin.Recovery())
 
 	// リバースプロキシを使用しない構成のため、X-Forwarded-For等のヘッダーを信頼しない
 	// c.ClientIP()がRemoteAddr（実際のTCP接続元）を返すようにする

--- a/internal/infra/logging/slog.go
+++ b/internal/infra/logging/slog.go
@@ -1,0 +1,54 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+)
+
+// NewHandler はログ出力フォーマットを切り替えて slog ハンドラーを生成します。
+//   - useJSON == true: Cloud Logging 対応の JSON ハンドラー（本番 / Cloud Run 向け）
+//   - useJSON == false: 人が読みやすいプレーンな TextHandler（ローカル開発向け）
+//
+// Text 形式は Cloud Logging 連携を前提としないため、severity / message への
+// リマップは行わず slog 既定のキー（level / msg）のまま出力します。
+func NewHandler(w io.Writer, level slog.Level, useJSON bool) slog.Handler {
+	if useJSON {
+		return NewCloudLoggingHandler(w, level)
+	}
+	return slog.NewTextHandler(w, &slog.HandlerOptions{Level: level})
+}
+
+// NewCloudLoggingHandler は Cloud Logging（Cloud Run）が構造化ログとして解釈できる
+// JSON ハンドラーを生成します。slog 既定のキー（level / msg）を Cloud Logging の
+// 特別フィールド（severity / message）にリマップします。time キーは既定のまま
+// （Cloud Logging が timestamp として解釈可能）です。
+//
+// これにより Cloud Logging 上で severity フィルタ・色分けが効き、メッセージ本文が
+// 正しく表示されます。
+func NewCloudLoggingHandler(w io.Writer, level slog.Level) slog.Handler {
+	return slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level:       level,
+		ReplaceAttr: cloudLoggingReplaceAttr,
+	})
+}
+
+// cloudLoggingReplaceAttr は slog の属性を Cloud Logging 仕様にリマップします。
+// httpRequest のようなネストしたグループ内のフィールドは対象外とするため、
+// トップレベル（len(groups) == 0）のキーのみを変換します。
+func cloudLoggingReplaceAttr(groups []string, a slog.Attr) slog.Attr {
+	if len(groups) > 0 {
+		return a
+	}
+	switch a.Key {
+	case slog.LevelKey:
+		a.Key = "severity"
+		// Cloud Logging の正式な severity 名は WARNING。slog の "WARN" は認識
+		// されないため明示的に置換する（INFO / ERROR / DEBUG はそのまま一致）。
+		if level, ok := a.Value.Any().(slog.Level); ok && level == slog.LevelWarn {
+			a.Value = slog.StringValue("WARNING")
+		}
+	case slog.MessageKey:
+		a.Key = "message"
+	}
+	return a
+}

--- a/internal/infra/logging/slog_test.go
+++ b/internal/infra/logging/slog_test.go
@@ -1,0 +1,151 @@
+package logging
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestNewCloudLoggingHandler_RemapsTopLevelKeys は level / msg が Cloud Logging の
+// severity / message にリマップされ、WARN が WARNING に変換されることを検証します。
+func TestNewCloudLoggingHandler_RemapsTopLevelKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		logFunc      func(l *slog.Logger)
+		wantSeverity string
+		wantMessage  string
+	}{
+		{
+			name:         "info",
+			logFunc:      func(l *slog.Logger) { l.Info("hello") },
+			wantSeverity: "INFO",
+			wantMessage:  "hello",
+		},
+		{
+			name:         "warn maps to WARNING",
+			logFunc:      func(l *slog.Logger) { l.Warn("careful") },
+			wantSeverity: "WARNING",
+			wantMessage:  "careful",
+		},
+		{
+			name:         "error",
+			logFunc:      func(l *slog.Logger) { l.Error("boom") },
+			wantSeverity: "ERROR",
+			wantMessage:  "boom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(NewCloudLoggingHandler(&buf, slog.LevelInfo))
+			tt.logFunc(logger)
+
+			got := decodeLog(t, buf.Bytes())
+
+			if got["severity"] != tt.wantSeverity {
+				t.Errorf("severity = %v, want %v", got["severity"], tt.wantSeverity)
+			}
+			if got["message"] != tt.wantMessage {
+				t.Errorf("message = %v, want %v", got["message"], tt.wantMessage)
+			}
+			// 既定キーが残っていないこと。
+			if _, ok := got["level"]; ok {
+				t.Errorf("unexpected 'level' key present: %v", got)
+			}
+			if _, ok := got["msg"]; ok {
+				t.Errorf("unexpected 'msg' key present: %v", got)
+			}
+		})
+	}
+}
+
+// TestNewCloudLoggingHandler_LeavesNestedKeys はネストしたグループ内のフィールドが
+// リマップ対象外であることを検証します（httpRequest の msg/level 等を壊さないため）。
+func TestNewCloudLoggingHandler_LeavesNestedKeys(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewCloudLoggingHandler(&buf, slog.LevelInfo))
+	logger.Info("request", slog.Any("httpRequest", map[string]any{
+		"requestMethod": "GET",
+		"status":        200,
+	}))
+
+	got := decodeLog(t, buf.Bytes())
+
+	req, ok := got["httpRequest"].(map[string]any)
+	if !ok {
+		t.Fatalf("httpRequest missing or wrong type: %v", got["httpRequest"])
+	}
+	if req["requestMethod"] != "GET" {
+		t.Errorf("httpRequest.requestMethod = %v, want GET", req["requestMethod"])
+	}
+}
+
+// TestNewCloudLoggingHandler_RespectsLevel は指定レベル未満のログが出力されないことを検証します。
+func TestNewCloudLoggingHandler_RespectsLevel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewCloudLoggingHandler(&buf, slog.LevelInfo))
+	logger.Debug("should be dropped")
+
+	if buf.Len() != 0 {
+		t.Errorf("expected no output for debug below info level, got: %s", buf.String())
+	}
+}
+
+// TestNewHandler_JSON は useJSON=true で Cloud Logging 対応の JSON を出力することを検証します。
+func TestNewHandler_JSON(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewHandler(&buf, slog.LevelInfo, true))
+	logger.Info("hello")
+
+	got := decodeLog(t, buf.Bytes())
+	if got["severity"] != "INFO" {
+		t.Errorf("severity = %v, want INFO", got["severity"])
+	}
+	if got["message"] != "hello" {
+		t.Errorf("message = %v, want hello", got["message"])
+	}
+}
+
+// TestNewHandler_Text は useJSON=false でプレーンな Text 形式（JSON ではない・既定キー）を
+// 出力することを検証します。
+func TestNewHandler_Text(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(NewHandler(&buf, slog.LevelInfo, false))
+	logger.Info("hello")
+
+	out := buf.String()
+	if json.Valid(bytes.TrimSpace(buf.Bytes())) {
+		t.Errorf("expected non-JSON text output, got: %s", out)
+	}
+	// Text 形式はリマップせず既定キー（level / msg）のまま。
+	if !strings.Contains(out, "level=INFO") {
+		t.Errorf("expected 'level=INFO' in text output, got: %s", out)
+	}
+	if !strings.Contains(out, "msg=hello") {
+		t.Errorf("expected 'msg=hello' in text output, got: %s", out)
+	}
+}
+
+func decodeLog(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("failed to parse log JSON: %v (raw=%s)", err, b)
+	}
+	return got
+}

--- a/internal/transport/middleware/access_log.go
+++ b/internal/transport/middleware/access_log.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AccessLog は各 HTTP リクエストを slog の構造化ログとして出力する Gin ミドルウェアを返します。
+// Gin 標準のテキストアクセスログ（gin.Logger）の代わりに使用し、Cloud Logging が解釈できる
+// httpRequest フィールドとトレース相関フィールドを出力します。
+//
+// projectID（GOOGLE_CLOUD_PROJECT）が指定されている場合、X-Cloud-Trace-Context ヘッダーから
+// トレース ID を抽出してログをリクエスト単位で相関させます。空の場合はトレースフィールドを
+// 出力しません。
+func AccessLog(projectID string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		path := c.Request.URL.Path
+		if raw := c.Request.URL.RawQuery; raw != "" {
+			path = path + "?" + raw
+		}
+
+		c.Next()
+
+		status := c.Writer.Status()
+		latency := time.Since(start)
+
+		responseSize := c.Writer.Size()
+		if responseSize < 0 {
+			responseSize = 0
+		}
+
+		// Cloud Logging の httpRequest 構造化フィールド。
+		// latency は protobuf Duration の JSON 表現（秒 + "s"）、サイズ系は文字列で表す。
+		attrs := []slog.Attr{
+			slog.Any("httpRequest", map[string]any{
+				"requestMethod": c.Request.Method,
+				"requestUrl":    path,
+				"status":        status,
+				"responseSize":  fmt.Sprintf("%d", responseSize),
+				"userAgent":     c.Request.UserAgent(),
+				"remoteIp":      c.ClientIP(),
+				"protocol":      c.Request.Proto,
+				"latency":       fmt.Sprintf("%.9fs", latency.Seconds()),
+			}),
+		}
+
+		if trace, span, ok := traceContext(projectID, c.Request.Header.Get("X-Cloud-Trace-Context")); ok {
+			attrs = append(attrs,
+				slog.String("logging.googleapis.com/trace", trace),
+				slog.String("logging.googleapis.com/spanId", span),
+			)
+		}
+
+		// Gin が収集したハンドラー内エラーがあれば付加する。
+		if msg := strings.TrimSpace(c.Errors.ByType(gin.ErrorTypePrivate).String()); msg != "" {
+			attrs = append(attrs, slog.String("error", msg))
+		}
+
+		slog.LogAttrs(c.Request.Context(), severityForStatus(status), "request", attrs...)
+	}
+}
+
+// severityForStatus は HTTP ステータスコードを slog のレベルに対応付けます。
+// 5xx は Error、4xx は Warn、それ以外は Info とします。
+func severityForStatus(status int) slog.Level {
+	switch {
+	case status >= http.StatusInternalServerError:
+		return slog.LevelError
+	case status >= http.StatusBadRequest:
+		return slog.LevelWarn
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// traceContext は X-Cloud-Trace-Context ヘッダー（"TRACE_ID/SPAN_ID;o=1" 形式）を
+// パースし、Cloud Logging が要求する trace リソース名と span ID を返します。
+// projectID が空、またはヘッダーから trace ID を取得できない場合は ok=false を返します。
+func traceContext(projectID, header string) (trace, span string, ok bool) {
+	if projectID == "" || header == "" {
+		return "", "", false
+	}
+
+	traceID := header
+	if i := strings.IndexByte(traceID, '/'); i >= 0 {
+		span = traceID[i+1:]
+		traceID = traceID[:i]
+		if j := strings.IndexByte(span, ';'); j >= 0 {
+			span = span[:j]
+		}
+	}
+	if traceID == "" {
+		return "", "", false
+	}
+
+	return fmt.Sprintf("projects/%s/traces/%s", projectID, traceID), span, true
+}

--- a/internal/transport/middleware/access_log_test.go
+++ b/internal/transport/middleware/access_log_test.go
@@ -1,0 +1,210 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMain は全テスト共通のテスト環境を設定します。
+func TestMain(m *testing.M) {
+	gin.SetMode(gin.TestMode)
+	m.Run()
+}
+
+func TestSeverityForStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		status int
+		want   slog.Level
+	}{
+		{http.StatusOK, slog.LevelInfo},
+		{http.StatusMovedPermanently, slog.LevelInfo},
+		{http.StatusBadRequest, slog.LevelWarn},
+		{http.StatusNotFound, slog.LevelWarn},
+		{http.StatusInternalServerError, slog.LevelError},
+		{http.StatusBadGateway, slog.LevelError},
+	}
+
+	for _, tt := range tests {
+		if got := severityForStatus(tt.status); got != tt.want {
+			t.Errorf("severityForStatus(%d) = %v, want %v", tt.status, got, tt.want)
+		}
+	}
+}
+
+func TestTraceContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		projectID string
+		header    string
+		wantTrace string
+		wantSpan  string
+		wantOK    bool
+	}{
+		{
+			name:      "full header with span and options",
+			projectID: "my-proj",
+			header:    "abc123/456;o=1",
+			wantTrace: "projects/my-proj/traces/abc123",
+			wantSpan:  "456",
+			wantOK:    true,
+		},
+		{
+			name:      "trace id only",
+			projectID: "my-proj",
+			header:    "abc123",
+			wantTrace: "projects/my-proj/traces/abc123",
+			wantSpan:  "",
+			wantOK:    true,
+		},
+		{
+			name:      "empty project disables trace",
+			projectID: "",
+			header:    "abc123/456;o=1",
+			wantOK:    false,
+		},
+		{
+			name:      "empty header",
+			projectID: "my-proj",
+			header:    "",
+			wantOK:    false,
+		},
+		{
+			name:      "empty trace id",
+			projectID: "my-proj",
+			header:    "/456;o=1",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			trace, span, ok := traceContext(tt.projectID, tt.header)
+			assert.Equal(t, tt.wantOK, ok)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantTrace, trace)
+				assert.Equal(t, tt.wantSpan, span)
+			}
+		})
+	}
+}
+
+// TestAccessLog_LogsStructuredRequest はミドルウェアがリクエストを slog の構造化ログとして
+// httpRequest フィールド付きで出力し、ステータスに応じた severity を設定することを検証します。
+func TestAccessLog_LogsStructuredRequest(t *testing.T) {
+	// 並列化しない: slog.Default() というグローバルを差し替えるため。
+	var buf bytes.Buffer
+	restore := swapDefaultLogger(&buf)
+	defer restore()
+
+	r := gin.New()
+	r.Use(AccessLog(""))
+	r.GET("/v1/symbols", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/symbols?interval=1day", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+
+	got := decodeLog(t, buf.Bytes())
+	assert.Equal(t, "INFO", got["severity"])
+	assert.Equal(t, "request", got["message"])
+
+	httpReq, ok := got["httpRequest"].(map[string]any)
+	require.True(t, ok, "httpRequest field missing: %v", got)
+	assert.Equal(t, http.MethodGet, httpReq["requestMethod"])
+	assert.Equal(t, "/v1/symbols?interval=1day", httpReq["requestUrl"])
+	assert.EqualValues(t, http.StatusOK, httpReq["status"])
+
+	// projectID が空のためトレースフィールドは出力されない。
+	_, hasTrace := got["logging.googleapis.com/trace"]
+	assert.False(t, hasTrace)
+}
+
+// TestAccessLog_IncludesTrace は projectID と X-Cloud-Trace-Context が揃っている場合に
+// トレース相関フィールドが出力されることを検証します。
+func TestAccessLog_IncludesTrace(t *testing.T) {
+	// 並列化しない: slog.Default() というグローバルを差し替えるため。
+	var buf bytes.Buffer
+	restore := swapDefaultLogger(&buf)
+	defer restore()
+
+	r := gin.New()
+	r.Use(AccessLog("my-proj"))
+	r.GET("/ping", func(c *gin.Context) { c.Status(http.StatusOK) })
+
+	req := httptest.NewRequest(http.MethodGet, "/ping", nil)
+	req.Header.Set("X-Cloud-Trace-Context", "trace-abc/span-1;o=1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	got := decodeLog(t, buf.Bytes())
+	assert.Equal(t, "projects/my-proj/traces/trace-abc", got["logging.googleapis.com/trace"])
+	assert.Equal(t, "span-1", got["logging.googleapis.com/spanId"])
+}
+
+// TestAccessLog_ErrorStatusSeverity は 5xx 応答で severity が ERROR になることを検証します。
+func TestAccessLog_ErrorStatusSeverity(t *testing.T) {
+	// 並列化しない: slog.Default() というグローバルを差し替えるため。
+	var buf bytes.Buffer
+	restore := swapDefaultLogger(&buf)
+	defer restore()
+
+	r := gin.New()
+	r.Use(AccessLog(""))
+	r.GET("/fail", func(c *gin.Context) { c.Status(http.StatusInternalServerError) })
+
+	req := httptest.NewRequest(http.MethodGet, "/fail", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	got := decodeLog(t, buf.Bytes())
+	assert.Equal(t, "ERROR", got["severity"])
+}
+
+// swapDefaultLogger は slog のデフォルトロガーをバッファ出力に差し替え、復元関数を返します。
+// テスト対象のミドルウェアが slog.LogAttrs を使うため、出力をキャプチャするのに使います。
+func swapDefaultLogger(buf *bytes.Buffer) func() {
+	prev := slog.Default()
+	// 本番と同じ severity/message リマップを再現するため簡易ハンドラを使う。
+	slog.SetDefault(slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) > 0 {
+				return a
+			}
+			switch a.Key {
+			case slog.LevelKey:
+				a.Key = "severity"
+			case slog.MessageKey:
+				a.Key = "message"
+			}
+			return a
+		},
+	})))
+	return func() { slog.SetDefault(prev) }
+}
+
+func decodeLog(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("failed to parse log JSON: %v (raw=%s)", err, b)
+	}
+	return got
+}


### PR DESCRIPTION
## 概要
Gin 標準のテキストアクセスログを slog による構造化ログへ置き換え、Cloud Run（Cloud Logging）でフィールド検索・severity フィルタ・トレース相関が効くようにする。あわせてローカル開発向けに Text / JSON の出力フォーマットを切り替えられるようにした。

## 変更内容
- **アクセスログの slog 化**: `gin.Default()` を `gin.New()` + `AccessLog` + `gin.Recovery()` に変更。`AccessLog` ミドルウェアが Cloud Logging の `httpRequest` 構造化フィールドと、`X-Cloud-Trace-Context` からのトレース相関（`logging.googleapis.com/trace`）を出力する
- **Cloud Logging 対応ハンドラー**: slog の `level`/`msg` を Cloud Logging の `severity`/`message` にリマップする `NewCloudLoggingHandler` を追加（`WARN`→`WARNING` 変換含む）
- **フォーマット切替**: `LOG_FORMAT`(text|json) と `APP_ENV` から出力形式を決める純粋関数 `ParseLogFormat` と、フォーマットを選ぶ `NewHandler` を追加。`production` は JSON、それ以外（docker-dev 等）は Text を既定とし、`LOG_FORMAT` で明示上書き可能
- **3 エントリへ適用**: api / batch / migrate すべてで上記ハンドラーを使用
- `docker/example.env.app` に `LOG_FORMAT` の説明を追記

## 補足（後方互換）
- `LOG_FORMAT` は任意の追加環境変数で、未設定でも従来通り動作する（既定は APP_ENV 判定）
- `router.NewRouter` に `gcpProjectID` 引数を追加（内部 DI のみ・外部 API 契約への影響なし）

## テスト
- `go build ./...` / `golangci-lint` / `go tool go-arch-lint check` 通過
- ユニットテスト追加: `ParseLogFormat`（config, 100%）・`NewHandler`/Cloud Logging リマップ（logging, 93.8%）・`AccessLog`/trace パース/severity 対応（middleware, 81.6%）
- 手動確認: docker-compose（`APP_ENV=docker-dev`）で Text 形式、`LOG_FORMAT=json` で Cloud Logging 構造化 JSON を確認

## レビューポイント
- `AccessLog` を外側・`gin.Recovery()` を内側に置き、panic 由来の 500 もアクセスログに記録される順序にしている点
- Text 形式では可読性優先で severity/message リマップを行わず slog 既定キーのまま出力している点

🤖 Generated with [Claude Code](https://claude.com/claude-code)