### PR TITLE
fix: パスワードに最大長1024バイトの上限を追加

### DIFF
--- a/internal/feature/auth/usecase.go
+++ b/internal/feature/auth/usecase.go
@@ -17,6 +17,12 @@ const (
 	// 辞書攻撃への耐性を高めるため、より長い 12 文字を最低長とする。
 	minPasswordLength = 12
 
+	// maxPasswordLength はパスワードの最大バイト数を定義します。
+	// パスワードは HMAC-SHA256 ペッパー適用を経て bcrypt にかけられるため、
+	// 上限がないと過大なパスワード本体に対する HMAC 計算で CPU を浪費させられる。
+	// これを防ぐため上限を設ける（len() はバイト数を返す）。
+	maxPasswordLength = 1024
+
 	// EnvKeyPasswordPepper はパスワードペッパーの環境変数キーです。
 	EnvKeyPasswordPepper = "PASSWORD_PEPPER"
 )
@@ -127,6 +133,9 @@ func validatePassword(password string) error {
 	if len(password) < minPasswordLength {
 		return fmt.Errorf("password must be at least %d characters long", minPasswordLength)
 	}
+	if len(password) > maxPasswordLength {
+		return fmt.Errorf("password must be at most %d characters long", maxPasswordLength)
+	}
 	return nil
 }
 
@@ -155,6 +164,13 @@ func (u *usecase) Signup(ctx context.Context, email, password string) (int64, er
 // メールアドレスとパスワードを検証し、署名済みJWTトークンを生成します。
 // タイミング攻撃を防止するため、ユーザーが存在しない場合でもbcrypt比較を実行します。
 func (u *usecase) Login(ctx context.Context, email, password string) (string, error) {
+	// 過大なパスワードによる CPU 枯渇を防止するため、HMAC 計算前に上限を超えるものを弾く。
+	// 上限超過のパスワードは正規パスワードと一致し得ないため汎用エラーを返す。
+	// ユーザー存在有無に関わらず同じ経路で早期 return するため、ユーザー列挙にはつながらない。
+	if len(password) > maxPasswordLength {
+		return "", ErrInvalidCredentials
+	}
+
 	// メールアドレスでユーザーを検索
 	user, err := u.users.FindByEmail(ctx, email)
 

--- a/internal/feature/auth/usecase_test.go
+++ b/internal/feature/auth/usecase_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/bcrypt"
@@ -175,6 +176,20 @@ func TestAuthUsecase_Signup(t *testing.T) {
 			verifyBcryptHash: true,
 		},
 		{
+			name:             "password at maximum length",
+			email:            "test@example.com",
+			password:         strings.Repeat("a", 1024),
+			wantErr:          false,
+			verifyBcryptHash: true,
+		},
+		{
+			name:     "password too long",
+			email:    "test@example.com",
+			password: strings.Repeat("a", 1025),
+			wantErr:  true,
+			errMsg:   "password must be at most 1024 characters long",
+		},
+		{
 			name:          "repository create failure",
 			email:         "test@example.com",
 			password:      "password12345",
@@ -268,6 +283,14 @@ func TestAuthUsecase_Login(t *testing.T) {
 			name:              "edge case: empty password with valid user",
 			email:             "test@example.com",
 			password:          "",
+			wantErr:           true,
+			errMsg:            "invalid email or password",
+			findByEmailResult: testUser,
+		},
+		{
+			name:              "password too long is rejected before hashing",
+			email:             "test@example.com",
+			password:          strings.Repeat("a", 1025),
 			wantErr:           true,
 			errMsg:            "invalid email or password",
 			findByEmailResult: testUser,


### PR DESCRIPTION
## 概要
パスワードに最大長の上限がなく、過大なパスワードによる HMAC-SHA256 計算で CPU を浪費させられる余地があった（Issue #193）。`validatePassword` に上限チェックを追加し、Login にも独立したガードを設けることでこのリスクを解消する。

## 変更内容
- `maxPasswordLength = 1024`（バイト）を定数として追加
- `validatePassword` に上限チェックを追加（Signup を保護）
- Login は `validatePassword` を経由しないため、`pepperPassword`（HMAC 計算）の前に上限超過のパスワードを `ErrInvalidCredentials` で弾くガードを追加
  - 最低長チェックは入れず、ユーザー存在有無に関わらず同じ経路で早期 return するため、ユーザー列挙にはつながらない
- Signup/Login に境界値（ちょうど1024バイト）・超過（1025バイト）のテストケースを追加

## 関連issue
- closes #193

## テスト
- `go test ./internal/feature/auth/... -race` パス
- `go build ./...` / `golangci-lint run` / `go tool go-arch-lint check` いずれもパス