### PR TITLE
fix: 外部APIから取得したロゴURLのスキーム検証を追加

### DIFF
--- a/internal/feature/candles/twelvedata/logo.go
+++ b/internal/feature/candles/twelvedata/logo.go
@@ -44,5 +44,25 @@ func (t *TwelveDataMarket) GetLogoURL(ctx context.Context, symbol string) (strin
 	if logoURL == "" {
 		return "", fmt.Errorf("twelvedata: empty logo url for %q", symbol)
 	}
+	if err := validateLogoURL(logoURL); err != nil {
+		return "", fmt.Errorf("twelvedata: invalid logo url for %q: %w", symbol, err)
+	}
 	return logoURL, nil
+}
+
+// validateLogoURL は外部APIが返したロゴURLを検証します。
+// 取得したURLはDBに保存されフロントエンドへ配信されるため、
+// https以外のスキーム（javascript: 等）やホスト欠落のURLを拒否します。
+func validateLogoURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if u.Scheme != "https" {
+		return fmt.Errorf("scheme must be https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing host")
+	}
+	return nil
 }

--- a/internal/feature/candles/twelvedata/logo_test.go
+++ b/internal/feature/candles/twelvedata/logo_test.go
@@ -98,6 +98,44 @@ func TestTwelveDataMarket_GetLogoURL_InvalidJSON(t *testing.T) {
 	}
 }
 
+func TestTwelveDataMarket_GetLogoURL_InvalidURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		logoURL string
+	}{
+		{name: "http scheme", logoURL: "http://api.twelvedata.com/logo/apple.com"},
+		{name: "javascript scheme", logoURL: "javascript:alert(1)"},
+		{name: "scheme relative", logoURL: "//api.twelvedata.com/logo/apple.com"},
+		{name: "missing host", logoURL: "https:///logo/apple.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"meta":{"symbol":"AAPL"},"url":"` + tt.logoURL + `"}`))
+			}))
+			defer server.Close()
+
+			market := NewTwelveDataMarket(Config{TwelveDataAPIKey: "test-key", BaseURL: server.URL}, server.Client())
+
+			_, err := market.GetLogoURL(context.Background(), "AAPL")
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "invalid logo url") {
+				t.Errorf("expected invalid logo url error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestTwelveDataMarket_GetLogoURL_EmptyURL(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概要

セキュリティ検査の指摘への対応。Twelve Data の Logo endpoint が返すロゴURLはDBに保存されフロントエンドへ配信されるため、信頼境界の外から来る値として検証を追加します。

## 変更内容

- `GetLogoURL` に `validateLogoURL` を追加し、以下を拒否
  - https 以外のスキーム（`http:`、`javascript:` 等）
  - スキーム相対URL・ホスト欠落URL
- 不正URLパターンのテーブル駆動テストを追加

## 動作確認

- twelvedata パッケージの全テスト合格（`-race` 付き）

https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT

---
_Generated by [Claude Code](https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT)_