### PR TITLE
fix: 銘柄コードのパスパラメータにバリデーションを追加

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -228,6 +228,8 @@ paths:
           description: "銘柄コード（例: AAPL, 7203.T）"
           schema:
             type: string
+            maxLength: 20
+            pattern: "^[A-Za-z0-9._-]{1,20}$"
         - name: interval
           in: query
           required: false
@@ -377,9 +379,17 @@ paths:
           description: "銘柄コード（例: AAPL, 7203.T）"
           schema:
             type: string
+            maxLength: 20
+            pattern: "^[A-Za-z0-9._-]{1,20}$"
       responses:
         "204":
           description: 削除成功
+        "400":
+          description: バリデーションエラー（銘柄コードの形式不正）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "403":
           description: CSRFトークン不一致
           content:

--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
@@ -12,6 +13,10 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/candles"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
 )
+
+// symbolCodePattern は銘柄コードとして許可する形式（例: AAPL, 7203.T）。
+// symbols.code が VARCHAR(20) のため最大20文字、英数字と . _ - のみ許可する。
+var symbolCodePattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,20}$`)
 
 // Usecase はローソク足データ操作のユースケースインターフェースを定義します。
 // Goの慣例に従い、インターフェースは利用者（handler）側で定義します。
@@ -35,6 +40,10 @@ func NewHandler(uc Usecase) *Handler {
 // GET /candles/{code}?interval=1day&outputsize=200
 func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 	code := chi.URLParam(r, "code")
+	if !symbolCodePattern.MatchString(code) {
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid symbol code"})
+		return
+	}
 	// 未指定の場合はデフォルト値を使用
 	interval := queryOrDefault(r, "interval", "1day")
 	outputsizeStr := queryOrDefault(r, "outputsize", "200")

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -78,6 +78,20 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"error":"outputsize must be an integer"}`,
 		},
+		{
+			name:           "error: symbol code with invalid characters returns 400",
+			url:            "/candles/7203%26T",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"invalid symbol code"}`,
+		},
+		{
+			name:           "error: symbol code longer than 20 characters returns 400",
+			url:            "/candles/AAAAAAAAAAAAAAAAAAAAA",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"invalid symbol code"}`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/feature/watchlist/watchlisthttp/handler.go
+++ b/internal/feature/watchlist/watchlisthttp/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"regexp"
 
 	"github.com/go-chi/chi/v5"
 
@@ -13,6 +14,10 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
+
+// symbolCodePattern は銘柄コードとして許可する形式（例: AAPL, 7203.T）。
+// symbols.code が VARCHAR(20) のため最大20文字、英数字と . _ - のみ許可する。
+var symbolCodePattern = regexp.MustCompile(`^[A-Za-z0-9._-]{1,20}$`)
 
 // Usecase はウォッチリスト操作のユースケースインターフェースを定義します。
 type Usecase interface {
@@ -96,6 +101,10 @@ func (h *Handler) Remove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	code := chi.URLParam(r, "code")
+	if !symbolCodePattern.MatchString(code) {
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid symbol code"})
+		return
+	}
 
 	if err := h.uc.RemoveSymbol(r.Context(), userID, code); err != nil {
 		switch {

--- a/internal/feature/watchlist/watchlisthttp/handler_test.go
+++ b/internal/feature/watchlist/watchlisthttp/handler_test.go
@@ -245,6 +245,20 @@ func TestWatchlistHandler_Remove(t *testing.T) {
 			expectedStatus: http.StatusInternalServerError,
 			expectedBody:   `{"error":"internal server error"}`,
 		},
+		{
+			name:           "error: symbol code with invalid characters returns 400",
+			code:           "AAPL%26x",
+			mockRemove:     nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"invalid symbol code"}`,
+		},
+		{
+			name:           "error: symbol code longer than 20 characters returns 400",
+			code:           "AAAAAAAAAAAAAAAAAAAAA",
+			mockRemove:     nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"invalid symbol code"}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要

セキュリティ検査の指摘への対応。`/v1/candles/{code}` と `/v1/watchlist/{code}` のパスパラメータ（銘柄コード）が未検証だったため、形式チェックを追加します。

## 変更内容

- 銘柄コードの形式を「英数字と `. _ -` のみ・最大20文字」（`symbols.code VARCHAR(20)` に対応）に制限し、不正な場合は 400 Bad Request を返す
- OpenAPI 仕様の path パラメータに `maxLength` / `pattern` を明記し、watchlist DELETE に 400 レスポンスを追加
- 不正コード（記号混入・21文字以上）のテストケースを追加

## 補足

後続のDBアクセスはパラメータ化クエリで保護済みのため実害はありませんでしたが、不正入力を入口で遮断する多層防御として導入します。

## 動作確認

- candleshttp / watchlisthttp の全テスト合格（`-race` 付き）

https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT

---
_Generated by [Claude Code](https://claude.ai/code/session_015aoiz96bJU315A6PYXtZNT)_