### PR TITLE
refactor: NewRouter の引数を Handlers / Config 構造体に集約

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -149,7 +149,19 @@ func run() int {
 	}
 
 	// ルーター作成
-	r := router.NewRouter(authH, oauthH, candlesH, symbolH, logoH, watchlistH, rateLimiter, openapiValidator, cfg.Server.CORSOrigins, cfg.Server.GCPProjectID, cfg.Server.JWTSecret)
+	r := router.NewRouter(
+		router.Handlers{
+			Auth: authH, OAuth: oauthH, Candles: candlesH,
+			Symbol: symbolH, Logo: logoH, Watchlist: watchlistH,
+		},
+		router.Config{
+			Limiter:          rateLimiter,
+			OpenAPIValidator: openapiValidator,
+			AllowedOrigins:   cfg.Server.CORSOrigins,
+			GCPProjectID:     cfg.Server.GCPProjectID,
+			JWTSecret:        cfg.Server.JWTSecret,
+		},
+	)
 
 	srv := &http.Server{
 		Addr:              ":8080",

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -20,28 +20,38 @@ import (
 	httpmw "github.com/UCHIDAnobuhiro/stock-backend/internal/transport/middleware"
 )
 
+// Handlers は各フィーチャーのHTTPハンドラーをまとめる。
+type Handlers struct {
+	Auth      *authhttp.Handler
+	OAuth     *authhttp.OAuthHandler // nil ならOAuthルート未登録
+	Candles   *candleshttp.Handler
+	Symbol    *symbollisthttp.Handler
+	Logo      *logodetectionhttp.Handler
+	Watchlist *watchlisthttp.Handler
+}
+
+// Config はルーター構築に必要な設定値・横断部品。
+type Config struct {
+	Limiter          *httpratelimit.Limiter
+	OpenAPIValidator func(http.Handler) http.Handler
+	AllowedOrigins   []string
+	GCPProjectID     string
+	JWTSecret        string
+}
+
 // NewRouter はすべてのアプリケーションルートを設定したHTTPハンドラー（chiルーター）を生成します。
 // 公開ルート（signup, login）とJWT認証ミドルウェア付きの保護ルート（candles, symbols, logo, watchlist）を設定します。
-// oauthHandler が nil の場合はOAuthルートを登録しません。
-func NewRouter(authHandler *authhttp.Handler, oauthHandler *authhttp.OAuthHandler,
-	candles *candleshttp.Handler,
-	symbol *symbollisthttp.Handler, logo *logodetectionhttp.Handler,
-	watchlist *watchlisthttp.Handler,
-	limiter *httpratelimit.Limiter,
-	openapiValidator func(http.Handler) http.Handler,
-	allowedOrigins []string,
-	gcpProjectID string,
-	jwtSecret string,
-) http.Handler {
+// h.OAuth が nil の場合はOAuthルートを登録しません。
+func NewRouter(h Handlers, cfg Config) http.Handler {
 	r := chi.NewRouter()
 
 	// AccessLog を外側、Recover を内側に置くことで、panic を 500 に変換した結果も
 	// アクセスログに記録される。
-	r.Use(httpmw.AccessLog(gcpProjectID))
+	r.Use(httpmw.AccessLog(cfg.GCPProjectID))
 	r.Use(httpmw.Recover())
 
 	r.Use(cors.Handler(cors.Options{
-		AllowedOrigins:   allowedOrigins,
+		AllowedOrigins:   cfg.AllowedOrigins,
 		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"},
 		AllowedHeaders:   []string{"Origin", "Content-Type", "Authorization", "X-CSRF-Token"},
 		AllowCredentials: true,
@@ -58,32 +68,32 @@ func NewRouter(authHandler *authhttp.Handler, oauthHandler *authhttp.OAuthHandle
 		// 公開ルート（認証不要）+ レートリミット + OpenAPI バリデーション。
 		// OpenAPI スペックに基づき、パス/クエリ/JSON ボディを契約準拠で検証する。
 		r.Group(func(r chi.Router) {
-			r.Use(openapiValidator)
+			r.Use(cfg.OpenAPIValidator)
 
-			r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
+			r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
 				Prefix: "rl:signup:ip",
 				Limit:  5,
 				Window: 1 * time.Hour,
-			})).Post("/signup", authHandler.Signup)
+			})).Post("/signup", h.Auth.Signup)
 
-			r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
+			r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
 				Prefix: "rl:login:ip",
 				Limit:  10,
 				Window: 1 * time.Minute,
-			})).Post("/login", authHandler.Login)
+			})).Post("/login", h.Auth.Login)
 
 			// 期限切れトークンでもログアウトできるよう認証不要
-			r.Delete("/logout", authHandler.Logout)
+			r.Delete("/logout", h.Auth.Logout)
 
 			// OAuthルート（環境変数が設定されている場合のみ登録）
-			if oauthHandler != nil {
+			if h.OAuth != nil {
 				r.Route("/auth/oauth", func(r chi.Router) {
-					r.Get("/{provider}", oauthHandler.BeginAuth)
-					r.With(httpratelimit.ByIP(limiter, httpratelimit.IPRateLimitConfig{
+					r.Get("/{provider}", h.OAuth.BeginAuth)
+					r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
 						Prefix: "rl:oauth:callback:ip",
 						Limit:  20,
 						Window: 1 * time.Minute,
-					})).Get("/{provider}/callback", oauthHandler.Callback)
+					})).Get("/{provider}/callback", h.OAuth.Callback)
 				})
 			}
 		})
@@ -92,18 +102,18 @@ func NewRouter(authHandler *authhttp.Handler, oauthHandler *authhttp.OAuthHandle
 		// バリデーションは認証・CSRF の後に行う（未認証/CSRF 不正は 401/403 を優先し、
 		// 認証済みリクエストのボディ/パラメータのみ spec 準拠で検証する）。
 		r.Group(func(r chi.Router) {
-			r.Use(jwt.AuthRequired(jwtSecret))
+			r.Use(jwt.AuthRequired(cfg.JWTSecret))
 			r.Use(csrfmw.Protect())
-			r.Use(openapiValidator)
+			r.Use(cfg.OpenAPIValidator)
 
-			r.Get("/candles/{code}", candles.GetCandlesHandler)
-			r.Get("/symbols", symbol.List)
-			r.Post("/logo/detect", logo.DetectLogos)
-			r.Post("/logo/analyze", logo.AnalyzeCompany)
-			r.Get("/watchlist", watchlist.List)
-			r.Post("/watchlist", watchlist.Add)
-			r.Delete("/watchlist/{code}", watchlist.Remove)
-			r.Put("/watchlist/order", watchlist.Reorder)
+			r.Get("/candles/{code}", h.Candles.GetCandlesHandler)
+			r.Get("/symbols", h.Symbol.List)
+			r.Post("/logo/detect", h.Logo.DetectLogos)
+			r.Post("/logo/analyze", h.Logo.AnalyzeCompany)
+			r.Get("/watchlist", h.Watchlist.List)
+			r.Post("/watchlist", h.Watchlist.Add)
+			r.Delete("/watchlist/{code}", h.Watchlist.Remove)
+			r.Put("/watchlist/order", h.Watchlist.Reorder)
 		})
 	})
 


### PR DESCRIPTION
## 概要
`router.NewRouter` の引数が11個に膨れ上がり保守性が低下していたため、役割ごとに構造体へ集約するリファクタを行いました。挙動の変更はありません。

## 変更内容
- `Handlers` 構造体（各フィーチャーのHTTPハンドラー6個）と `Config` 構造体（Limiter・OpenAPIValidator・CORS/GCP/JWT などの設定値）を新設
- `NewRouter(h Handlers, cfg Config)` にシグネチャを変更し、本体は参照名のみ差し替え（ルート定義・ミドルウェア順序は不変）
- 呼び出し側 `cmd/api/main.go` をフィールド名付き struct リテラルに変更し、同型 `string` 引数（`GCPProjectID`/`JWTSecret`）の取り違えを防止

## テスト
- `go build ./...`
- `go tool go-arch-lint check`（依存構成に変更なし）
- `go test ./internal/app/... ./cmd/...`（`cmd/api` 含めパス）

## レビューポイント
- `NewRouter` は `internal/app/router` の内部関数で、呼び出しは `main.go` の1箇所のみ。外部公開APIへの影響はありません。