### PR TITLE
fix: コードレビュー指摘の修正（キャッシュ定数の統一・HTTPエラー応答の統一）

### DIFF
--- a/internal/feature/candles/caching_repository.go
+++ b/internal/feature/candles/caching_repository.go
@@ -10,10 +10,6 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// maxCacheOutputSize はキャッシュに保存する最大ローソク足件数です。
-// usecaseのMaxOutputSizeと合わせています（依存ルール上usecaseをimport不可のためここで定義）。
-const maxCacheOutputSize = 5000
-
 // DefaultCacheTTL はingestの連続失敗時に古いデータが残り続けないためのセーフティネットTTL。
 // 通常運用ではingestのUpsertBatchによりキャッシュが日次で上書きされるため、
 // この値はフォールバックとしてのみ機能する。
@@ -77,7 +73,7 @@ func (c *CachingRepository) UpsertBatch(ctx context.Context, candles []Candle) e
 		key := c.cacheKey(si.symbol, si.interval)
 		_ = c.rdb.Del(ctx, key).Err() // ベストエフォート
 
-		data, err := c.inner.Find(ctx, si.symbol, si.interval, maxCacheOutputSize)
+		data, err := c.inner.Find(ctx, si.symbol, si.interval, MaxOutputSize)
 		if err != nil {
 			continue // ベストエフォート: エラー時はウォームアップをスキップ
 		}
@@ -89,7 +85,7 @@ func (c *CachingRepository) UpsertBatch(ctx context.Context, candles []Candle) e
 }
 
 // Find はローソク足データを取得します。まずキャッシュを確認し、なければデータベースにフォールバックします。
-// キャッシュには全データ（最大maxCacheOutputSize件）を保存し、outputsize件にスライスして返します。
+// キャッシュには全データ（最大MaxOutputSize件）を保存し、outputsize件にスライスして返します。
 func (c *CachingRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 	// Redisが未設定の場合はキャッシュをバイパス
 	if c.rdb == nil {
@@ -109,7 +105,7 @@ func (c *CachingRepository) Find(ctx context.Context, symbol, interval string, o
 	}
 
 	// 2) データベースにフォールバック（全データ取得してキャッシュに保存）
-	all, err := c.inner.Find(ctx, symbol, interval, maxCacheOutputSize)
+	all, err := c.inner.Find(ctx, symbol, interval, MaxOutputSize)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/feature/candles/caching_repository_test.go
+++ b/internal/feature/candles/caching_repository_test.go
@@ -201,9 +201,9 @@ func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 
 	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
-			// maxCacheOutputSize(5000) で呼ばれることを検証
-			if outputsize != maxCacheOutputSize {
-				t.Errorf("expected outputsize %d, got %d", maxCacheOutputSize, outputsize)
+			// MaxOutputSize(5000) で呼ばれることを検証
+			if outputsize != MaxOutputSize {
+				t.Errorf("expected outputsize %d, got %d", MaxOutputSize, outputsize)
 			}
 			return expectedCandles, nil
 		},

--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -2,6 +2,7 @@ package candleshttp
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -46,7 +47,8 @@ func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 
 	candles, err := h.uc.GetCandles(r.Context(), code, interval, outputsize)
 	if err != nil {
-		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: err.Error()})
+		slog.Error("failed to get candles", "error", err, "code", code)
+		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
 		return
 	}
 

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -68,7 +68,7 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
 				return nil, errors.New("internal server error")
 			},
-			expectedStatus: http.StatusBadGateway,
+			expectedStatus: http.StatusInternalServerError,
 			expectedBody:   `{"error":"internal server error"}`,
 		},
 		{

--- a/internal/feature/symbollist/symbollisthttp/handler.go
+++ b/internal/feature/symbollist/symbollisthttp/handler.go
@@ -2,6 +2,7 @@ package symbollisthttp
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
@@ -31,7 +32,8 @@ func NewHandler(uc Usecase) *Handler {
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	symbols, err := h.uc.ListActiveSymbols(r.Context())
 	if err != nil {
-		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: err.Error()})
+		slog.Error("failed to list symbols", "error", err)
+		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
 		return
 	}
 	out := make([]api.SymbolItem, 0, len(symbols))

--- a/internal/feature/symbollist/symbollisthttp/handler_test.go
+++ b/internal/feature/symbollist/symbollisthttp/handler_test.go
@@ -83,7 +83,7 @@ func TestSymbolHandler_List(t *testing.T) {
 				return nil, errors.New("database connection failed")
 			},
 			expectedStatus: http.StatusInternalServerError,
-			expectedBody:   `{"error":"database connection failed"}`,
+			expectedBody:   `{"error":"internal server error"}`,
 		},
 		{
 			name: "success: returns nil from usecase",


### PR DESCRIPTION
## 概要

プロジェクト全体のコードレビューで挙がったポリッシュレベルの指摘のうち、実効性の高い2点を修正します。責務分離・Go 慣例の構造的な問題はなく、いずれも軽微な改善です。

## 変更内容

### 1. キャッシュ件数上限を `MaxOutputSize` に統一
- `CachingRepository` 内で重複定義していた `maxCacheOutputSize` 定数を削除し、同一 `package candles` の `MaxOutputSize` を直接参照するよう変更。
- 「依存ルール上 usecase を import 不可」という事実誤認のコメントを除去（同一パッケージのため import 不要）。値ずれの温床を解消。

### 2. 読み取りハンドラのエラー応答を統一
- `candles` / `symbollist` のハンドラで `err.Error()` をそのままクライアントへ返していた箇所を、`slog.Error` でログ出力しつつ汎用メッセージを返すよう変更し、内部エラー詳細の漏洩を解消（watchlist / auth と同方針に統一）。
- `candles` の読み取りエラーのステータスを `502 BadGateway` → `500 InternalServerError` に修正（読み取り経路に上流外部 API はないため）。
- 対応するテストのアサーションを追従。

## 検証

- `go build ./...` / `go vet` ✅
- `go tool go-arch-lint check` → OK（依存ルール違反なし）
- `golangci-lint run`（対象パッケージ）→ 0 issues
- 対象テスト（candleshttp / symbollisthttp / caching）→ すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)