### PR TITLE
chore: 環境変数ファイルを単一の .env に統合

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ go build ./...
 ```
 
 ### 環境セットアップ
-- `docker/example.env.app` を `docker/.env.app` にコピーして設定（GCP ADC を使う場合は `docker/example.env.gcp` を `docker/.env` にコピー）：
+- `docker/example.env` を `docker/.env` にコピーして設定（GCP ADC を使う場合は ADC 関連の変数も設定）：
   - `TWELVE_DATA_API_KEY`: https://twelvedata.com/ から取得（無料枠: 8リクエスト/分）
   - `JWT_SECRET`: 本番環境では強力なシークレットを設定
   - DB・Redisの設定はローカル開発用

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ go build ./...
 ```
 
 ### 環境セットアップ
-- `docker/example.env.app` を `docker/.env.app` にコピーして設定（GCP ADC を使う場合は `docker/example.env.gcp` を `docker/.env` にコピー）：
+- `docker/example.env` を `docker/.env` にコピーして設定（GCP ADC を使う場合は ADC 関連の変数も設定）：
   - `TWELVE_DATA_API_KEY`: https://twelvedata.com/ から取得（無料枠: 8リクエスト/分）
   - `JWT_SECRET`: 本番環境では強力なシークレットを設定
   - DB・Redisの設定はローカル開発用

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 | AI / ML         | Cloud Vision API / Gemini API（Vertex AI）                          |
 | 認証・セキュリティ | JWT / bcrypt / OAuth2（Google・GitHub, PKCE）/ CSRF（Double Submit Cookie）/ レートリミット |
 | API仕様         | OpenAPI 3.0.4 / oapi-codegen（型生成）                              |
-| 設定管理        | **docker/.env.app（ローカル）/ Secret Manager（本番）+ os.Getenv()**|
+| 設定管理        | **docker/.env（ローカル）/ Secret Manager（本番）+ os.Getenv()**|
 | コンテナ        | Docker / Docker Compose                                             |
 | クラウド        | Google Cloud Run / Cloud SQL / Secret Manager / Artifact Registry   |
 | CI/CD           | GitHub Actions                                                      |
@@ -134,8 +134,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 │   ├── Dockerfile.api.dev      # APIサーバー用Dockerfile（ローカル開発）
 │   ├── docker-compose.yml      # ローカル開発用 compose 定義（サービス・ネットワーク設定）
 │   ├── air.toml                # Air（ホットリロード）設定
-│   ├── example.env.app         # アプリ用環境変数テンプレート（コンテナにロード）
-│   ├── example.env.gcp         # GCP ADC 用テンプレート（compose 変数置換用）
+│   ├── example.env             # 環境変数テンプレート（compose 変数置換 + コンテナにロード）
 │   └── postgres/               # PostgreSQL初期化スクリプト
 │
 ├── docs/
@@ -273,7 +272,7 @@ go generate ./internal/api/...
 - **Redis（Cloud Memorystore）**: キャッシュ管理
 - **Secret Manager**: APIキー・DBパスワード・JWTシークレットキーを安全に管理
 - 起動時に `os.Getenv()` + Secret Manager APIで読み込み
-- **ローカル開発では `docker/.env.app` から読み込み**
+- **ローカル開発では `docker/.env` から読み込み**
 
 ## CI/CD
 
@@ -288,7 +287,7 @@ go generate ./internal/api/...
 
 - Docker / Docker Compose がインストール済みであること
 - Go のインストールは不要（すべてDocker内で実行）
-- `docker/.env.app` にローカル環境変数を設定
+- `docker/.env` にローカル環境変数を設定
 
 ---
 
@@ -300,8 +299,7 @@ git clone https://github.com/UCHIDAnobuhiro/stock-backend.git
 cd stock-backend
 
 # 環境変数ファイルをコピー
-cp docker/example.env.app docker/.env.app
-cp docker/example.env.gcp docker/.env   # compose 変数置換に必要
+cp docker/example.env docker/.env
 ```
 
 ### Twelve Data APIキーの取得
@@ -311,7 +309,7 @@ cp docker/example.env.gcp docker/.env   # compose 変数置換に必要
 
 1. Twelve Dataのウェブサイトでアカウントを作成
 2. 「Dashboard > API Keys」からキーを発行
-3. `docker/.env.app` に `TWELVE_DATA_API_KEY` として設定
+3. `docker/.env` に `TWELVE_DATA_API_KEY` として設定
    例: `TWELVE_DATA_API_KEY=your_api_key_here`
 
 ### Twelve Data 無料プランの制限事項
@@ -342,7 +340,7 @@ GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credenti
 HOST_GOOGLE_ADC_PATH=$HOME/.config/gcloud/application_default_credentials.json
 ```
 
-4. `docker/.env.app` に以下を追加
+4. `docker/.env` に以下を追加
 
 ```env
 GOOGLE_GENAI_USE_VERTEXAI=true
@@ -393,7 +391,7 @@ docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --r
 docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --rm tbls diff --config /work/docs/tbls.yml
 ```
 
-`backend` は `.env.app` や GCP ADC 等の環境が必要です。認証情報を持たない環境では、手順 1) を以下の軽量バイナリ (`cmd/migrate`) に置き換えられます（引数なしで `up` が適用されます）。
+`backend` は `.env` や GCP ADC 等の環境が必要です。認証情報を持たない環境では、手順 1) を以下の軽量バイナリ (`cmd/migrate`) に置き換えられます（引数なしで `up` が適用されます）。
 
 ```bash
 # 1') db だけ起動してローカルの cmd/migrate でスキーマを反映（GCP 認証不要）

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       dockerfile: docker/Dockerfile.api.dev
     container_name: stock-backend
     env_file:
-      - ./.env.app
+      - ./.env
     environment:
       APP_ENV: docker-dev
       GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS}
@@ -71,7 +71,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.api.dev
     env_file:
-      - ./.env.app
+      - ./.env
     volumes:
       - ..:/app
       - go-mod-cache:/go/pkg/mod
@@ -89,7 +89,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.api.dev
     env_file:
-      - ./.env.app
+      - ./.env
     volumes:
       - ..:/app
       - go-mod-cache:/go/pkg/mod
@@ -108,7 +108,7 @@ services:
       context: ..
       dockerfile: docker/Dockerfile.migrate
     env_file:
-      - ./.env.app
+      - ./.env
     restart: "no"
     depends_on:
       db:
@@ -120,7 +120,7 @@ services:
     image: postgres:18
     container_name: stock-seed
     env_file:
-      - ./.env.app
+      - ./.env
     volumes:
       - ../db/seed/seed.sql:/seed.sql:ro
     command:

--- a/docker/example.env
+++ b/docker/example.env
@@ -54,6 +54,12 @@ GOOGLE_GENAI_USE_VERTEXAI=true
 GOOGLE_CLOUD_PROJECT=your_gcp_project_id
 GOOGLE_CLOUD_LOCATION=asia-northeast1
 
+# Google Cloud ADC（compose 変数置換用。ロゴ検出・企業分析機能で GCP ADC を使う場合に設定）
+# GOOGLE_APPLICATION_CREDENTIALS: コンテナ内の ADC パス（通常は変更不要）
+# HOST_GOOGLE_ADC_PATH: ホスト側の ADC ファイルパス（コンテナへマウントされる）
+GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
+HOST_GOOGLE_ADC_PATH=/path/to/your/.config/gcloud/application_default_credentials.json
+
 # OAuth 2.0（未設定の場合はOAuth機能なしで起動）
 # Google OAuth: https://console.cloud.google.com/apis/credentials で OAuth 2.0 クライアントIDを作成
 # GOOGLE_CLIENT_ID=your_google_client_id

--- a/docker/example.env.gcp
+++ b/docker/example.env.gcp
@@ -1,2 +1,0 @@
-GOOGLE_APPLICATION_CREDENTIALS=/root/.config/gcloud/application_default_credentials.json
-HOST_GOOGLE_ADC_PATH=/path/to/your/.config/gcloud/application_default_credentials.json

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -733,7 +733,7 @@ go test ./internal/feature/auth/... -v -race -cover
 
 `GOOGLE_CLIENT_ID` または `GITHUB_CLIENT_ID` のいずれかが設定されている場合、OAuth 機能が有効化されます。OAuth 有効時は Redis 接続が必須です（state 保存に使用）。
 
-**設定例**（`docker/.env.app`）:
+**設定例**（`docker/.env`）:
 ```
 JWT_SECRET=your-super-secret-key-change-this-in-production
 PASSWORD_PEPPER=your-password-pepper-change-this-in-production


### PR DESCRIPTION
## 概要
ローカル開発の環境変数ファイルが `docker/.env`（compose 変数置換用）と `docker/.env.app`（コンテナ用）の 2 つに分かれて設定箇所が分散していたため、単一の `docker/.env` に統合し、セットアップとメンテを 1 ファイルに集約する。

## 変更内容
- `docker-compose.yml` の `env_file` を `./.env.app` から `./.env` に変更（backend / candles / logo / migrate / seed の 5 サービス）
- テンプレートを `example.env` に統合し、`example.env.app` / `example.env.gcp` を削除
- compose 変数置換用の GCP ADC 変数（`GOOGLE_APPLICATION_CREDENTIALS` / `HOST_GOOGLE_ADC_PATH`）を統合ファイルに集約
- README / CLAUDE.md / AGENTS.md / docs/features/auth.md のセットアップ手順を更新

## 破壊的変更
- ローカル開発環境のセットアップ手順が変わります。既存の開発者は以下の対応が必要です:
  - 旧 `docker/.env.app` の内容を `docker/.env` に統合（テンプレートから再作成する場合は `cp docker/example.env docker/.env`）
  - 旧 `docker/.env.app` は不要になるため削除
- `docker/.env` / `docker/.env.app` は gitignore 対象のため、本 PR の差分には実ファイルは含まれません（テンプレートと compose 定義・ドキュメントのみ）

## テスト
- `docker compose -f docker/docker-compose.yml -p stock config` で compose 定義が正しく解決され、変数置換にエラーが出ないことを確認
- backend コンテナにアプリ変数（`TWELVE_DATA_API_KEY` 等）と GCP 変数（`GOOGLE_APPLICATION_CREDENTIALS` / `HOST_GOOGLE_ADC_PATH`）の両方が渡ることを `config` 出力で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)