### PR TITLE
feat: パスワードの最低文字数を8文字から12文字に強化

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -559,10 +559,10 @@ components:
             binding: "required,email"
         password:
           type: string
-          minLength: 8
-          description: パスワード（8文字以上）
+          minLength: 12
+          description: パスワード（12文字以上）
           x-oapi-codegen-extra-tags:
-            binding: "required,min=8"
+            binding: "required,min=12"
 
     LoginRequest:
       type: object

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -244,7 +244,7 @@ sequenceDiagram
 
 **バリデーションルール**
 - `email`: 必須、有効なメールアドレス形式
-- `password`: 必須、最低8文字
+- `password`: 必須、最低12文字
 
 **レスポンス**
 
@@ -499,7 +499,7 @@ graph TB
 
 #### Usecase層
 - **Usecase**（[usecase.go](../../internal/feature/auth/usecase.go)）: 認証ビジネスロジックを実装
-  - パスワードバリデーション（最低8文字）
+  - パスワードバリデーション（最低12文字）
   - パスワードハッシュ化（bcrypt + HMAC-SHA256 ペッパー）
   - タイミング攻撃を防止するパスワード検証（ユーザー未検出時もbcrypt比較を実行）
   - UserRepository / JWTGenerator / UserCreatedHook インターフェースを定義

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -111,8 +111,8 @@ type SignupRequest struct {
 	// Email メールアドレス
 	Email string `binding:"required,email" json:"email"`
 
-	// Password パスワード（8文字以上）
-	Password string `binding:"required,min=8" json:"password"`
+	// Password パスワード（12文字以上）
+	Password string `binding:"required,min=12" json:"password"`
 }
 
 // SymbolItem defines model for SymbolItem.

--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -120,14 +120,14 @@ func TestAuthHandler_Signup(t *testing.T) {
 	}{
 		{
 			name:           "success: user registration",
-			requestBody:    H{"email": "test@example.com", "password": "password123"},
+			requestBody:    H{"email": "test@example.com", "password": "password12345"},
 			mockSignupFunc: func(ctx context.Context, email, password string) (int64, error) { return 1, nil },
 			expectedStatus: http.StatusCreated,
 			expectedBody:   H{"message": "ok"},
 		},
 		{
 			name:           "failure: invalid email address",
-			requestBody:    H{"email": "invalid-email", "password": "password123"},
+			requestBody:    H{"email": "invalid-email", "password": "password12345"},
 			mockSignupFunc: nil, // Usecaseは呼ばれない
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   H{"error": "invalid request"},
@@ -141,7 +141,7 @@ func TestAuthHandler_Signup(t *testing.T) {
 		},
 		{
 			name:        "failure: duplicate email (usecase error)",
-			requestBody: H{"email": "existing@example.com", "password": "password123"},
+			requestBody: H{"email": "existing@example.com", "password": "password12345"},
 			mockSignupFunc: func(ctx context.Context, email, password string) (int64, error) {
 				return 0, errors.New("email already exists")
 			},
@@ -189,7 +189,7 @@ func TestAuthHandler_Login_RateLimited(t *testing.T) {
 
 	w := makeRequest(t, h.Login, http.MethodPost, "/login", H{
 		"email":    "test@example.com",
-		"password": "password123",
+		"password": "password12345",
 	})
 
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
@@ -219,7 +219,7 @@ func TestAuthHandler_Login(t *testing.T) {
 	}{
 		{
 			name:           "success: user login",
-			requestBody:    H{"email": "test@example.com", "password": "password123"},
+			requestBody:    H{"email": "test@example.com", "password": "password12345"},
 			mockLoginFunc:  func(ctx context.Context, email, password string) (string, error) { return "dummy-jwt-token", nil },
 			expectedStatus: http.StatusOK,
 			expectedBody:   H{"message": "ok"},
@@ -228,7 +228,7 @@ func TestAuthHandler_Login(t *testing.T) {
 		},
 		{
 			name:           "success: user login (secureCookie=true)",
-			requestBody:    H{"email": "test@example.com", "password": "password123"},
+			requestBody:    H{"email": "test@example.com", "password": "password12345"},
 			mockLoginFunc:  func(ctx context.Context, email, password string) (string, error) { return "dummy-jwt-token", nil },
 			expectedStatus: http.StatusOK,
 			expectedBody:   H{"message": "ok"},
@@ -237,7 +237,7 @@ func TestAuthHandler_Login(t *testing.T) {
 		},
 		{
 			name:           "failure: invalid email address",
-			requestBody:    H{"email": "invalid-email", "password": "password123"},
+			requestBody:    H{"email": "invalid-email", "password": "password12345"},
 			mockLoginFunc:  nil, // Usecaseは呼ばれない
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   H{"error": "invalid request"},
@@ -260,7 +260,7 @@ func TestAuthHandler_Login(t *testing.T) {
 		},
 		{
 			name:        "failure: JWT secret not set (usecase error)",
-			requestBody: H{"email": "test@example.com", "password": "password123"},
+			requestBody: H{"email": "test@example.com", "password": "password12345"},
 			mockLoginFunc: func(ctx context.Context, email, password string) (string, error) {
 				return "", errors.New("server misconfigured: JWT_SECRET missing")
 			},

--- a/internal/feature/auth/usecase.go
+++ b/internal/feature/auth/usecase.go
@@ -13,7 +13,9 @@ import (
 
 const (
 	// minPasswordLength はパスワードの最低文字数を定義します。
-	minPasswordLength = 8
+	// NIST SP 800-63B はユーザー選択パスワードに 8 文字以上を要求しているが、
+	// 辞書攻撃への耐性を高めるため、より長い 12 文字を最低長とする。
+	minPasswordLength = 12
 
 	// EnvKeyPasswordPepper はパスワードペッパーの環境変数キーです。
 	EnvKeyPasswordPepper = "PASSWORD_PEPPER"

--- a/internal/feature/auth/usecase_test.go
+++ b/internal/feature/auth/usecase_test.go
@@ -142,7 +142,7 @@ func TestAuthUsecase_Signup(t *testing.T) {
 		{
 			name:             "successful signup",
 			email:            "test@example.com",
-			password:         "password123",
+			password:         "password12345",
 			wantErr:          false,
 			verifyBcryptHash: true,
 		},
@@ -151,12 +151,12 @@ func TestAuthUsecase_Signup(t *testing.T) {
 			email:    "test@example.com",
 			password: "short",
 			wantErr:  true,
-			errMsg:   "password must be at least 8 characters long",
+			errMsg:   "password must be at least 12 characters long",
 		},
 		{
 			name:             "password at minimum length",
 			email:            "test@example.com",
-			password:         "12345678",
+			password:         "123456789012",
 			wantErr:          false,
 			verifyBcryptHash: true,
 		},
@@ -165,7 +165,7 @@ func TestAuthUsecase_Signup(t *testing.T) {
 			email:    "test@example.com",
 			password: "",
 			wantErr:  true,
-			errMsg:   "password must be at least 8 characters long",
+			errMsg:   "password must be at least 12 characters long",
 		},
 		{
 			name:             "long password",
@@ -177,7 +177,7 @@ func TestAuthUsecase_Signup(t *testing.T) {
 		{
 			name:          "repository create failure",
 			email:         "test@example.com",
-			password:      "password123",
+			password:      "password12345",
 			wantErr:       true,
 			repositoryErr: errors.New("database error"),
 		},
@@ -216,7 +216,7 @@ func TestAuthUsecase_Login(t *testing.T) {
 	t.Parallel() // enable parallel execution for test function
 
 	// Create test user using helper function
-	testUser := createTestUser(t, 1, "test@example.com", "password123")
+	testUser := createTestUser(t, 1, "test@example.com", "password12345")
 
 	tests := []struct {
 		name              string
@@ -233,7 +233,7 @@ func TestAuthUsecase_Login(t *testing.T) {
 		{
 			name:              "successful login",
 			email:             "test@example.com",
-			password:          "password123",
+			password:          "password12345",
 			wantErr:           false,
 			expectedToken:     "mock-jwt-token",
 			findByEmailResult: testUser,
@@ -242,7 +242,7 @@ func TestAuthUsecase_Login(t *testing.T) {
 		{
 			name:           "user not found",
 			email:          "wrong@example.com",
-			password:       "password123",
+			password:       "password12345",
 			wantErr:        true,
 			errMsg:         "invalid email or password",
 			findByEmailErr: errors.New("user not found"),
@@ -258,7 +258,7 @@ func TestAuthUsecase_Login(t *testing.T) {
 		{
 			name:              "JWT generation failure",
 			email:             "test@example.com",
-			password:          "password123",
+			password:          "password12345",
 			wantErr:           true,
 			errMsg:            "failed to generate token: failed to sign token",
 			findByEmailResult: testUser,
@@ -329,12 +329,12 @@ func TestAuthUsecase_PepperApplied(t *testing.T) {
 		mockRepo := &mockUserRepository{
 			CreateFunc: func(ctx context.Context, user *auth.User) error {
 				// 生パスワードではハッシュが一致しないことを確認
-				err := bcrypt.CompareHashAndPassword([]byte(*user.Password), []byte("password123"))
+				err := bcrypt.CompareHashAndPassword([]byte(*user.Password), []byte("password12345"))
 				if err == nil {
 					t.Error("hash should not match raw password when pepper is applied")
 				}
 				// ペッパー適用済みパスワードでは一致することを確認
-				peppered := pepperPasswordForTest("password123", testPepper)
+				peppered := pepperPasswordForTest("password12345", testPepper)
 				if err := bcrypt.CompareHashAndPassword([]byte(*user.Password), []byte(peppered)); err != nil {
 					t.Errorf("hash should match peppered password: %v", err)
 				}
@@ -344,7 +344,7 @@ func TestAuthUsecase_PepperApplied(t *testing.T) {
 		mockJWT := &mockJWTGenerator{}
 
 		uc := auth.NewUsecase(mockRepo, mockJWT, testPepper)
-		_, err := uc.Signup(context.Background(), "test@example.com", "password123")
+		_, err := uc.Signup(context.Background(), "test@example.com", "password12345")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## 概要

セキュリティ検査の指摘（パスワードポリシーが最小限）への対応。辞書攻撃への耐性を高めるため、新規登録時のパスワード最低文字数を8文字から12文字に引き上げます。

## 変更内容

- auth usecase の `minPasswordLength` を 12 に変更（NIST SP 800-63B の最低要件 8 文字より長く設定）
- OpenAPI 仕様（`SignupRequest.password`）の `minLength` / `binding` を 12 に更新し、`internal/api/types.gen.go` を再生成
- テストを12文字基準に更新（境界値テスト含む）
- `docs/features/auth.md` の記載を更新

## 影響範囲

- 影響があるのは**新規登録（signup）のみ**。ログインはパスワード長を再検証しないため、既存ユーザー（8〜11文字のパスワード）はそのままログイン可能です
- フロントエンドのバリデーションメッセージがある場合は合わせて更新が必要です

## 動作確認

- auth 配下の全テスト合格（実 PostgreSQL 使用、`-race` 付き）

https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT

---
_Generated by [Claude Code](https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT)_