### PR TITLE
refactor: リクエスト検証を OpenAPI スペック駆動に移行

### DIFF
--- a/.go-arch-lint.yml
+++ b/.go-arch-lint.yml
@@ -41,6 +41,8 @@ components:
   infra:     { in: internal/infra/** }
   shared:    { in: internal/shared/** }
   api:      { in: internal/api }
+  # OpenAPI スペック（openapi.yaml）を埋め込む repo 直下の api パッケージ。
+  apispec:  { in: api }
   app:      { in: internal/app/** }
   cmd:      { in: cmd/** }
   # マイグレーション SQL を埋め込む repo 直下の db パッケージ。
@@ -70,7 +72,7 @@ deps:
   # transport（inbound HTTP）/ infra（技術基盤）は feature に依存できない。
   # transport は infra・共通基盤・api 型に依存可。infra は共通基盤・api 型・埋め込み migrations に依存可。
   # それぞれ内部のパッケージ間依存を許可するため自身も含める（例: infra の db/dbtest → db）。
-  transport: { mayDependOn: [transport, infra, shared, api] }
+  transport: { mayDependOn: [transport, infra, shared, api, apispec] }
   infra:     { mayDependOn: [infra, shared, api, migrations-embed] }
 
   # 合成ルート（DI/ルーティング/エントリポイント）は全コンポーネントに依存可。
@@ -95,6 +97,7 @@ deps:
       - infra
       - shared
       - api
+      - apispec
   cmd:
     mayDependOn:
       - app
@@ -115,3 +118,4 @@ deps:
       - infra
       - shared
       - api
+      - apispec

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -244,7 +244,7 @@ paths:
         - name: outputsize
           in: query
           required: false
-          description: "取得件数（1〜5000。範囲外の値が指定された場合は200に丸めて扱う）"
+          description: "取得件数（1〜5000。範囲外の値が指定された場合は400を返す）"
           schema:
             type: integer
             default: 200
@@ -260,7 +260,7 @@ paths:
                 items:
                   $ref: "#/components/schemas/CandleResponse"
         "400":
-          description: バリデーションエラー（outputsizeに整数以外、未対応のinterval等）
+          description: バリデーションエラー（outputsizeに整数以外、outputsize範囲外、未対応のinterval等）
           content:
             application/json:
               schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -615,14 +615,10 @@ components:
           format: email
           description: メールアドレス
           x-go-type: string
-          x-oapi-codegen-extra-tags:
-            binding: "required,email"
         password:
           type: string
           minLength: 12
           description: パスワード（12文字以上）
-          x-oapi-codegen-extra-tags:
-            binding: "required,min=12"
 
     LoginRequest:
       type: object
@@ -635,13 +631,10 @@ components:
           format: email
           description: メールアドレス
           x-go-type: string
-          x-oapi-codegen-extra-tags:
-            binding: "required,email"
         password:
           type: string
+          minLength: 1
           description: パスワード
-          x-oapi-codegen-extra-tags:
-            binding: "required"
 
     CandleResponse:
       type: object
@@ -720,9 +713,8 @@ components:
       properties:
         company_name:
           type: string
+          minLength: 1
           description: 分析対象の企業名
-          x-oapi-codegen-extra-tags:
-            binding: "required"
 
     DetectedLogoResponse:
       type: object
@@ -780,8 +772,6 @@ components:
           maxLength: 20
           pattern: "^[A-Za-z0-9._-]{1,20}$"
           description: "追加する銘柄コード（例: AAPL, 7203.T）"
-          x-oapi-codegen-extra-tags:
-            binding: "required,min=1,max=20"
 
     ReorderWatchlistRequest:
       type: object
@@ -798,8 +788,6 @@ components:
             minLength: 1
             maxLength: 20
             pattern: "^[A-Za-z0-9._-]{1,20}$"
-          x-oapi-codegen-extra-tags:
-            binding: "required,min=1"
 
     HealthResponse:
       type: object

--- a/api/spec.go
+++ b/api/spec.go
@@ -1,0 +1,42 @@
+// Package apispec は OpenAPI スペック（openapi.yaml）をバイナリに埋め込み、
+// パース済みの *openapi3.T として提供します。
+// リクエストバリデーションミドルウェア（internal/transport/openapivalidate）が
+// この契約を単一ソースとして実行時検証に利用します。
+package apispec
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func init() {
+	// kin-openapi はデフォルトで email など一部の string format を検証しない
+	// （byte / date / date-time / int32 / int64 のみ登録済み）。
+	// spec の `format: email` を実行時に強制するため、email バリデータを登録する。
+	openapi3.DefineStringFormatValidator("email", openapi3.NewRegexpFormatValidator(openapi3.FormatOfStringForEmail))
+}
+
+// specYAML は OpenAPI 3.0 スペックの生データです。
+// 埋め込みディレクティブは同一ディレクトリ以下しか参照できないため、
+// このファイルは openapi.yaml と同じ api/ に配置しています。
+//
+//go:embed openapi.yaml
+var specYAML []byte
+
+// Load は埋め込まれた OpenAPI スペックをパース・検証して返します。
+// スペック自体の妥当性検証（doc.Validate）まで行うため、契約の不整合は
+// アプリ起動時に検出できます。
+func Load() (*openapi3.T, error) {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(specYAML)
+	if err != nil {
+		return nil, fmt.Errorf("OpenAPI スペックのパースに失敗: %w", err)
+	}
+	if err := doc.Validate(context.Background()); err != nil {
+		return nil, fmt.Errorf("OpenAPI スペックの検証に失敗: %w", err)
+	}
+	return doc, nil
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -32,6 +32,7 @@ import (
 	infraredis "github.com/UCHIDAnobuhiro/stock-backend/internal/infra/redis"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/openapivalidate"
 )
 
 // main は run の戻り値で os.Exit するだけのラッパー。
@@ -140,8 +141,15 @@ func run() int {
 	logoH := logodetectionhttp.NewHandler(logoUC)
 	watchlistH := watchlisthttp.NewHandler(watchlistUC)
 
+	// OpenAPI スペックに基づくリクエストバリデーションミドルウェア
+	openapiValidator, err := openapivalidate.New()
+	if err != nil {
+		slog.Error("failed to set up OpenAPI request validator", "error", err)
+		return 1
+	}
+
 	// ルーター作成
-	r := router.NewRouter(authH, oauthH, candlesH, symbolH, logoH, watchlistH, rateLimiter, cfg.Server.CORSOrigins, cfg.Server.GCPProjectID, cfg.Server.JWTSecret)
+	r := router.NewRouter(authH, oauthH, candlesH, symbolH, logoH, watchlistH, rateLimiter, openapiValidator, cfg.Server.CORSOrigins, cfg.Server.GCPProjectID, cfg.Server.JWTSecret)
 
 	srv := &http.Server{
 		Addr:              ":8080",

--- a/docs/features/candles.md
+++ b/docs/features/candles.md
@@ -144,8 +144,8 @@ sequenceDiagram
 **クエリパラメータ**
 | パラメータ | デフォルト | 説明 |
 |-----------|-----------|------|
-| `interval` | `1day` | 時間間隔（`1day`, `1week`, `1month`） |
-| `outputsize` | `200` | 返却するデータポイント数（最大: 5000） |
+| `interval` | `1day` | 時間間隔（`1day`, `1week`, `1month`）。未指定時のみデフォルト適用。空文字や未対応値は `400` |
+| `outputsize` | `200` | 返却するデータポイント数（`1`〜`5000`）。範囲外・整数以外は `400` |
 
 **リクエスト例（Cookieベース）**
 ```http
@@ -287,9 +287,9 @@ graph TB
 - **API型**（`internal/api/types.gen.go`）: OpenAPI仕様から自動生成された `api.CandleResponse` を使用
 
 #### ユースケース層
-- **Usecase**（[usecase.go](../../internal/feature/candles/usecase.go)）: パラメータバリデーション付きのローソク足データ取得
-  - インターバルとoutputsizeのデフォルト値を適用
-  - 最大outputsize制限（5000）を適用
+- **Usecase**（[usecase.go](../../internal/feature/candles/usecase.go)）: ローソク足データ取得
+  - パラメータの妥当性検証は OpenAPI バリデーションミドルウェアと handler が担うため、usecase は受け取った値をそのままリポジトリへ渡す（丸めやデフォルト化はしない）
+  - 未指定時のデフォルト（`interval=1day` / `outputsize=200`）は handler が補う
   - `Repository`インターフェース（読み取り専用）を定義（Goの「インターフェースは利用者が定義する」慣例に従う）
 - **IngestUsecase**（[ingest.go](../../internal/feature/candles/ingest.go)）: 外部APIからのバッチデータ取り込み
   - アクティブな銘柄（コード + IANA タイムゾーン）を取得

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,13 @@ go 1.26.3
 
 require (
 	cloud.google.com/go/vision/v2 v2.14.0
+	github.com/getkin/kin-openapi v0.133.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2
-	github.com/go-playground/validator/v10 v10.30.3
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/oapi-codegen/nethttp-middleware v1.1.2
 	github.com/oapi-codegen/runtime v1.4.1
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/redis/go-redis/v9 v9.20.1
@@ -67,8 +68,6 @@ require (
 	github.com/fe3dback/go-arch-lint v1.15.0 // indirect
 	github.com/fe3dback/go-yaml v1.14.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
-	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
-	github.com/getkin/kin-openapi v0.133.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -76,8 +75,7 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-playground/locales v0.14.1 // indirect
-	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-playground/validator/v10 v10.30.3 // indirect
 	github.com/go-sourcemap/sourcemap v2.1.3+incompatible // indirect
 	github.com/go-sql-driver/mysql v1.9.3 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
@@ -91,6 +89,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
@@ -102,7 +101,6 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/logrusorgru/aurora/v3 v3.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,6 @@ github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+Gr
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
 github.com/go-pdf/fpdf v0.6.0 h1:MlgtGIfsdMEEQJr2le6b/HNr1ZlQwxyWr77r2aj2U/8=
 github.com/go-pdf/fpdf v0.6.0/go.mod h1:HzcnA+A23uwogo0tp9yU+l3V+KXhiESpt1PMayhOh5M=
-github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
-github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -272,6 +270,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.16 h1:F/VPrx0YPBdksZJQdC
 github.com/googleapis/enterprise-certificate-proxy v0.3.16/go.mod h1:9Yb0eAkH/Xqhvv3zbeKf/+wMJqCeocWc6KIhDvEAuYE=
 github.com/googleapis/gax-go/v2 v2.22.0 h1:PjIWBpgGIVKGoCXuiCoP64altEJCj3/Ei+kSU5vlZD4=
 github.com/googleapis/gax-go/v2 v2.22.0/go.mod h1:irWBbALSr0Sk3qlqb9SyJ1h68WjgeFuiOzI4Rqw5+aY=
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
@@ -372,6 +372,8 @@ github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJm
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
+github.com/oapi-codegen/nethttp-middleware v1.1.2 h1:TQwEU3WM6ifc7ObBEtiJgbRPaCe513tvJpiMJjypVPA=
+github.com/oapi-codegen/nethttp-middleware v1.1.2/go.mod h1:5qzjxMSiI8HjLljiOEjvs4RdrWyMPKnExeFS2kr8om4=
 github.com/oapi-codegen/oapi-codegen/v2 v2.5.1 h1:5vHNY1uuPBRBWqB2Dp0G7YB03phxLQZupZTIZaeorjc=
 github.com/oapi-codegen/oapi-codegen/v2 v2.5.1/go.mod h1:ro0npU1BWkcGpCgGD9QwPp44l5OIZ94tB3eabnT7DjQ=
 github.com/oapi-codegen/runtime v1.4.1 h1:9nwLoI+KrWxzbBcp0jO/R8uXqbik/HUyCvPeU68Y/qo=

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -33,7 +33,7 @@ const (
 // AddWatchlistRequest defines model for AddWatchlistRequest.
 type AddWatchlistRequest struct {
 	// SymbolCode 追加する銘柄コード（例: AAPL, 7203.T）
-	SymbolCode string `binding:"required,min=1,max=20" json:"symbol_code"`
+	SymbolCode string `json:"symbol_code"`
 }
 
 // CandleResponse defines model for CandleResponse.
@@ -60,7 +60,7 @@ type CandleResponse struct {
 // CompanyAnalysisRequest defines model for CompanyAnalysisRequest.
 type CompanyAnalysisRequest struct {
 	// CompanyName 分析対象の企業名
-	CompanyName string `binding:"required" json:"company_name"`
+	CompanyName string `json:"company_name"`
 }
 
 // CompanyAnalysisResponse defines model for CompanyAnalysisResponse.
@@ -96,10 +96,10 @@ type HealthResponse struct {
 // LoginRequest defines model for LoginRequest.
 type LoginRequest struct {
 	// Email メールアドレス
-	Email string `binding:"required,email" json:"email"`
+	Email string `json:"email"`
 
 	// Password パスワード
-	Password string `binding:"required" json:"password"`
+	Password string `json:"password"`
 }
 
 // MessageResponse defines model for MessageResponse.
@@ -110,16 +110,16 @@ type MessageResponse struct {
 // ReorderWatchlistRequest defines model for ReorderWatchlistRequest.
 type ReorderWatchlistRequest struct {
 	// Codes 新しい順序での銘柄コード一覧
-	Codes []string `binding:"required,min=1" json:"codes"`
+	Codes []string `json:"codes"`
 }
 
 // SignupRequest defines model for SignupRequest.
 type SignupRequest struct {
 	// Email メールアドレス
-	Email string `binding:"required,email" json:"email"`
+	Email string `json:"email"`
 
 	// Password パスワード（12文字以上）
-	Password string `binding:"required,min=12" json:"password"`
+	Password string `json:"password"`
 }
 
 // SymbolItem defines model for SymbolItem.

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -28,6 +28,7 @@ func NewRouter(authHandler *authhttp.Handler, oauthHandler *authhttp.OAuthHandle
 	symbol *symbollisthttp.Handler, logo *logodetectionhttp.Handler,
 	watchlist *watchlisthttp.Handler,
 	limiter *httpratelimit.Limiter,
+	openapiValidator func(http.Handler) http.Handler,
 	allowedOrigins []string,
 	gcpProjectID string,
 	jwtSecret string,
@@ -54,38 +55,46 @@ func NewRouter(authHandler *authhttp.Handler, oauthHandler *authhttp.OAuthHandle
 
 	// API v1 ルート
 	r.Route("/v1", func(r chi.Router) {
-		// 公開ルート（認証不要）+ レートリミット
-		r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
-			Prefix: "rl:signup:ip",
-			Limit:  5,
-			Window: 1 * time.Hour,
-		})).Post("/signup", authHandler.Signup)
+		// 公開ルート（認証不要）+ レートリミット + OpenAPI バリデーション。
+		// OpenAPI スペックに基づき、パス/クエリ/JSON ボディを契約準拠で検証する。
+		r.Group(func(r chi.Router) {
+			r.Use(openapiValidator)
 
-		r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
-			Prefix: "rl:login:ip",
-			Limit:  10,
-			Window: 1 * time.Minute,
-		})).Post("/login", authHandler.Login)
+			r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
+				Prefix: "rl:signup:ip",
+				Limit:  5,
+				Window: 1 * time.Hour,
+			})).Post("/signup", authHandler.Signup)
 
-		// 期限切れトークンでもログアウトできるよう認証不要
-		r.Delete("/logout", authHandler.Logout)
+			r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
+				Prefix: "rl:login:ip",
+				Limit:  10,
+				Window: 1 * time.Minute,
+			})).Post("/login", authHandler.Login)
 
-		// OAuthルート（環境変数が設定されている場合のみ登録）
-		if oauthHandler != nil {
-			r.Route("/auth/oauth", func(r chi.Router) {
-				r.Get("/{provider}", oauthHandler.BeginAuth)
-				r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
-					Prefix: "rl:oauth:callback:ip",
-					Limit:  20,
-					Window: 1 * time.Minute,
-				})).Get("/{provider}/callback", oauthHandler.Callback)
-			})
-		}
+			// 期限切れトークンでもログアウトできるよう認証不要
+			r.Delete("/logout", authHandler.Logout)
+
+			// OAuthルート（環境変数が設定されている場合のみ登録）
+			if oauthHandler != nil {
+				r.Route("/auth/oauth", func(r chi.Router) {
+					r.Get("/{provider}", oauthHandler.BeginAuth)
+					r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
+						Prefix: "rl:oauth:callback:ip",
+						Limit:  20,
+						Window: 1 * time.Minute,
+					})).Get("/{provider}/callback", oauthHandler.Callback)
+				})
+			}
+		})
 
 		// 保護ルート（認証必須・CSRF保護）
+		// バリデーションは認証・CSRF の後に行う（未認証/CSRF 不正は 401/403 を優先し、
+		// 認証済みリクエストのボディ/パラメータのみ spec 準拠で検証する）。
 		r.Group(func(r chi.Router) {
 			r.Use(jwt.AuthRequired(jwtSecret))
 			r.Use(csrfmw.Protect())
+			r.Use(openapiValidator)
 
 			r.Get("/candles/{code}", candles.GetCandlesHandler)
 			r.Get("/symbols", symbol.List)

--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -18,8 +18,8 @@ import (
 )
 
 // setAuthCookie は SameSite=Lax の認証関連 Cookie をレスポンスへ設定します。
-// Gin の SetSameSite + SetCookie の組をまとめたヘルパーで、auth_token / csrf_token の
-// 設定・削除に共通利用します。maxAge は秒数（削除時は -1）です。
+// auth_token / csrf_token の設定・削除に共通利用します。
+// maxAge は秒数（削除時は -1）です。
 func setAuthCookie(w http.ResponseWriter, name, value string, maxAge int, secure, httpOnly bool) {
 	http.SetCookie(w, &http.Cookie{
 		Name:     name,

--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -71,7 +71,7 @@ func NewHandler(uc Usecase, limiter *httpratelimit.Limiter, secureCookie bool, p
 // - 成功時は201を返却
 func (h *Handler) Signup(w http.ResponseWriter, r *http.Request) {
 	var req api.SignupRequest
-	if err := httpx.DecodeAndValidate(r, &req); err != nil {
+	if err := httpx.DecodeJSON(r, &req); err != nil {
 		slog.Warn("signup validation failed", "error", err, "remote_addr", httpx.ClientIP(r))
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
@@ -101,7 +101,7 @@ func (h *Handler) Signup(w http.ResponseWriter, r *http.Request) {
 // - 認証成功時はJWTトークン付きで200を返却
 func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	var req api.LoginRequest
-	if err := httpx.DecodeAndValidate(r, &req); err != nil {
+	if err := httpx.DecodeJSON(r, &req); err != nil {
 		slog.Warn("login validation failed", "error", err, "remote_addr", httpx.ClientIP(r))
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return

--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
 )
 
-// H は JSON ボディ構築用の簡易マップ型です（旧 gin.H 相当）。
+// H は JSON ボディ構築用の簡易マップ型です。
 type H = map[string]any
 
 // mockUsecase はUsecaseインターフェースのモック実装です。

--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -125,20 +125,9 @@ func TestAuthHandler_Signup(t *testing.T) {
 			expectedStatus: http.StatusCreated,
 			expectedBody:   H{"message": "ok"},
 		},
-		{
-			name:           "failure: invalid email address",
-			requestBody:    H{"email": "invalid-email", "password": "password12345"},
-			mockSignupFunc: nil, // Usecaseは呼ばれない
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   H{"error": "invalid request"},
-		},
-		{
-			name:           "failure: short password",
-			requestBody:    H{"email": "test@example.com", "password": "short"},
-			mockSignupFunc: nil, // Usecaseは呼ばれない
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   H{"error": "invalid request"},
-		},
+		// 注: email 形式・password 長さ等のスキーマバリデーションは
+		// OpenAPI バリデーションミドルウェア（internal/transport/openapivalidate）の
+		// 責務に移行したため、その検証は middleware_test.go で実施する。
 		{
 			name:        "failure: duplicate email (usecase error)",
 			requestBody: H{"email": "existing@example.com", "password": "password12345"},
@@ -235,20 +224,8 @@ func TestAuthHandler_Login(t *testing.T) {
 			checkCookies:   true,
 			secureCookie:   true,
 		},
-		{
-			name:           "failure: invalid email address",
-			requestBody:    H{"email": "invalid-email", "password": "password12345"},
-			mockLoginFunc:  nil, // Usecaseは呼ばれない
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   H{"error": "invalid request"},
-		},
-		{
-			name:           "failure: missing password",
-			requestBody:    H{"email": "test@example.com"},
-			mockLoginFunc:  nil, // Usecaseは呼ばれない
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   H{"error": "invalid request"},
-		},
+		// 注: email 形式・必須項目等のスキーマバリデーションは OpenAPI バリデーション
+		// ミドルウェアの責務に移行したため、その検証は middleware_test.go で実施する。
 		{
 			name:        "failure: invalid credentials (usecase error)",
 			requestBody: H{"email": "wrong@example.com", "password": "wrong-password"},

--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -46,8 +46,8 @@ func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	// 未指定の場合はデフォルト値を使用
 	interval := queryOrDefault(r, "interval", "1day")
-	// 空文字（?interval=）は usecase 側でデフォルトに丸めるため、非空の未対応値のみ拒否する。
-	if interval != "" && !candles.IsValidInterval(interval) {
+	// 空文字（?interval=）を含む未対応値は拒否する（OpenAPI spec の enum と整合）。
+	if !candles.IsValidInterval(interval) {
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "unsupported interval"})
 		return
 	}

--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -83,7 +83,7 @@ func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // queryOrDefault はクエリパラメータ key の値を返します。key が存在しない場合のみ def を返します。
-// Gin の c.DefaultQuery と同じく、key が空文字で存在する場合（?interval=）は空文字を返します。
+// key が空文字で存在する場合（?interval=）は空文字を返します。
 func queryOrDefault(r *http.Request, key, def string) string {
 	q := r.URL.Query()
 	if q.Has(key) {

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -86,14 +86,11 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			expectedBody:   `{"error":"unsupported interval"}`,
 		},
 		{
-			name: "success: empty interval falls back to default",
-			url:  "/candles/7203.T?interval=",
-			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				assert.Equal(t, "", interval) // 空文字はハンドラを通過し usecase 側でデフォルトに丸める
-				return []candles.Candle{}, nil
-			},
-			expectedStatus: http.StatusOK,
-			expectedBody:   `[]`,
+			name:           "error: empty interval returns 400",
+			url:            "/candles/7203.T?interval=",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"unsupported interval"}`,
 		},
 		{
 			name:           "error: symbol code with invalid characters returns 400",

--- a/internal/feature/candles/usecase.go
+++ b/internal/feature/candles/usecase.go
@@ -5,10 +5,6 @@ import (
 )
 
 const (
-	// DefaultInterval はローソク足クエリのデフォルト時間間隔です。
-	DefaultInterval = "1day"
-	// DefaultOutputSize はデフォルトのローソク足返却件数です。
-	DefaultOutputSize = 200
 	// MaxOutputSize はローソク足の最大返却件数です。
 	MaxOutputSize = 5000
 )
@@ -44,14 +40,9 @@ func NewUsecase(candle Repository) *usecase {
 }
 
 // GetCandles は指定された銘柄と時間間隔のローソク足データを取得します。
+// interval / outputsize の妥当性は OpenAPI バリデーションミドルウェアと handler が
+// 検証済みのため、ここでは丸めやデフォルト化は行わず受け取った値をそのまま使います。
 func (cu *usecase) GetCandles(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
-	if interval == "" {
-		interval = DefaultInterval
-	}
-	if outputsize <= 0 || outputsize > MaxOutputSize {
-		outputsize = DefaultOutputSize
-	}
-
 	cs, err := cu.candle.Find(ctx, symbol, interval, outputsize)
 	if err != nil {
 		return nil, err

--- a/internal/feature/candles/usecase_test.go
+++ b/internal/feature/candles/usecase_test.go
@@ -60,43 +60,19 @@ func TestCandlesUsecase_GetCandles(t *testing.T) {
 			expectedOutputsize: 50,
 		},
 		{
-			name:            "success: default value used when interval is empty",
+			// interval / outputsize の妥当性は handler・ミドルウェアが検証済みのため、
+			// usecase は受け取った値をそのままリポジトリに渡す（丸めやデフォルト化はしない）。
+			name:            "success: parameters passed through as-is",
 			inputSymbol:     "GOOG",
-			inputInterval:   "",
+			inputInterval:   "1month",
 			inputOutputsize: 100,
 			mockFindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
 				return expectedCandles, nil
 			},
 			expectedCandles:    expectedCandles,
 			expectedErr:        nil,
-			expectedInterval:   "1day",
-			expectedOutputsize: 100,
-		},
-		{
-			name:            "success: default value used when outputsize is 0",
-			inputSymbol:     "MSFT",
-			inputInterval:   "1month",
-			inputOutputsize: 0,
-			mockFindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				return expectedCandles, nil
-			},
-			expectedCandles:    expectedCandles,
-			expectedErr:        nil,
 			expectedInterval:   "1month",
-			expectedOutputsize: 200,
-		},
-		{
-			name:            "success: default value used when outputsize exceeds max",
-			inputSymbol:     "TSLA",
-			inputInterval:   "1day",
-			inputOutputsize: 5001,
-			mockFindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				return expectedCandles, nil
-			},
-			expectedCandles:    expectedCandles,
-			expectedErr:        nil,
-			expectedInterval:   "1day",
-			expectedOutputsize: 200,
+			expectedOutputsize: 100,
 		},
 		{
 			name:            "error: repository returns error",

--- a/internal/feature/logodetection/logodetectionhttp/handler.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler.go
@@ -41,7 +41,7 @@ func (h *Handler) DetectLogos(w http.ResponseWriter, r *http.Request) {
 	// 一時ファイルの肥大を防ぐため、ParseMultipartForm の前段でハードリミットをかける。
 	r.Body = http.MaxBytesReader(w, r.Body, maxImageSize+1<<20)
 
-	// ParseMultipartForm の引数はメモリ上限（Gin の MaxMultipartMemory 相当）。
+	// ParseMultipartForm の引数はメモリ上限。
 	if err := r.ParseMultipartForm(maxImageSize); err != nil {
 		var mbe *http.MaxBytesError
 		if errors.As(err, &mbe) {

--- a/internal/feature/logodetection/logodetectionhttp/handler.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler.go
@@ -103,8 +103,8 @@ func (h *Handler) DetectLogos(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) AnalyzeCompany(w http.ResponseWriter, r *http.Request) {
 	var req api.CompanyAnalysisRequest
 	if err := httpx.DecodeJSON(r, &req); err != nil {
-		slog.Warn("企業分析リクエストのバリデーションに失敗", "error", err, "remote_addr", httpx.ClientIP(r))
-		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "企業名が必要です"})
+		slog.Warn("企業分析リクエストのデコードに失敗", "error", err, "remote_addr", httpx.ClientIP(r))
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
 	}
 

--- a/internal/feature/logodetection/logodetectionhttp/handler.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler.go
@@ -102,7 +102,7 @@ func (h *Handler) DetectLogos(w http.ResponseWriter, r *http.Request) {
 // Content-Type: application/json
 func (h *Handler) AnalyzeCompany(w http.ResponseWriter, r *http.Request) {
 	var req api.CompanyAnalysisRequest
-	if err := httpx.DecodeAndValidate(r, &req); err != nil {
+	if err := httpx.DecodeJSON(r, &req); err != nil {
 		slog.Warn("企業分析リクエストのバリデーションに失敗", "error", err, "remote_addr", httpx.ClientIP(r))
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "企業名が必要です"})
 		return

--- a/internal/feature/logodetection/logodetectionhttp/handler_test.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler_test.go
@@ -142,12 +142,9 @@ func TestLogoDetectionHandler_AnalyzeCompany(t *testing.T) {
 			expectedStatus: http.StatusOK,
 			expectedBody:   `{"company_name":"任天堂","summary":"任天堂の強みは..."}`,
 		},
-		{
-			name:           "error: empty request body",
-			requestBody:    `{}`,
-			expectedStatus: http.StatusBadRequest,
-			expectedBody:   `{"error":"企業名が必要です"}`,
-		},
+		// 注: company_name の必須・空文字チェックは OpenAPI バリデーションミドルウェアの
+		// 責務に移行したため、その検証は middleware_test.go で実施する。
+		// ここではハンドラ自身の JSON デコード失敗分岐のみを検証する。
 		{
 			name:           "error: invalid json",
 			requestBody:    `invalid`,

--- a/internal/feature/logodetection/logodetectionhttp/handler_test.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler_test.go
@@ -149,7 +149,7 @@ func TestLogoDetectionHandler_AnalyzeCompany(t *testing.T) {
 			name:           "error: invalid json",
 			requestBody:    `invalid`,
 			expectedStatus: http.StatusBadRequest,
-			expectedBody:   `{"error":"企業名が必要です"}`,
+			expectedBody:   `{"error":"invalid request"}`,
 		},
 		{
 			name:        "error: usecase returns error",

--- a/internal/feature/watchlist/watchlisthttp/handler.go
+++ b/internal/feature/watchlist/watchlisthttp/handler.go
@@ -72,7 +72,7 @@ func (h *Handler) Add(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req api.AddWatchlistRequest
-	if err := httpx.DecodeAndValidate(r, &req); err != nil {
+	if err := httpx.DecodeJSON(r, &req); err != nil {
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
 	}
@@ -133,7 +133,7 @@ func (h *Handler) Reorder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req api.ReorderWatchlistRequest
-	if err := httpx.DecodeAndValidate(r, &req); err != nil {
+	if err := httpx.DecodeJSON(r, &req); err != nil {
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "invalid request"})
 		return
 	}

--- a/internal/feature/watchlist/watchlisthttp/handler_test.go
+++ b/internal/feature/watchlist/watchlisthttp/handler_test.go
@@ -175,8 +175,10 @@ func TestWatchlistHandler_Add(t *testing.T) {
 			expectedBody:   `{"error":"symbol already in watchlist"}`,
 		},
 		{
-			name:           "error: invalid request body returns 400",
-			body:           `{"symbol_code":""}`,
+			// 空文字・必須等のスキーマ検証はミドルウェアの責務（middleware_test.go）。
+			// ここではハンドラ自身の JSON デコード失敗分岐を検証する。
+			name:           "error: malformed JSON returns 400",
+			body:           `{"symbol_code":`,
 			mockAdd:        nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"error":"invalid request"}`,
@@ -403,8 +405,10 @@ func TestWatchlistHandler_Reorder(t *testing.T) {
 			expectedBody:   "",
 		},
 		{
-			name:           "error: invalid request body returns 400",
-			body:           `{"codes":[]}`,
+			// 空配列・必須等のスキーマ検証はミドルウェアの責務（middleware_test.go）。
+			// ここではハンドラ自身の JSON デコード失敗分岐を検証する。
+			name:           "error: malformed JSON returns 400",
+			body:           `{"codes":`,
 			mockReorder:    nil,
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"error":"invalid request"}`,

--- a/internal/transport/httpx/httpx.go
+++ b/internal/transport/httpx/httpx.go
@@ -1,26 +1,12 @@
-// Package httpx は net/http ハンドラー向けの共通ユーティリティを提供します。
-// Gin の c.JSON / c.ShouldBindJSON / c.ClientIP に相当する処理を、
-// 標準ライブラリベースで再実装し、各ハンドラーから利用します。
+// Package httpx は net/http ハンドラー向けの共通ユーティリティ
+// （JSON レスポンス書き出し・JSON ボディデコード・クライアント IP 取得）を提供します。
 package httpx
 
 import (
 	"encoding/json"
 	"net"
 	"net/http"
-
-	"github.com/go-playground/validator/v10"
 )
-
-// validate は構造体タグによるバリデーションを行うシングルトンです。
-// api パッケージの型は `binding:"..."` タグ（Gin 由来）を持つため、
-// validator のタグ名を "binding" に切り替えて既存タグをそのまま利用します。
-var validate = newValidator()
-
-func newValidator() *validator.Validate {
-	v := validator.New(validator.WithRequiredStructEnabled())
-	v.SetTagName("binding")
-	return v
-}
 
 // WriteJSON は status コードと共に v を JSON としてレスポンスへ書き込みます。
 // Gin の c.JSON 相当です。エンコードに失敗した場合はステータス設定後のため
@@ -34,15 +20,13 @@ func WriteJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-// DecodeAndValidate はリクエストボディを JSON として dst にデコードし、
-// `binding` タグに基づくバリデーションを実行します。Gin の c.ShouldBindJSON 相当です。
-// デコードまたはバリデーションに失敗した場合はエラーを返します。
-func DecodeAndValidate(r *http.Request, dst any) error {
-	dec := json.NewDecoder(r.Body)
-	if err := dec.Decode(dst); err != nil {
-		return err
-	}
-	return validate.Struct(dst)
+// DecodeJSON はリクエストボディを JSON として dst にデコードします。
+// スキーマに基づくバリデーション（required / format / minLength 等）は
+// OpenAPI バリデーションミドルウェア（internal/transport/openapivalidate）が
+// ハンドラ到達前に実施するため、ここでは型へのデコードのみを行います。
+// JSON 構文エラー等のデコード失敗時はエラーを返します。
+func DecodeJSON(r *http.Request, dst any) error {
+	return json.NewDecoder(r.Body).Decode(dst)
 }
 
 // ClientIP はリクエスト元のIPアドレスを返します。

--- a/internal/transport/httpx/httpx.go
+++ b/internal/transport/httpx/httpx.go
@@ -9,7 +9,7 @@ import (
 )
 
 // WriteJSON は status コードと共に v を JSON としてレスポンスへ書き込みます。
-// Gin の c.JSON 相当です。エンコードに失敗した場合はステータス設定後のため
+// エンコードに失敗した場合はステータス設定後のため
 // それ以上の回復はできず、呼び出し側の責務として v は常にエンコード可能であることを前提とします。
 func WriteJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -30,8 +30,8 @@ func DecodeJSON(r *http.Request, dst any) error {
 }
 
 // ClientIP はリクエスト元のIPアドレスを返します。
-// Gin の SetTrustedProxies(nil) + c.ClientIP() と同様に、X-Forwarded-For 等の
-// プロキシヘッダーは信頼せず、TCP接続元（RemoteAddr）のホスト部のみを返します。
+// X-Forwarded-For 等のプロキシヘッダーは信頼せず、TCP接続元（RemoteAddr）の
+// ホスト部のみを返します。
 func ClientIP(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/internal/transport/middleware/recover.go
+++ b/internal/transport/middleware/recover.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Recover はハンドラー内で発生した panic を回復し、500 を返すミドルウェアを返します。
-// gin.Recovery() の代替で、AccessLog の内側に配置することで panic を 500 に変換した結果も
+// AccessLog の内側に配置することで panic を 500 に変換した結果も
 // アクセスログに記録されます。
 func Recover() func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {

--- a/internal/transport/openapivalidate/middleware.go
+++ b/internal/transport/openapivalidate/middleware.go
@@ -1,0 +1,67 @@
+// Package openapivalidate は OpenAPI スペックを単一ソースとして、受信リクエストを
+// 実行時に検証する net/http ミドルウェアを提供します。
+// バリデーション制約（required / format / minLength 等）は api/openapi.yaml に集約し、
+// Go 側に検証タグを持たせません。
+package openapivalidate
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/getkin/kin-openapi/openapi3filter"
+	nethttpmiddleware "github.com/oapi-codegen/nethttp-middleware"
+
+	apispec "github.com/UCHIDAnobuhiro/stock-backend/api"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
+)
+
+// skipPaths は OpenAPI バリデーションを適用しないパスです。
+// /v1/logo/detect は multipart/form-data で、ハンドラ側が独自に 10MB の
+// ストリーム制御（http.MaxBytesReader）を行うため、kin-openapi による
+// multipart パースとの二重読みを避けて検証をスキップします。
+var skipPaths = map[string]bool{
+	"/v1/logo/detect": true,
+}
+
+// New は埋め込み OpenAPI スペックに基づくリクエストバリデーションミドルウェアを生成します。
+// スペックのロード・検証に失敗した場合はエラーを返します（起動時に検出）。
+func New() (func(http.Handler) http.Handler, error) {
+	spec, err := apispec.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	opts := &nethttpmiddleware.Options{
+		Options: openapi3filter.Options{
+			// 認証は jwt / csrf ミドルウェアが担うため、検証層では認証を no-op にする。
+			// spec の protected route は security: [cookieAuth] を宣言しており、
+			// これを設定しないと openapi3filter が認証器不在でエラーになる。
+			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
+		},
+		// バリデーション失敗時は詳細をログに残しつつ、クライアントへは汎用文言を返す
+		// （スキーマ内部情報を外部に漏らさない）。
+		ErrorHandler: func(w http.ResponseWriter, message string, statusCode int) {
+			slog.Warn("OpenAPI リクエストバリデーション失敗", "message", message, "status", statusCode)
+			httpx.WriteJSON(w, statusCode, api.ErrorResponse{Error: "invalid request"})
+		},
+		// servers の Host 検証を無効化する。実行環境（localhost / Cloud Run のホスト名）で
+		// Host が変わると "no matching operation" の 400 になるため、パスベース検証のみ行う。
+		DoNotValidateServers: true,
+	}
+
+	validator := nethttpmiddleware.OapiRequestValidatorWithOptions(spec, opts)
+
+	// multipart エンドポイントや CORS preflight は検証対象外にするためのラッパー。
+	// （nethttp-middleware v1.1.2 には Skipper オプションが無いため自前で分岐する）
+	return func(next http.Handler) http.Handler {
+		validated := validator(next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodOptions || skipPaths[r.URL.Path] {
+				next.ServeHTTP(w, r)
+				return
+			}
+			validated.ServeHTTP(w, r)
+		})
+	}, nil
+}

--- a/internal/transport/openapivalidate/middleware_test.go
+++ b/internal/transport/openapivalidate/middleware_test.go
@@ -1,0 +1,115 @@
+package openapivalidate_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/openapivalidate"
+)
+
+// newValidatedRouter は OpenAPI バリデーションミドルウェアを /v1 に適用したルーターを返す。
+// 各ルートは到達したら 200 を返すだけのダミーハンドラーに繋ぐ。
+// （バリデーション通過 = 200、バリデーション失敗 = ミドルウェアが 400 を返す）
+func newValidatedRouter(t *testing.T) http.Handler {
+	t.Helper()
+
+	validator, err := openapivalidate.New()
+	require.NoError(t, err)
+
+	ok := func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }
+
+	r := chi.NewRouter()
+	r.Route("/v1", func(r chi.Router) {
+		r.Use(validator)
+		r.Post("/signup", ok)
+		r.Post("/login", ok)
+		r.Post("/logo/analyze", ok)
+		r.Post("/logo/detect", ok)
+		r.Post("/watchlist", ok)
+		r.Put("/watchlist/order", ok)
+		r.Get("/symbols", ok)
+	})
+	return r
+}
+
+func TestMiddleware_RequestValidation(t *testing.T) {
+	t.Parallel()
+
+	router := newValidatedRouter(t)
+
+	tests := []struct {
+		name           string
+		method         string
+		path           string
+		body           string
+		expectedStatus int
+	}{
+		// --- signup ---
+		{"signup: 正常", http.MethodPost, "/v1/signup", `{"email":"test@example.com","password":"password12345"}`, http.StatusOK},
+		{"signup: email 形式不正", http.MethodPost, "/v1/signup", `{"email":"invalid-email","password":"password12345"}`, http.StatusBadRequest},
+		{"signup: password が短い(<12)", http.MethodPost, "/v1/signup", `{"email":"test@example.com","password":"short"}`, http.StatusBadRequest},
+		{"signup: email 欠落", http.MethodPost, "/v1/signup", `{"password":"password12345"}`, http.StatusBadRequest},
+		{"signup: 不正な JSON", http.MethodPost, "/v1/signup", `{`, http.StatusBadRequest},
+
+		// --- login ---
+		{"login: 正常", http.MethodPost, "/v1/login", `{"email":"test@example.com","password":"x"}`, http.StatusOK},
+		{"login: password 欠落", http.MethodPost, "/v1/login", `{"email":"test@example.com"}`, http.StatusBadRequest},
+		{"login: password 空文字", http.MethodPost, "/v1/login", `{"email":"test@example.com","password":""}`, http.StatusBadRequest},
+
+		// --- logo/analyze ---
+		{"analyze: 正常", http.MethodPost, "/v1/logo/analyze", `{"company_name":"任天堂"}`, http.StatusOK},
+		{"analyze: company_name 欠落", http.MethodPost, "/v1/logo/analyze", `{}`, http.StatusBadRequest},
+		{"analyze: company_name 空文字", http.MethodPost, "/v1/logo/analyze", `{"company_name":""}`, http.StatusBadRequest},
+
+		// --- watchlist add ---
+		{"add: 正常", http.MethodPost, "/v1/watchlist", `{"symbol_code":"AAPL"}`, http.StatusOK},
+		{"add: symbol_code 空文字", http.MethodPost, "/v1/watchlist", `{"symbol_code":""}`, http.StatusBadRequest},
+		{"add: symbol_code 不正文字", http.MethodPost, "/v1/watchlist", `{"symbol_code":"AAPL@x"}`, http.StatusBadRequest},
+		{"add: symbol_code 長すぎ", http.MethodPost, "/v1/watchlist", `{"symbol_code":"AAAAAAAAAAAAAAAAAAAAA"}`, http.StatusBadRequest},
+
+		// --- watchlist reorder ---
+		{"reorder: 正常", http.MethodPut, "/v1/watchlist/order", `{"codes":["AAPL","MSFT"]}`, http.StatusOK},
+		{"reorder: codes 空配列", http.MethodPut, "/v1/watchlist/order", `{"codes":[]}`, http.StatusBadRequest},
+		{"reorder: codes 内に不正文字", http.MethodPut, "/v1/watchlist/order", `{"codes":["AAPL","MSFT@x"]}`, http.StatusBadRequest},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			// 保護ルートは spec で X-CSRF-Token ヘッダーを必須宣言しているため常に付与する
+			// （実運用では csrf ミドルウェアが先に検証し、ここには到達済みの値が渡る）。
+			req.Header.Set("X-CSRF-Token", "dummy-csrf-token")
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.expectedStatus, w.Code)
+			if tt.expectedStatus == http.StatusBadRequest {
+				assert.JSONEq(t, `{"error":"invalid request"}`, w.Body.String())
+			}
+		})
+	}
+}
+
+// TestMiddleware_SkipsMultipart は multipart の logo/detect が検証スキップされることを確認する。
+// （JSON でない multipart ボディでも 400 にならず、後続ハンドラに到達して 200 になる）
+func TestMiddleware_SkipsMultipart(t *testing.T) {
+	t.Parallel()
+
+	router := newValidatedRouter(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/logo/detect", strings.NewReader("not-a-multipart-body"))
+	req.Header.Set("Content-Type", "multipart/form-data; boundary=xxx")
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/transport/openapivalidate/middleware_test.go
+++ b/internal/transport/openapivalidate/middleware_test.go
@@ -34,6 +34,7 @@ func newValidatedRouter(t *testing.T) http.Handler {
 		r.Post("/watchlist", ok)
 		r.Put("/watchlist/order", ok)
 		r.Get("/symbols", ok)
+		r.Get("/candles/{code}", ok)
 	})
 	return r
 }
@@ -77,6 +78,17 @@ func TestMiddleware_RequestValidation(t *testing.T) {
 		{"reorder: 正常", http.MethodPut, "/v1/watchlist/order", `{"codes":["AAPL","MSFT"]}`, http.StatusOK},
 		{"reorder: codes 空配列", http.MethodPut, "/v1/watchlist/order", `{"codes":[]}`, http.StatusBadRequest},
 		{"reorder: codes 内に不正文字", http.MethodPut, "/v1/watchlist/order", `{"codes":["AAPL","MSFT@x"]}`, http.StatusBadRequest},
+
+		// --- candles ---
+		{"candles: 正常", http.MethodGet, "/v1/candles/AAPL?interval=1week&outputsize=10", "", http.StatusOK},
+		{"candles: クエリ省略", http.MethodGet, "/v1/candles/AAPL", "", http.StatusOK},
+		{"candles: outputsize 上限超過", http.MethodGet, "/v1/candles/AAPL?outputsize=10000", "", http.StatusBadRequest},
+		{"candles: outputsize 0", http.MethodGet, "/v1/candles/AAPL?outputsize=0", "", http.StatusBadRequest},
+		{"candles: outputsize 整数以外", http.MethodGet, "/v1/candles/AAPL?outputsize=abc", "", http.StatusBadRequest},
+		{"candles: interval 未対応値", http.MethodGet, "/v1/candles/AAPL?interval=3day", "", http.StatusBadRequest},
+		// 空文字（?interval=）は kin-openapi が enum 未指定扱いとして通過させるため、
+		// ミドルウェアでは 200。空文字の拒否は handler が担う（candleshttp の handler_test で検証）。
+		{"candles: interval 空文字はミドルウェアを通過", http.MethodGet, "/v1/candles/AAPL?interval=", "", http.StatusOK},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要
リクエストバリデーションの制約が OpenAPI ネイティブ制約と Gin 由来の `binding` タグで二重定義されていた問題を解消するため、検証を OpenAPI スペック駆動の実行時バリデーション（`oapi-codegen/nethttp-middleware` + kin-openapi）へ移行しました。openapi.yaml を制約の単一ソースとし、ドリフトリスクと Go 固有の検証タグ（gin 残滓）を排除します。

## 変更内容
- `api/openapi.yaml` から重複していた `x-oapi-codegen-extra-tags: binding`（全7箇所）を削除し、型を再生成
- `apispec` パッケージ（`api/spec.go`）で openapi.yaml を埋め込み、kin-openapi が既定で検証しない `email` format を登録
- `openapivalidate` ミドルウェアを新設し、受信リクエストを spec に対し実行時検証
  - 認証は jwt/csrf が担うため検証層は `NoopAuthenticationFunc`
  - 実行環境のホスト差異対策で `DoNotValidateServers`
  - multipart の `logo/detect` と OPTIONS は検証対象外
  - 失敗時は詳細をログに残し、クライアントへは汎用文言 `{"error":"invalid request"}` を返却
- ルーターは保護ルートで **jwt → csrf → validator** の順に適用（未認証/CSRF 不正は 401/403 を優先）
- `httpx` から go-playground/validator と `SetTagName("binding")` を撤去、`DecodeAndValidate` を `DecodeJSON`（デコード専用）へ置換
- go-playground の `required` が空文字を弾く挙動を保つため、login の `password` と `company_name` に `minLength: 1` を追加
- `.go-arch-lint.yml` に `apispec` コンポーネントと依存を追加

## 破壊的変更
- バリデーション失敗時のエラーメッセージが項目別の文言から汎用の `{"error":"invalid request"}` に統一されます（HTTP ステータスは従来どおり 400）。
- OAuth コールバックの `code`/`state` 欠落・未知 provider など一部のケースも、ステータスは 400 のままメッセージのみ汎用化されます。
- `GET /v1/candles/{code}` の `outputsize` 範囲外値（`<=0` / `>5000`）は、従来 `200` に丸めて 200 OK を返していましたが、`400` を返すようになります（spec の `minimum:1 / maximum:5000` を単一ソースとし、usecase 側の丸めロジックを撤去）。
- 同 `interval` の空文字（`?interval=`）は、従来デフォルト（`1day`）に丸めて 200 OK を返していましたが、`400`（`unsupported interval`）を返すようになります（spec の `enum` と整合）。

## テスト
- `internal/transport/openapivalidate/middleware_test.go` を新設し、email形式・文字数・必須・パターン・空配列・multipartスキップを一元検証
- 各 handler_test からスキーマ検証ケースを除去し、ハンドラ固有の責務（JSON デコード失敗・銘柄コード正規表現）に限定
- `go build` / `go vet` / `go tool go-arch-lint check` / `golangci-lint`（0 issues）/ `go test ./... -race`（testcontainers 込みで全パス）

## レビューポイント
- 保護ルートでの validator の適用順序（jwt/csrf の後）が意図通りか
- `email` format をグローバル登録している点（`apispec` の `init`）の是非
- 空文字許容を防ぐための `minLength: 1` 追加が妥当か
