### PR TITLE
refactor: 未使用の symbollist.ListActiveCodes を削除

### DIFF
--- a/docs/features/symbollist.md
+++ b/docs/features/symbollist.md
@@ -165,7 +165,6 @@ graph TB
 - **repository**: sqlc + database/sql ベースのリポジトリ実装。`Repository` と `LogoSymbolRepository` の両インターフェースを満たす
   - `ListActive(ctx)`: コード昇順でアクティブな銘柄を返す
   - `UpdateLogoURL(ctx, code, logoURL, updatedAt)`: 指定銘柄のロゴ URL と取得日時を更新（対象行が無い場合は警告ログのみ）
-  - `ListActiveCodes(ctx)`: アクティブな銘柄のコードのみを返す（補助メソッド）
   - `Exists(ctx, code)`: 指定コードの銘柄存在チェック
 
 なお、candles フィーチャーの `IngestUsecase` が要求する `SymbolRepository`（`ListActiveSymbols(ctx) ([]ActiveSymbol, error)`）は、`internal/app/di/ingest_symbol.go` のアダプターで `repository.ListActive` の結果を変換することで満たしています。これによりフィーチャー間の直接依存を避けています。

--- a/internal/feature/symbollist/repository.go
+++ b/internal/feature/symbollist/repository.go
@@ -38,11 +38,6 @@ func (r *repository) ListActive(ctx context.Context) ([]Symbol, error) {
 	return out, nil
 }
 
-// ListActiveCodes はコード昇順にアクティブな銘柄のコードのみを返します。
-func (r *repository) ListActiveCodes(ctx context.Context) ([]string, error) {
-	return r.q.ListActiveSymbolCodes(ctx)
-}
-
 // Exists は指定されたコードの銘柄が存在するかを返します。
 func (r *repository) Exists(ctx context.Context, code string) (bool, error) {
 	return r.q.SymbolExists(ctx, code)

--- a/internal/feature/symbollist/repository_test.go
+++ b/internal/feature/symbollist/repository_test.go
@@ -162,69 +162,6 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 	}
 }
 
-func TestSymbolRepository_ListActiveCodes(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		setupFunc     func(t *testing.T, db *sql.DB)
-		expectedCodes []string
-	}{
-		{
-			name: "success: returns active symbol codes sorted by code",
-			setupFunc: func(t *testing.T, db *sql.DB) {
-				seedSymbol(t, db, "9984.T", "SoftBank Group", "TSE", true)
-				seedSymbol(t, db, "6758.T", "Sony Group", "TSE", true)
-				seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
-			},
-			expectedCodes: []string{"6758.T", "7203.T", "9984.T"},
-		},
-		{
-			name: "success: excludes inactive symbol codes",
-			setupFunc: func(t *testing.T, db *sql.DB) {
-				seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
-				inactive := seedSymbol(t, db, "6758.T", "Sony Group", "TSE", true)
-				updateSymbolActive(t, db, inactive, false)
-				seedSymbol(t, db, "9984.T", "SoftBank Group", "TSE", true)
-			},
-			expectedCodes: []string{"7203.T", "9984.T"},
-		},
-		{
-			name:          "success: returns empty list when no symbols",
-			setupFunc:     func(t *testing.T, db *sql.DB) {},
-			expectedCodes: []string{},
-		},
-		{
-			name: "success: returns empty list when all symbols are inactive",
-			setupFunc: func(t *testing.T, db *sql.DB) {
-				s1 := seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
-				updateSymbolActive(t, db, s1, false)
-				s2 := seedSymbol(t, db, "6758.T", "Sony Group", "TSE", true)
-				updateSymbolActive(t, db, s2, false)
-			},
-			expectedCodes: []string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			db := setupTestDB(t)
-			repo := NewRepository(db)
-			if tt.setupFunc != nil {
-				tt.setupFunc(t, db)
-			}
-			codes, err := repo.ListActiveCodes(context.Background())
-			require.NoError(t, err)
-			if len(tt.expectedCodes) == 0 {
-				assert.Empty(t, codes)
-			} else {
-				assert.Equal(t, tt.expectedCodes, codes)
-			}
-		})
-	}
-}
-
 func TestSymbolRepository_ListActive_FieldValues(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/internal/feature/symbollist/sqlc/querier.go
+++ b/internal/feature/symbollist/sqlc/querier.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Querier interface {
-	ListActiveSymbolCodes(ctx context.Context) ([]string, error)
 	ListActiveSymbols(ctx context.Context) ([]Symbol, error)
 	SymbolExists(ctx context.Context, code string) (bool, error)
 	UpdateSymbolLogoURL(ctx context.Context, arg UpdateSymbolLogoURLParams) (int64, error)

--- a/internal/feature/symbollist/sqlc/queries.sql
+++ b/internal/feature/symbollist/sqlc/queries.sql
@@ -4,12 +4,6 @@ FROM symbols
 WHERE is_active = TRUE
 ORDER BY code ASC;
 
--- name: ListActiveSymbolCodes :many
-SELECT code
-FROM symbols
-WHERE is_active = TRUE
-ORDER BY code ASC;
-
 -- name: SymbolExists :one
 SELECT EXISTS (
   SELECT 1 FROM symbols WHERE code = $1

--- a/internal/feature/symbollist/sqlc/queries.sql.go
+++ b/internal/feature/symbollist/sqlc/queries.sql.go
@@ -10,36 +10,6 @@ import (
 	"database/sql"
 )
 
-const listActiveSymbolCodes = `-- name: ListActiveSymbolCodes :many
-SELECT code
-FROM symbols
-WHERE is_active = TRUE
-ORDER BY code ASC
-`
-
-func (q *Queries) ListActiveSymbolCodes(ctx context.Context) ([]string, error) {
-	rows, err := q.db.QueryContext(ctx, listActiveSymbolCodes)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var code string
-		if err := rows.Scan(&code); err != nil {
-			return nil, err
-		}
-		items = append(items, code)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const listActiveSymbols = `-- name: ListActiveSymbols :many
 SELECT id, code, name, market, timezone, logo_url, logo_updated_at, is_active, created_at, updated_at
 FROM symbols


### PR DESCRIPTION
## 概要
symbollist の `repository.ListActiveCodes` がどのインターフェース契約（`Repository` / `LogoSymbolRepository` / watchlist の `symbolChecker`）からも参照されず、本番コードからの呼び出しが一切ないデッドコードだったため削除しました。

## 変更内容
- `internal/feature/symbollist/repository.go` の `ListActiveCodes` メソッドを削除
- `sqlc/queries.sql` の `ListActiveSymbolCodes` クエリを削除し、`go tool sqlc generate` で生成コード（`querier.go` / `queries.sql.go`）を更新
- `repository_test.go` の `TestSymbolRepository_ListActiveCodes` を削除
- `docs/features/symbollist.md` の該当メソッド記載を削除

なお `candles/ingest_test.go` のテスト名に含まれる "ListActiveCodes" は candles 側の独立した命名であり、本変更とは無関係のため変更していません。

## テスト
- `go build ./...` — 成功
- `golangci-lint run` — 0 issues
- `go tool go-arch-lint check` — No warnings
- `go test ./internal/feature/symbollist/... -race` — ok