### PR TITLE
ci: govulncheck による脆弱性スキャンと Dependabot を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot 設定。
+# Go モジュールと GitHub Actions の依存を週次でチェックし、更新 PR を自動作成する。
+# セキュリティアドバイザリ該当の更新はスケジュールに関係なく即時 PR が作成される。
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,27 @@ jobs:
       - name: Run go-arch-lint
         run: go tool go-arch-lint check
 
+  # 既知脆弱性スキャン（govulncheck、Go vulnerability database 照合）
+  vuln-scan:
+    name: Vulnerability Scan
+    needs: docs-check
+    if: needs.docs-check.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26.x"
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        run: govulncheck ./...
+
   # ビルド確認とテスト実行
   build-test:
     name: Build & Test
@@ -181,7 +202,7 @@ jobs:
   # GitHub Branch Protectionではこのジョブだけをrequiredに設定する
   ci-gate:
     name: CI Gate
-    needs: [lint, arch-lint, build-test, schema-doc-check]
+    needs: [lint, arch-lint, vuln-scan, build-test, schema-doc-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -189,11 +210,13 @@ jobs:
         run: |
           LINT="${{ needs.lint.result }}"
           ARCH_LINT="${{ needs.arch-lint.result }}"
+          VULN_SCAN="${{ needs.vuln-scan.result }}"
           BUILD_TEST="${{ needs.build-test.result }}"
           SCHEMA_DOC="${{ needs.schema-doc-check.result }}"
-          echo "lint=${LINT} arch-lint=${ARCH_LINT} build-test=${BUILD_TEST} schema-doc=${SCHEMA_DOC}"
+          echo "lint=${LINT} arch-lint=${ARCH_LINT} vuln-scan=${VULN_SCAN} build-test=${BUILD_TEST} schema-doc=${SCHEMA_DOC}"
           if [[ "${LINT}" == "success" || "${LINT}" == "skipped" ]] && \
              [[ "${ARCH_LINT}" == "success" || "${ARCH_LINT}" == "skipped" ]] && \
+             [[ "${VULN_SCAN}" == "success" || "${VULN_SCAN}" == "skipped" ]] && \
              [[ "${BUILD_TEST}" == "success" || "${BUILD_TEST}" == "skipped" ]] && \
              [[ "${SCHEMA_DOC}" == "success" || "${SCHEMA_DOC}" == "skipped" ]]; then
             echo "CI passed"


### PR DESCRIPTION
## 概要

セキュリティ検査で「CI に既知脆弱性（CVE）のスキャンが組み込まれていない」ことが判明したため、CI への脆弱性スキャン追加と Dependabot の有効化を行います。

## 変更内容

### 1. CI に脆弱性スキャンジョブを追加（`.github/workflows/ci.yaml`）

- `vuln-scan` ジョブを新設し、`govulncheck` で依存パッケージ・標準ライブラリを Go vulnerability database と照合します
- 既存ジョブと同様に `docs-check` に依存し、ドキュメントのみの変更ではスキップされます
- `ci-gate` の集約対象に追加したため、脆弱性検出時は CI が失敗します（Branch Protection は ci-gate のみ required の運用のため、ゲートへの組み込みで保護が有効になります）

### 2. Dependabot 設定を追加（`.github/dependabot.yml`）

- Go モジュールと GitHub Actions の依存を週次（月曜・JST）でチェックし、更新 PR を自動作成します
- セキュリティアドバイザリに該当する更新はスケジュールを待たず即時 PR が作成されるため、PR 契機でしか動かない CI スキャンの隙間（新規 CVE 公開時）を補完します
- レビュー負荷を抑えるため、オープン PR 数は各エコシステム 5 件までに制限しています

## 動作確認

- ci.yaml / dependabot.yml の YAML 構文検証済み
- この PR の CI 自体が `vuln-scan` ジョブの初回実行になります

https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT