### PR TITLE
refactor: usecase を非公開化しフック interface の重複を解消

### DIFF
--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/auth"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/infra/logging"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/csrf"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
@@ -26,11 +27,6 @@ type Usecase interface {
 	Login(ctx context.Context, email, password string) (string, error)
 }
 
-// PostSignupHook はサインアップ成功後に呼び出されるフックのインターフェースです。
-type PostSignupHook interface {
-	OnUserCreated(ctx context.Context, userID int64) error
-}
-
 // ログインのメールベースレートリミット設定
 const (
 	loginEmailLimit  = 5                // 15分間のメールアドレスあたりの最大ログイン試行回数
@@ -40,18 +36,18 @@ const (
 // Handler は認証操作のHTTPリクエストを処理します。
 // Usecaseインターフェースに依存し、JSONリクエスト/レスポンスを処理します。
 type Handler struct {
-	auth         Usecase
+	uc           Usecase
 	limiter      *httpratelimit.Limiter
 	secureCookie bool
-	postHooks    []PostSignupHook
+	postHooks    []auth.UserCreatedHook
 }
 
 // NewHandler はHandlerの新しいインスタンスを生成します。
 // 依存性注入用のコンストラクタで、外部からUsecaseとレートリミッターを注入します。
 // secureCookie が true の場合、Secure属性付きのCookieを設定します（本番環境用）。
 // postHooks にはサインアップ後に実行するフックを任意で渡せます。
-func NewHandler(auth Usecase, limiter *httpratelimit.Limiter, secureCookie bool, postHooks ...PostSignupHook) *Handler {
-	return &Handler{auth: auth, limiter: limiter, secureCookie: secureCookie, postHooks: postHooks}
+func NewHandler(uc Usecase, limiter *httpratelimit.Limiter, secureCookie bool, postHooks ...auth.UserCreatedHook) *Handler {
+	return &Handler{uc: uc, limiter: limiter, secureCookie: secureCookie, postHooks: postHooks}
 }
 
 // Signup はユーザー登録APIエンドポイントを処理します。
@@ -66,7 +62,7 @@ func (h *Handler) Signup(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
 	}
-	userID, err := h.auth.Signup(c.Request.Context(), req.Email, req.Password)
+	userID, err := h.uc.Signup(c.Request.Context(), req.Email, req.Password)
 	if err != nil {
 		// ユーザー列挙攻撃を防止するため、実際のエラーを公開しない
 		slog.Warn("signup failed", "error", err, "email_hash", logging.HashedEmail(req.Email), "remote_addr", c.ClientIP())
@@ -111,7 +107,7 @@ func (h *Handler) Login(c *gin.Context) {
 		return
 	}
 
-	token, err := h.auth.Login(c.Request.Context(), req.Email, req.Password)
+	token, err := h.uc.Login(c.Request.Context(), req.Email, req.Password)
 	if err != nil {
 		// ユーザー列挙攻撃を防止するため、実際のエラーを公開しない
 		slog.Warn("login failed", "error", err, "email_hash", logging.HashedEmail(req.Email), "remote_addr", c.ClientIP())

--- a/internal/feature/symbollist/usecase.go
+++ b/internal/feature/symbollist/usecase.go
@@ -11,17 +11,17 @@ type Repository interface {
 	ListActive(ctx context.Context) ([]Symbol, error)
 }
 
-// Usecase は銘柄操作のビジネスロジックを提供します。
-type Usecase struct {
+// usecase は銘柄操作のビジネスロジックを提供します。
+type usecase struct {
 	repo Repository
 }
 
-// NewUsecase は指定されたリポジトリでUsecaseの新しいインスタンスを生成します。
-func NewUsecase(r Repository) *Usecase {
-	return &Usecase{repo: r}
+// NewUsecase は指定されたリポジトリでusecaseの新しいインスタンスを生成します。
+func NewUsecase(r Repository) *usecase {
+	return &usecase{repo: r}
 }
 
 // ListActiveSymbols はリポジトリからすべてのアクティブな銘柄を取得して返します。
-func (u *Usecase) ListActiveSymbols(ctx context.Context) ([]Symbol, error) {
+func (u *usecase) ListActiveSymbols(ctx context.Context) ([]Symbol, error) {
 	return u.repo.ListActive(ctx)
 }

--- a/internal/feature/watchlist/usecase.go
+++ b/internal/feature/watchlist/usecase.go
@@ -25,26 +25,26 @@ type SymbolExistsChecker interface {
 	Exists(ctx context.Context, code string) (bool, error)
 }
 
-// Usecase はウォッチリスト操作のビジネスロジックを提供します。
-type Usecase struct {
+// usecase はウォッチリスト操作のビジネスロジックを提供します。
+type usecase struct {
 	repo          Repository
 	symbolChecker SymbolExistsChecker
 }
 
-// NewUsecase は指定されたリポジトリと銘柄チェッカーで Usecase の新しいインスタンスを生成します。
-func NewUsecase(repo Repository, symbolChecker SymbolExistsChecker) *Usecase {
-	return &Usecase{repo: repo, symbolChecker: symbolChecker}
+// NewUsecase は指定されたリポジトリと銘柄チェッカーで usecase の新しいインスタンスを生成します。
+func NewUsecase(repo Repository, symbolChecker SymbolExistsChecker) *usecase {
+	return &usecase{repo: repo, symbolChecker: symbolChecker}
 }
 
 // ListUserSymbols はユーザーのウォッチリストをソート順で返します。
-func (u *Usecase) ListUserSymbols(ctx context.Context, userID int64) ([]UserSymbol, error) {
+func (u *usecase) ListUserSymbols(ctx context.Context, userID int64) ([]UserSymbol, error) {
 	return u.repo.ListByUser(ctx, userID)
 }
 
 // AddSymbol はウォッチリストに銘柄を追加します。
 // symbols テーブルに存在しない銘柄コードの場合は ErrSymbolNotFound を返します。
 // 既にウォッチリストに存在する場合は ErrAlreadyInWatchlist を返します。
-func (u *Usecase) AddSymbol(ctx context.Context, userID int64, symbolCode string) error {
+func (u *usecase) AddSymbol(ctx context.Context, userID int64, symbolCode string) error {
 	exists, err := u.symbolChecker.Exists(ctx, symbolCode)
 	if err != nil {
 		return fmt.Errorf("checking symbol existence: %w", err)
@@ -57,12 +57,12 @@ func (u *Usecase) AddSymbol(ctx context.Context, userID int64, symbolCode string
 }
 
 // RemoveSymbol はウォッチリストから銘柄を削除します。
-func (u *Usecase) RemoveSymbol(ctx context.Context, userID int64, symbolCode string) error {
+func (u *usecase) RemoveSymbol(ctx context.Context, userID int64, symbolCode string) error {
 	return u.repo.Remove(ctx, userID, symbolCode)
 }
 
 // ReorderSymbols はウォッチリストの並び順を更新します。
-func (u *Usecase) ReorderSymbols(ctx context.Context, userID int64, orderedCodes []string) error {
+func (u *usecase) ReorderSymbols(ctx context.Context, userID int64, orderedCodes []string) error {
 	entries := make([]UserSymbol, 0, len(orderedCodes))
 	for i, code := range orderedCodes {
 		entries = append(entries, UserSymbol{
@@ -76,13 +76,13 @@ func (u *Usecase) ReorderSymbols(ctx context.Context, userID int64, orderedCodes
 
 // OnUserCreated は PostSignupHook インターフェースを実装します。
 // サインアップ直後に呼ばれ、デフォルト銘柄を追加します。
-func (u *Usecase) OnUserCreated(ctx context.Context, userID int64) error {
+func (u *usecase) OnUserCreated(ctx context.Context, userID int64) error {
 	return u.InitializeDefaults(ctx, userID)
 }
 
 // InitializeDefaults は新規ユーザー向けにデフォルト銘柄（AAPL/MSFT/GOOGL）を追加します。
 // symbols テーブルに存在する銘柄のみ追加します（存在しない場合はスキップ）。
-func (u *Usecase) InitializeDefaults(ctx context.Context, userID int64) error {
+func (u *usecase) InitializeDefaults(ctx context.Context, userID int64) error {
 	defaultSymbols := []string{"AAPL", "MSFT", "GOOGL"}
 
 	for i, code := range defaultSymbols {


### PR DESCRIPTION
## 概要
コードレビューで見つかった「惰性で増えた不統一・重複」を解消するリファクタです。挙動の変更はなく、公開 API 表面を縮小して 5 feature の usecase 構成を対称化します。

## 変更内容
- watchlist / symbollist の usecase 型を `*Usecase` から `*usecase` へ非公開化し、candles / auth / logodetection と合わせて 5 feature の構成を統一
  - http ハンドラは consumer-defined interface 経由で usecase を受け取るため、具象型を公開する必要がない
  - バッチ用の `symbollist.LogoIngestUsecase` / `candles.IngestUsecase` は対象外（公開のまま維持）
- 同一シグネチャで重複していた `authhttp.PostSignupHook` を削除し、`auth.UserCreatedHook` に統合
- 統合に伴う名前衝突（import した `auth` パッケージと引数名 `auth`）を回避するため、`authhttp.Handler` のフィールド/引数を `auth` から `uc` にリネーム（sibling の candleshttp / watchlisthttp と命名統一）

## テスト
- `go build ./...` / `go test ./... -race` パス（既存テストはそのまま緑）
- `golangci-lint run` 0 issues、`go tool go-arch-lint check` 警告なし
- 型名を明示参照している外部箇所は調査の結果ゼロ（生成は全て `:=`、http は interface 経由）で破壊的変更なし

## レビューポイント
- 非公開化対象を「http 経由で消費される read usecase」に限定し、バッチ用 usecase を公開のまま残した判断