### PR TITLE
fix: OpenAPI仕様を実装に整合させ入力検証を強化

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -237,13 +237,19 @@ paths:
           schema:
             type: string
             default: "1day"
+            enum:
+              - "1day"
+              - "1week"
+              - "1month"
         - name: outputsize
           in: query
           required: false
-          description: 取得件数
+          description: "取得件数（1〜5000。範囲外の値が指定された場合は200に丸めて扱う）"
           schema:
             type: integer
             default: 200
+            minimum: 1
+            maximum: 5000
       responses:
         "200":
           description: ローソク足データ一覧
@@ -254,13 +260,15 @@ paths:
                 items:
                   $ref: "#/components/schemas/CandleResponse"
         "400":
-          description: バリデーションエラー（outputsizeに整数以外が指定された等）
+          description: バリデーションエラー（outputsizeに整数以外、未対応のinterval等）
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "502":
-          description: 外部API通信エラー
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "500":
+          description: サーバーエラー
           content:
             application/json:
               schema:
@@ -283,6 +291,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/SymbolItem"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "500":
           description: サーバーエラー
           content:
@@ -307,6 +317,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/WatchlistItem"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "500":
           description: サーバーエラー
           content:
@@ -320,6 +332,8 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CsrfToken"
       requestBody:
         required: true
         content:
@@ -339,14 +353,16 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "404":
-          description: 銘柄が存在しない
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          description: CSRFトークン不一致
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
-        "403":
-          description: CSRFトークン不一致
+        "404":
+          description: 銘柄が存在しない
           content:
             application/json:
               schema:
@@ -381,6 +397,7 @@ paths:
             type: string
             maxLength: 20
             pattern: "^[A-Za-z0-9._-]{1,20}$"
+        - $ref: "#/components/parameters/CsrfToken"
       responses:
         "204":
           description: 削除成功
@@ -390,6 +407,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "403":
           description: CSRFトークン不一致
           content:
@@ -417,6 +436,8 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CsrfToken"
       requestBody:
         required: true
         content:
@@ -432,6 +453,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "403":
           description: CSRFトークン不一致
           content:
@@ -453,6 +476,8 @@ paths:
         - logo
       security:
         - cookieAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CsrfToken"
       requestBody:
         required: true
         content:
@@ -481,6 +506,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "403":
           description: CSRFトークン不一致
           content:
@@ -514,6 +541,8 @@ paths:
         - logo
       security:
         - cookieAuth: []
+      parameters:
+        - $ref: "#/components/parameters/CsrfToken"
       requestBody:
         required: true
         content:
@@ -533,6 +562,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
         "403":
           description: CSRFトークン不一致
           content:
@@ -552,6 +583,25 @@ components:
       type: apiKey
       in: cookie
       name: auth_token
+
+  parameters:
+    CsrfToken:
+      name: X-CSRF-Token
+      in: header
+      required: true
+      description: |
+        CSRFトークン（Double Submit Cookieパターン）。
+        ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
+      schema:
+        type: string
+
+  responses:
+    UnauthorizedError:
+      description: 認証失敗（auth_token Cookieが無い・無効・期限切れ）
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
 
   schemas:
     SignupRequest:
@@ -726,6 +776,9 @@ components:
       properties:
         symbol_code:
           type: string
+          minLength: 1
+          maxLength: 20
+          pattern: "^[A-Za-z0-9._-]{1,20}$"
           description: "追加する銘柄コード（例: AAPL, 7203.T）"
           x-oapi-codegen-extra-tags:
             binding: "required,min=1,max=20"
@@ -744,6 +797,7 @@ components:
             type: string
             minLength: 1
             maxLength: 20
+            pattern: "^[A-Za-z0-9._-]{1,20}$"
           x-oapi-codegen-extra-tags:
             binding: "required,min=1"
 

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -23,6 +23,13 @@ const (
 	OauthCallbackParamsProviderGoogle OauthCallbackParamsProvider = "google"
 )
 
+// Defines values for GetCandlesParamsInterval.
+const (
+	N1day   GetCandlesParamsInterval = "1day"
+	N1month GetCandlesParamsInterval = "1month"
+	N1week  GetCandlesParamsInterval = "1week"
+)
+
 // AddWatchlistRequest defines model for AddWatchlistRequest.
 type AddWatchlistRequest struct {
 	// SymbolCode 追加する銘柄コード（例: AAPL, 7203.T）
@@ -139,6 +146,12 @@ type WatchlistItem struct {
 	SymbolCode string `json:"symbol_code"`
 }
 
+// CsrfToken defines model for CsrfToken.
+type CsrfToken = string
+
+// UnauthorizedError defines model for UnauthorizedError.
+type UnauthorizedError = ErrorResponse
+
 // BeginOAuthParamsProvider defines parameters for BeginOAuth.
 type BeginOAuthParamsProvider string
 
@@ -154,16 +167,54 @@ type OauthCallbackParamsProvider string
 // GetCandlesParams defines parameters for GetCandles.
 type GetCandlesParams struct {
 	// Interval 時間間隔
-	Interval *string `form:"interval,omitempty" json:"interval,omitempty"`
+	Interval *GetCandlesParamsInterval `form:"interval,omitempty" json:"interval,omitempty"`
 
-	// Outputsize 取得件数
+	// Outputsize 取得件数（1〜5000。範囲外の値が指定された場合は200に丸めて扱う）
 	Outputsize *int `form:"outputsize,omitempty" json:"outputsize,omitempty"`
+}
+
+// GetCandlesParamsInterval defines parameters for GetCandles.
+type GetCandlesParamsInterval string
+
+// AnalyzeCompanyParams defines parameters for AnalyzeCompany.
+type AnalyzeCompanyParams struct {
+	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
+	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
+	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
 }
 
 // DetectLogoMultipartBody defines parameters for DetectLogo.
 type DetectLogoMultipartBody struct {
 	// Image ロゴ検出対象の画像ファイル（最大10MB）
 	Image openapi_types.File `json:"image"`
+}
+
+// DetectLogoParams defines parameters for DetectLogo.
+type DetectLogoParams struct {
+	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
+	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
+	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
+}
+
+// AddToWatchlistParams defines parameters for AddToWatchlist.
+type AddToWatchlistParams struct {
+	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
+	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
+	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
+}
+
+// ReorderWatchlistParams defines parameters for ReorderWatchlist.
+type ReorderWatchlistParams struct {
+	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
+	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
+	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
+}
+
+// RemoveFromWatchlistParams defines parameters for RemoveFromWatchlist.
+type RemoveFromWatchlistParams struct {
+	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
+	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
+	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
 }
 
 // LoginJSONRequestBody defines body for Login for application/json ContentType.

--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -46,6 +46,11 @@ func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// 未指定の場合はデフォルト値を使用
 	interval := queryOrDefault(r, "interval", "1day")
+	// 空文字（?interval=）は usecase 側でデフォルトに丸めるため、非空の未対応値のみ拒否する。
+	if interval != "" && !candles.IsValidInterval(interval) {
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "unsupported interval"})
+		return
+	}
 	outputsizeStr := queryOrDefault(r, "outputsize", "200")
 	// 文字列を整数に変換
 	outputsize, err := strconv.Atoi(outputsizeStr)

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -79,6 +79,23 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			expectedBody:   `{"error":"outputsize must be an integer"}`,
 		},
 		{
+			name:           "error: unsupported interval returns 400",
+			url:            "/candles/7203.T?interval=3day",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"unsupported interval"}`,
+		},
+		{
+			name: "success: empty interval falls back to default",
+			url:  "/candles/7203.T?interval=",
+			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+				assert.Equal(t, "", interval) // 空文字はハンドラを通過し usecase 側でデフォルトに丸める
+				return []candles.Candle{}, nil
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `[]`,
+		},
+		{
 			name:           "error: symbol code with invalid characters returns 400",
 			url:            "/candles/7203%26T",
 			mockGetCandles: nil,

--- a/internal/feature/candles/usecase.go
+++ b/internal/feature/candles/usecase.go
@@ -13,6 +13,19 @@ const (
 	MaxOutputSize = 5000
 )
 
+// validIntervals は許可する時間間隔の集合です。
+var validIntervals = map[string]struct{}{
+	"1day":   {},
+	"1week":  {},
+	"1month": {},
+}
+
+// IsValidInterval は interval が許可された時間間隔かどうかを返します。
+func IsValidInterval(interval string) bool {
+	_, ok := validIntervals[interval]
+	return ok
+}
+
 // Repository はローソク足データの読み取りレイヤーを抽象化します。
 // Goの慣例に従い、インターフェースは利用者（usecase）側で定義します。
 type Repository interface {

--- a/internal/feature/watchlist/watchlisthttp/handler.go
+++ b/internal/feature/watchlist/watchlisthttp/handler.go
@@ -76,6 +76,10 @@ func (h *Handler) Add(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
 	}
+	if !symbolCodePattern.MatchString(req.SymbolCode) {
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid symbol code"})
+		return
+	}
 
 	if err := h.uc.AddSymbol(r.Context(), userID, req.SymbolCode); err != nil {
 		switch {
@@ -132,6 +136,12 @@ func (h *Handler) Reorder(w http.ResponseWriter, r *http.Request) {
 	if err := httpx.DecodeAndValidate(r, &req); err != nil {
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
+	}
+	for _, code := range req.Codes {
+		if !symbolCodePattern.MatchString(code) {
+			httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid symbol code"})
+			return
+		}
 	}
 
 	if err := h.uc.ReorderSymbols(r.Context(), userID, req.Codes); err != nil {

--- a/internal/feature/watchlist/watchlisthttp/handler_test.go
+++ b/internal/feature/watchlist/watchlisthttp/handler_test.go
@@ -173,6 +173,13 @@ func TestWatchlistHandler_Add(t *testing.T) {
 			expectedBody:   `{"error":"invalid request"}`,
 		},
 		{
+			name:           "error: symbol code with invalid characters returns 400",
+			body:           `{"symbol_code":"AAPL@x"}`,
+			mockAdd:        nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"invalid symbol code"}`,
+		},
+		{
 			name: "error: usecase returns internal error",
 			body: `{"symbol_code":"AAPL"}`,
 			mockAdd: func(ctx context.Context, userID int64, symbolCode string) error {
@@ -310,6 +317,13 @@ func TestWatchlistHandler_Reorder(t *testing.T) {
 			mockReorder:    nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"error":"invalid request"}`,
+		},
+		{
+			name:           "error: code with invalid characters returns 400",
+			body:           `{"codes":["AAPL","MSFT@x"]}`,
+			mockReorder:    nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"invalid symbol code"}`,
 		},
 		{
 			name: "error: usecase returns internal error",


### PR DESCRIPTION
## 概要
`api/openapi.yaml` をレビューし実装と突き合わせた結果、仕様が実装の挙動を表していない箇所と入力経路で検証強度が食い違う箇所が見つかったため、仕様を実装に整合させ、併せて入力検証を強化する。

## 変更内容
- **認証**: `cookieAuth` 保護下の全ルート（candles / symbols / watchlist / logo）に `401` レスポンスを追加（実装は認証失敗時に 401 を返すが仕様に未定義だった）
- **CSRF**: 変更系オペレーションに送信ヘッダー `X-CSRF-Token` を仕様化（実装の検証ヘッダーが仕様に存在しなかった）
- **candles エラーコード**: 実装に合わせ `502` を `500` へ是正
- **candles バリデーション**: `outputsize` に `minimum:1`/`maximum:5000`、`interval` を enum（`1day`/`1week`/`1month`）で制限。ハンドラでも未対応 interval を 400 で拒否
- **watchlist バリデーション**: `symbol_code` に pattern（`^[A-Za-z0-9._-]{1,20}$`）を追加し、Add/Reorder のリクエストボディで形式検証（従来はパスパラメータのみ検証）
- テーブル駆動テストを追加し、`types.gen.go` を再生成

## 破壊的変更
- candles の `interval` は `1day`/`1week`/`1month` 以外を `400` で拒否するようになる（従来は任意の文字列を素通し）
- watchlist の追加/並び替えリクエストで、形式不正な `symbol_code`（許可文字以外・21文字以上）は `400` を返すようになる
- いずれも従来「素通ししていたが本来不正な値」を弾くもので、正当なクライアントへの影響はない想定

## テスト
- `go test ./... -race -cover`（testcontainers で実 PostgreSQL 起動、全パッケージ pass）
  - candles 本体 95.8% / candleshttp 100% / watchlist 本体 86.9% / watchlisthttp 87.7%
- `golangci-lint run`（0 issues）
- `go tool go-arch-lint check`（No warnings）
- `go generate ./internal/api/...` で `types.gen.go` 再生成済み

## レビューポイント
- candles の上流通信失敗を 502 として区別する対応は本PR範囲外（現状は全エラー 500）。区別にはハンドラのエラー型分類が必要なため将来課題とした