### PR TITLE
feat: DB 接続の堅牢化（コネクションプール / PingContext / sslmode）

### DIFF
--- a/docker/example.env
+++ b/docker/example.env
@@ -16,6 +16,11 @@ DB_PASSWORD=apppass
 DB_NAME=app
 RUN_MIGRATIONS=true
 
+# DB 接続オプション（任意。未設定時は db パッケージのデフォルトを使用）
+# DB_MAX_OPEN_CONNS=25             # 最大接続数（デフォルト 25）
+# DB_MAX_IDLE_CONNS=25             # アイドル接続数（デフォルト 25）
+# DB_CONN_MAX_LIFETIME=5m          # 接続の最大生存時間（time.ParseDuration 形式。デフォルト 5m）
+
 # GORM ログレベル（任意。info / warn / error のいずれか。未設定・不明値は Silent）
 # DB_LOG_LEVEL=warn
 

--- a/docker/example.env
+++ b/docker/example.env
@@ -17,6 +17,7 @@ DB_NAME=app
 RUN_MIGRATIONS=true
 
 # DB 接続オプション（任意。未設定時は db パッケージのデフォルトを使用）
+# DB_SSLMODE=disable               # TCP 接続時の sslmode（本番 TCP 外部接続では require 等を推奨）
 # DB_MAX_OPEN_CONNS=25             # 最大接続数（デフォルト 25）
 # DB_MAX_IDLE_CONNS=25             # アイドル接続数（デフォルト 25）
 # DB_CONN_MAX_LIFETIME=5m          # 接続の最大生存時間（time.ParseDuration 形式。デフォルト 5m）

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -148,6 +148,7 @@ func readDB(warn *[]string) db.Config {
 		Host:            os.Getenv("DB_HOST"),
 		Port:            os.Getenv("DB_PORT"),
 		InstanceName:    os.Getenv("INSTANCE_CONNECTION_NAME"),
+		SSLMode:         os.Getenv("DB_SSLMODE"),
 		MaxOpenConns:    readInt("DB_MAX_OPEN_CONNS", warn),
 		MaxIdleConns:    readInt("DB_MAX_IDLE_CONNS", warn),
 		ConnMaxLifetime: readDuration("DB_CONN_MAX_LIFETIME", warn),

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/app/di"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/auth"
@@ -83,7 +84,7 @@ type BatchConfig struct {
 func LoadAPI() (*Config, error) {
 	cfg := &Config{}
 	cfg.Log = readLog(&cfg.Warnings)
-	cfg.DB = readDB()
+	cfg.DB = readDB(&cfg.Warnings)
 	cfg.Redis = readRedis()
 
 	server, err := readServer(&cfg.Warnings)
@@ -106,7 +107,7 @@ func LoadAPI() (*Config, error) {
 func LoadBatch() (*Config, error) {
 	cfg := &Config{}
 	cfg.Log = readLog(&cfg.Warnings)
-	cfg.DB = readDB()
+	cfg.DB = readDB(&cfg.Warnings)
 	cfg.Redis = readRedis()
 	cfg.TwelveData = readTwelveData()
 	cfg.Batch = readBatch(&cfg.Warnings)
@@ -117,7 +118,7 @@ func LoadBatch() (*Config, error) {
 func LoadMigrate() (*Config, error) {
 	cfg := &Config{}
 	cfg.Log = readLog(&cfg.Warnings)
-	cfg.DB = readDB()
+	cfg.DB = readDB(&cfg.Warnings)
 	return cfg, nil
 }
 
@@ -137,14 +138,19 @@ func readLog(warn *[]string) LogConfig {
 
 // readDB は DB_* 環境変数からデータベース設定を組み立てます。
 // 必須項目の検証は接続時（Config.Validate）に行います。
-func readDB() db.Config {
+// コネクションプール関連の数値・duration は未設定ならゼロ値のままにし、
+// db パッケージ側のデフォルト（Default* 定数）にフォールバックさせます。不正値は警告を蓄積します。
+func readDB(warn *[]string) db.Config {
 	return db.Config{
-		User:         os.Getenv("DB_USER"),
-		Password:     db.Password(os.Getenv("DB_PASSWORD")),
-		Name:         os.Getenv("DB_NAME"),
-		Host:         os.Getenv("DB_HOST"),
-		Port:         os.Getenv("DB_PORT"),
-		InstanceName: os.Getenv("INSTANCE_CONNECTION_NAME"),
+		User:            os.Getenv("DB_USER"),
+		Password:        db.Password(os.Getenv("DB_PASSWORD")),
+		Name:            os.Getenv("DB_NAME"),
+		Host:            os.Getenv("DB_HOST"),
+		Port:            os.Getenv("DB_PORT"),
+		InstanceName:    os.Getenv("INSTANCE_CONNECTION_NAME"),
+		MaxOpenConns:    readInt("DB_MAX_OPEN_CONNS", warn),
+		MaxIdleConns:    readInt("DB_MAX_IDLE_CONNS", warn),
+		ConnMaxLifetime: readDuration("DB_CONN_MAX_LIFETIME", warn),
 	}
 }
 
@@ -272,6 +278,37 @@ func readMaxFailureRate(key string, def float64, warn *[]string) float64 {
 		*warn = append(*warn, fmt.Sprintf("invalid max failure rate for %s=%q, using default %v", key, v, def))
 	}
 	return def
+}
+
+// readInt は env の正の整数を読み取ります。未設定なら 0 を返し、呼び出し側（db パッケージ）の
+// デフォルトにフォールバックさせます。不正値（非整数・0 以下）の場合は警告を蓄積して 0 を返します。
+func readInt(key string, warn *[]string) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		*warn = append(*warn, fmt.Sprintf("invalid int for %s=%q, using default", key, v))
+		return 0
+	}
+	return n
+}
+
+// readDuration は env の duration（time.ParseDuration 形式、例 "5m"）を読み取ります。
+// 未設定なら 0 を返し、呼び出し側のデフォルトにフォールバックさせます。
+// 不正値（解釈不能・0 以下）の場合は警告を蓄積して 0 を返します。
+func readDuration(key string, warn *[]string) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d <= 0 {
+		*warn = append(*warn, fmt.Sprintf("invalid duration for %s=%q, using default", key, v))
+		return 0
+	}
+	return d
 }
 
 // ParseCORSOrigins は CORS_ALLOWED_ORIGINS env の生文字列を、カンマ区切りで

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -3,7 +3,81 @@ package config
 import (
 	"reflect"
 	"testing"
+	"time"
 )
+
+// TestReadInt は readInt の未設定（0）・正常・不正値（警告蓄積して 0）の各ケースを検証します。
+func TestReadInt(t *testing.T) {
+	const key = "TEST_READ_INT"
+
+	tests := []struct {
+		name     string
+		set      bool
+		value    string
+		want     int
+		wantWarn bool
+	}{
+		{name: "未設定なら 0", set: false, want: 0, wantWarn: false},
+		{name: "正常値", set: true, value: "25", want: 25, wantWarn: false},
+		{name: "非整数は警告して 0", set: true, value: "abc", want: 0, wantWarn: true},
+		{name: "0 以下は警告して 0", set: true, value: "0", want: 0, wantWarn: true},
+		{name: "負数は警告して 0", set: true, value: "-1", want: 0, wantWarn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(key, tt.value)
+			} else {
+				t.Setenv(key, "")
+			}
+			var warn []string
+			got := readInt(key, &warn)
+			if got != tt.want {
+				t.Errorf("readInt = %d, want %d", got, tt.want)
+			}
+			if (len(warn) > 0) != tt.wantWarn {
+				t.Errorf("warn = %v, wantWarn %v", warn, tt.wantWarn)
+			}
+		})
+	}
+}
+
+// TestReadDuration は readDuration の未設定（0）・正常・不正値（警告蓄積して 0）の各ケースを検証します。
+func TestReadDuration(t *testing.T) {
+	const key = "TEST_READ_DURATION"
+
+	tests := []struct {
+		name     string
+		set      bool
+		value    string
+		want     time.Duration
+		wantWarn bool
+	}{
+		{name: "未設定なら 0", set: false, want: 0, wantWarn: false},
+		{name: "正常値", set: true, value: "5m", want: 5 * time.Minute, wantWarn: false},
+		{name: "解釈不能は警告して 0", set: true, value: "5", want: 0, wantWarn: true},
+		{name: "0 以下は警告して 0", set: true, value: "0s", want: 0, wantWarn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(key, tt.value)
+			} else {
+				t.Setenv(key, "")
+			}
+			var warn []string
+			got := readDuration(key, &warn)
+			if got != tt.want {
+				t.Errorf("readDuration = %v, want %v", got, tt.want)
+			}
+			if (len(warn) > 0) != tt.wantWarn {
+				t.Errorf("warn = %v, wantWarn %v", warn, tt.wantWarn)
+			}
+		})
+	}
+}
 
 // TestParseCORSOrigins は CORS_ALLOWED_ORIGINS env の生文字列パースが
 // trim・空要素除去・複数要素対応を正しく行うことを検証します。

--- a/internal/infra/db/config.go
+++ b/internal/infra/db/config.go
@@ -5,6 +5,18 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
+)
+
+const (
+	// DefaultMaxOpenConns はコネクションプールの最大接続数のデフォルト値です。
+	// database/sql のデフォルトは無制限のため、本番での接続枯渇を避けるべく上限を設けます。
+	DefaultMaxOpenConns = 25
+	// DefaultMaxIdleConns はアイドル接続数のデフォルト値です（database/sql のデフォルトは 2）。
+	DefaultMaxIdleConns = 25
+	// DefaultConnMaxLifetime は接続の最大生存時間のデフォルト値です。
+	// Cloud SQL は古い接続を切るため、それより短い 5 分を既定とします。
+	DefaultConnMaxLifetime = 5 * time.Minute
 )
 
 // Password はログ出力・文字列化・JSONシリアライズ時に値をマスクする機密文字列型です。
@@ -33,6 +45,11 @@ type Config struct {
 	Host         string
 	Port         string
 	InstanceName string // Cloud SQLインスタンス接続名（オプション）
+
+	// コネクションプール設定。ゼロ値のときは Default* 定数にフォールバックします。
+	MaxOpenConns    int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
 }
 
 // Validate は Config の必須項目が設定されているかを検証します。

--- a/internal/infra/db/config.go
+++ b/internal/infra/db/config.go
@@ -17,6 +17,8 @@ const (
 	// DefaultConnMaxLifetime は接続の最大生存時間のデフォルト値です。
 	// Cloud SQL は古い接続を切るため、それより短い 5 分を既定とします。
 	DefaultConnMaxLifetime = 5 * time.Minute
+	// DefaultSSLMode は TCP 接続時の sslmode のデフォルト値です。
+	DefaultSSLMode = "disable"
 )
 
 // Password はログ出力・文字列化・JSONシリアライズ時に値をマスクする機密文字列型です。
@@ -45,6 +47,7 @@ type Config struct {
 	Host         string
 	Port         string
 	InstanceName string // Cloud SQLインスタンス接続名（オプション）
+	SSLMode      string // TCP 接続時の sslmode（空なら DefaultSSLMode）
 
 	// コネクションプール設定。ゼロ値のときは Default* 定数にフォールバックします。
 	MaxOpenConns    int
@@ -104,10 +107,15 @@ func BuildDSN(cfg Config) string {
 			quotePGValue(string(cfg.Password)),
 			quotePGValue(cfg.Name))
 	}
-	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=disable",
+	sslMode := cfg.SSLMode
+	if sslMode == "" {
+		sslMode = DefaultSSLMode
+	}
+	return fmt.Sprintf("host=%s port=%s user=%s password=%s dbname=%s sslmode=%s",
 		quotePGValue(cfg.Host),
 		quotePGValue(cfg.Port),
 		quotePGValue(cfg.User),
 		quotePGValue(string(cfg.Password)),
-		quotePGValue(cfg.Name))
+		quotePGValue(cfg.Name),
+		quotePGValue(sslMode))
 }

--- a/internal/infra/db/config_test.go
+++ b/internal/infra/db/config_test.go
@@ -29,6 +29,39 @@ func TestBuildDSN_TCP(t *testing.T) {
 	}
 }
 
+// TestBuildDSN_SSLMode は TCP 接続で SSLMode が指定された場合に DSN へ反映され、
+// 未指定なら DefaultSSLMode（disable）にフォールバックすることを検証します。
+func TestBuildDSN_SSLMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		sslMode  string
+		expected string
+	}{
+		{
+			name:     "explicit require",
+			sslMode:  "require",
+			expected: "host=localhost port=5432 user=u password=p dbname=d sslmode=require",
+		},
+		{
+			name:     "empty falls back to disable",
+			sslMode:  "",
+			expected: "host=localhost port=5432 user=u password=p dbname=d sslmode=disable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := Config{User: "u", Password: "p", Name: "d", Host: "localhost", Port: "5432", SSLMode: tt.sslMode}
+			if got := BuildDSN(cfg); got != tt.expected {
+				t.Errorf("BuildDSN mismatch\n want: %q\n  got: %q", tt.expected, got)
+			}
+		})
+	}
+}
+
 // TestBuildDSN_CloudSQL はCloud SQL Unixソケット接続用のDSN文字列が正しく生成されることを検証します。
 func TestBuildDSN_CloudSQL(t *testing.T) {
 	t.Parallel()

--- a/internal/infra/db/sql.go
+++ b/internal/infra/db/sql.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -8,6 +9,10 @@ import (
 
 	_ "github.com/jackc/pgx/v5/stdlib" // database/sql driver "pgx" の登録
 )
+
+// pingTimeout は接続確認 (PingContext) のタイムアウトです。
+// 接続先がハングした場合でも有限時間で失敗させ、起動時の挙動を安定させます。
+const pingTimeout = 5 * time.Second
 
 // SQLOpener は database/sql のコネクションを開く関数型です。
 // テストでモック化するために関数型として定義します。
@@ -60,7 +65,10 @@ func DefaultSQLOpener(dsn string) (*sql.DB, error) {
 		return nil, err
 	}
 	// sql.Open はコネクション確立を遅延するため、Ping で疎通確認する。
-	if err := db.Ping(); err != nil {
+	// ハング時に有限時間で失敗させるためタイムアウト付きコンテキストを使う。
+	ctx, cancel := context.WithTimeout(context.Background(), pingTimeout)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
 		_ = db.Close()
 		return nil, err
 	}

--- a/internal/infra/db/sql.go
+++ b/internal/infra/db/sql.go
@@ -37,7 +37,35 @@ func openSQLWithRetry(cfg Config, timeout time.Duration, opener SQLOpener) (*sql
 	}
 	dsn := BuildDSN(cfg)
 
-	return ConnectSQLWithRetry(dsn, timeout, opener)
+	db, err := ConnectSQLWithRetry(dsn, timeout, opener)
+	if err != nil {
+		return nil, err
+	}
+	configurePool(db, cfg)
+	return db, nil
+}
+
+// configurePool は cfg に基づいてコネクションプールを設定します。
+// 各値がゼロ値（未設定）の場合は Default* 定数にフォールバックします。
+// SetMaxOpenConns 等は接続を必要としないセッターのため、接続確立後の呼び出しで問題ありません。
+func configurePool(db *sql.DB, cfg Config) {
+	maxOpen := cfg.MaxOpenConns
+	if maxOpen <= 0 {
+		maxOpen = DefaultMaxOpenConns
+	}
+	db.SetMaxOpenConns(maxOpen)
+
+	maxIdle := cfg.MaxIdleConns
+	if maxIdle <= 0 {
+		maxIdle = DefaultMaxIdleConns
+	}
+	db.SetMaxIdleConns(maxIdle)
+
+	lifetime := cfg.ConnMaxLifetime
+	if lifetime <= 0 {
+		lifetime = DefaultConnMaxLifetime
+	}
+	db.SetConnMaxLifetime(lifetime)
 }
 
 // ConnectSQLWithRetry はリトライ付きで *sql.DB を取得します。
@@ -58,7 +86,7 @@ func ConnectSQLWithRetry(dsn string, timeout time.Duration, opener SQLOpener) (*
 }
 
 // DefaultSQLOpener は pgx/v5/stdlib driver で PostgreSQL に接続する SQLOpener です。
-// 接続プールのデフォルト値はそのままで、必要に応じて呼び出し側で SetMaxOpenConns 等を調整します。
+// コネクションプールの設定は呼び出し元（openSQLWithRetry）が configurePool で行います。
 func DefaultSQLOpener(dsn string) (*sql.DB, error) {
 	db, err := sql.Open("pgx", dsn)
 	if err != nil {

--- a/internal/infra/db/sql_test.go
+++ b/internal/infra/db/sql_test.go
@@ -93,6 +93,31 @@ func TestConnectSQLWithRetry_ErrorWrapped(t *testing.T) {
 	}
 }
 
+// TestConfigurePool_AppliesDefaults は cfg の値がゼロのとき Default* がプールに適用されることを検証します。
+// MaxIdleConns / ConnMaxLifetime は database/sql に getter がないため、検証可能な MaxOpenConnections を確認します。
+func TestConfigurePool_AppliesDefaults(t *testing.T) {
+	t.Parallel()
+
+	db := &sql.DB{}
+	configurePool(db, Config{})
+
+	if got := db.Stats().MaxOpenConnections; got != DefaultMaxOpenConns {
+		t.Errorf("expected MaxOpenConnections %d, got %d", DefaultMaxOpenConns, got)
+	}
+}
+
+// TestConfigurePool_AppliesExplicit は cfg に明示された値がプールに適用されることを検証します。
+func TestConfigurePool_AppliesExplicit(t *testing.T) {
+	t.Parallel()
+
+	db := &sql.DB{}
+	configurePool(db, Config{MaxOpenConns: 7, MaxIdleConns: 3, ConnMaxLifetime: time.Minute})
+
+	if got := db.Stats().MaxOpenConnections; got != 7 {
+		t.Errorf("expected MaxOpenConnections 7, got %d", got)
+	}
+}
+
 func TestOpenSQL_InvalidConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## 概要
本番（Cloud Run 複数インスタンス × Cloud SQL）を見据えて DB 接続の弱点を解消します。コネクションプール未設定による接続枯渇リスク、コンテキスト無し Ping によるハング、sslmode のハードコードに対応します。

## 変更内容
- **コネクションプール設定**: 接続確立後に `SetMaxOpenConns` / `SetMaxIdleConns` / `SetConnMaxLifetime` を適用する `configurePool` を追加。`DB_MAX_OPEN_CONNS` / `DB_MAX_IDLE_CONNS` / `DB_CONN_MAX_LIFETIME` で設定でき、未設定時は db パッケージのデフォルト（最大25接続・生存時間5分）にフォールバック
- **PingContext 化**: `db.Ping()` を 5 秒タイムアウト付きの `PingContext` に置き換え、接続先ハング時に有限時間で失敗するように変更
- **sslmode 環境変数化**: `BuildDSN` でハードコードしていた `sslmode=disable` を `DB_SSLMODE` で上書き可能に（未設定時はデフォルトの `disable`）
- `internal/app/config` に `readInt` / `readDuration` ヘルパーを追加し、不正値は警告として蓄積
- `docker/example.env` に新しい環境変数の例を追記

## テスト
- `BuildDSN` の sslmode 反映・フォールバック、`configurePool` のデフォルト/明示値適用、`readInt` / `readDuration` のパースをユニットテストで追加
- `go build ./...` / 対象パッケージの `go test` / `golangci-lint` / `go-arch-lint check` がすべてパス

## レビューポイント
- 環境変数で未設定の値は config 層ではゼロ値のままにし、デフォルト適用を db パッケージ側（`Default*` 定数）に一元化しています
- 新しい環境変数はすべて任意で、未設定時の挙動は従来と互換（プールのみデフォルト上限が付与されます）