### PR TITLE
docs: watchlist Repository インターフェースのメソッドコメントを補完

### DIFF
--- a/internal/feature/watchlist/usecase.go
+++ b/internal/feature/watchlist/usecase.go
@@ -8,13 +8,19 @@ import (
 
 // Repository はウォッチリスト操作の永続化層を抽象化します。
 type Repository interface {
+	// ListByUser はユーザーのウォッチリストを sort_key 昇順で返します。
 	ListByUser(ctx context.Context, userID int64) ([]UserSymbol, error)
 	// Add はsort_keyを指定してウォッチリストに銘柄を追加します。
+	// 重複エントリは ErrAlreadyInWatchlist、銘柄コードの FK 違反は ErrSymbolNotFound を返します。
 	Add(ctx context.Context, entry UserSymbol) error
 	// AddWithNextSortKey はsort_keyをトランザクション内でMAX+1採番して銘柄を追加します。
 	// MaxSortKey取得とInsertをアトミックに実行するため、並行追加時の重複順位を防ぎます。
 	AddWithNextSortKey(ctx context.Context, userID int64, symbolCode string) error
+	// Remove はウォッチリストから銘柄を削除します。
+	// 対象がウォッチリストに存在しない場合は ErrNotInWatchlist を返します。
 	Remove(ctx context.Context, userID int64, symbolCode string) error
+	// UpdateSortKeys は entries の SortKey でウォッチリストの並び順を一括更新します。
+	// 全更新は原子的に適用され、途中で失敗した場合はいずれの並び順も変更されません。
 	UpdateSortKeys(ctx context.Context, userID int64, entries []UserSymbol) error
 }
 


### PR DESCRIPTION
## 概要
watchlist フィーチャーの `Repository` インターフェースについて、コメントが付いていなかったメソッドを補完し、インターフェース＝契約として読めるよう記述を整えました。

## 変更内容
- `ListByUser` / `Remove` / `UpdateSortKeys` にメソッドコメントを追加
- `Add` に重複時（`ErrAlreadyInWatchlist`）・FK 違反時（`ErrSymbolNotFound`）の返却エラーを明記
- `UpdateSortKeys` のコメントを実装詳細（負値シフト等）ではなく契約（並び順更新の原子性）ベースに記述

## テスト
- コメントのみの変更のため挙動への影響なし

## レビューポイント
- インターフェースのコメントが「利用者が知るべき契約」に絞られているか（実装手段は repository.go 側の実装コメントに委ねる方針）