### PR TITLE
refactor: sql.go の関数を step-down 順に並べ替え

### DIFF
--- a/internal/infra/db/sql.go
+++ b/internal/infra/db/sql.go
@@ -13,38 +13,6 @@ import (
 // テストでモック化するために関数型として定義します。
 type SQLOpener func(dsn string) (*sql.DB, error)
 
-// DefaultSQLOpener は pgx/v5/stdlib driver で PostgreSQL に接続する SQLOpener です。
-// 接続プールのデフォルト値はそのままで、必要に応じて呼び出し側で SetMaxOpenConns 等を調整します。
-func DefaultSQLOpener(dsn string) (*sql.DB, error) {
-	db, err := sql.Open("pgx", dsn)
-	if err != nil {
-		return nil, err
-	}
-	// sql.Open はコネクション確立を遅延するため、Ping で疎通確認する。
-	if err := db.Ping(); err != nil {
-		_ = db.Close()
-		return nil, err
-	}
-	return db, nil
-}
-
-// ConnectSQLWithRetry はリトライ付きで *sql.DB を取得します。
-// timeout 期間中、3秒間隔で再試行します。
-func ConnectSQLWithRetry(dsn string, timeout time.Duration, opener SQLOpener) (*sql.DB, error) {
-	deadline := time.Now().Add(timeout)
-	for {
-		db, err := opener(dsn)
-		if err == nil {
-			return db, nil
-		}
-		if time.Now().After(deadline) {
-			return nil, fmt.Errorf("DB connect failed after %v: %w", timeout, err)
-		}
-		slog.Warn("DB connect failed, retrying", "error", err)
-		time.Sleep(3 * time.Second)
-	}
-}
-
 // OpenSQL は渡された設定を検証して *sql.DB を返します。
 // リトライロジックを含み、設定不正や接続失敗は呼び出し元へ返します。
 // 設定の読み込み（環境変数）は internal/app/config に集約されています。
@@ -65,4 +33,36 @@ func openSQLWithRetry(cfg Config, timeout time.Duration, opener SQLOpener) (*sql
 	dsn := BuildDSN(cfg)
 
 	return ConnectSQLWithRetry(dsn, timeout, opener)
+}
+
+// ConnectSQLWithRetry はリトライ付きで *sql.DB を取得します。
+// timeout 期間中、3秒間隔で再試行します。
+func ConnectSQLWithRetry(dsn string, timeout time.Duration, opener SQLOpener) (*sql.DB, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		db, err := opener(dsn)
+		if err == nil {
+			return db, nil
+		}
+		if time.Now().After(deadline) {
+			return nil, fmt.Errorf("DB connect failed after %v: %w", timeout, err)
+		}
+		slog.Warn("DB connect failed, retrying", "error", err)
+		time.Sleep(3 * time.Second)
+	}
+}
+
+// DefaultSQLOpener は pgx/v5/stdlib driver で PostgreSQL に接続する SQLOpener です。
+// 接続プールのデフォルト値はそのままで、必要に応じて呼び出し側で SetMaxOpenConns 等を調整します。
+func DefaultSQLOpener(dsn string) (*sql.DB, error) {
+	db, err := sql.Open("pgx", dsn)
+	if err != nil {
+		return nil, err
+	}
+	// sql.Open はコネクション確立を遅延するため、Ping で疎通確認する。
+	if err := db.Ping(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return db, nil
 }


### PR DESCRIPTION
## 概要
`internal/infra/db/sql.go` の関数定義が「呼ばれる側（末端）が上、呼ぶ側（公開エントリ）が下」という逆順になっており、公開エントリ `OpenSQL` を探すのにファイル末尾まで降りる必要があった。Go で一般的な step-down（呼ぶ側を上、呼ばれる側を下）に並べ替え、上から読めば処理が順に降りていく構成にした。

## 変更内容
- 関数を呼び出し関係の順に並べ替え: `SQLOpener` 型 → `OpenSQL` → `openSQLWithRetry` → `ConnectSQLWithRetry` → `DefaultSQLOpener`
- 各関数の本体・コメントは変更なし（純粋な並び替え）

## テスト
- `go build ./...` 成功
- `go test ./internal/infra/db/... -race` 成功
- 差分は関数ブロックの移動のみで、ロジックの変更なし