### PR TITLE
refactor: logodetection のクライアント向けエラーメッセージを英語に統一

### DIFF
--- a/docs/features/logodetection.md
+++ b/docs/features/logodetection.md
@@ -28,11 +28,11 @@ sequenceDiagram
     Handler->>Handler: FormFile("image")で画像取得
 
     alt 画像フィールドなし
-        Handler-->>Client: 400 Bad Request<br/>{"error":"画像ファイルが必要です"}
+        Handler-->>Client: 400 Bad Request<br/>{"error":"image file is required"}
     end
 
     alt ファイルサイズ > 10MB
-        Handler-->>Client: 413 Request Entity Too Large<br/>{"error":"画像サイズが上限（10MB）を超えています"}
+        Handler-->>Client: 413 Request Entity Too Large<br/>{"error":"image size exceeds the limit (10MB)"}
     end
 
     Handler->>Handler: io.ReadAll(io.LimitReader(f, 10MB+1))
@@ -50,7 +50,7 @@ sequenceDiagram
         API-->>Vision: Error
         Vision-->>Usecase: error
         Usecase-->>Handler: error
-        Handler-->>Client: 502 Bad Gateway<br/>{"error":"ロゴ検出に失敗しました"}
+        Handler-->>Client: 502 Bad Gateway<br/>{"error":"logo detection failed"}
     end
 ```
 
@@ -68,7 +68,7 @@ sequenceDiagram
     Handler->>Handler: ShouldBindJSON(&req)
 
     alt バリデーションエラー
-        Handler-->>Client: 400 Bad Request<br/>{"error":"企業名が必要です"}
+        Handler-->>Client: 400 Bad Request<br/>{"error":"invalid request"}
     end
 
     Handler->>Usecase: AnalyzeCompany(ctx, "任天堂")
@@ -85,7 +85,7 @@ sequenceDiagram
         API-->>Gemini: Error
         Gemini-->>Usecase: error
         Usecase-->>Handler: error
-        Handler-->>Client: 502 Bad Gateway<br/>{"error":"企業分析に失敗しました"}
+        Handler-->>Client: 502 Bad Gateway<br/>{"error":"company analysis failed"}
     end
 ```
 
@@ -141,21 +141,21 @@ Content-Type: image/jpeg
 - **400 Bad Request** - 画像フィールドなし
   ```json
   {
-    "error": "画像ファイルが必要です"
+    "error": "image file is required"
   }
   ```
 
 - **413 Request Entity Too Large** - 画像サイズ超過
   ```json
   {
-    "error": "画像サイズが上限（10MB）を超えています"
+    "error": "image size exceeds the limit (10MB)"
   }
   ```
 
 - **502 Bad Gateway** - Vision APIエラー
   ```json
   {
-    "error": "ロゴ検出に失敗しました"
+    "error": "logo detection failed"
   }
   ```
 
@@ -208,14 +208,14 @@ Content-Type: application/json
 - **400 Bad Request** - 企業名なしまたはバリデーションエラー
   ```json
   {
-    "error": "企業名が必要です"
+    "error": "invalid request"
   }
   ```
 
 - **502 Bad Gateway** - Gemini APIエラー
   ```json
   {
-    "error": "企業分析に失敗しました"
+    "error": "company analysis failed"
   }
   ```
 

--- a/internal/feature/logodetection/logodetectionhttp/handler.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler.go
@@ -46,18 +46,18 @@ func (h *Handler) DetectLogos(w http.ResponseWriter, r *http.Request) {
 		var mbe *http.MaxBytesError
 		if errors.As(err, &mbe) {
 			slog.Warn("画像ファイルサイズ超過", "max", maxImageSize, "remote_addr", httpx.ClientIP(r))
-			httpx.WriteJSON(w, http.StatusRequestEntityTooLarge, api.ErrorResponse{Error: "画像サイズが上限（10MB）を超えています"})
+			httpx.WriteJSON(w, http.StatusRequestEntityTooLarge, api.ErrorResponse{Error: "image size exceeds the limit (10MB)"})
 			return
 		}
 		slog.Warn("画像ファイルの取得に失敗", "error", err, "remote_addr", httpx.ClientIP(r))
-		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "画像ファイルが必要です"})
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "image file is required"})
 		return
 	}
 
 	file, header, err := r.FormFile("image")
 	if err != nil {
 		slog.Warn("画像ファイルの取得に失敗", "error", err, "remote_addr", httpx.ClientIP(r))
-		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "画像ファイルが必要です"})
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "image file is required"})
 		return
 	}
 	defer func() {
@@ -68,21 +68,21 @@ func (h *Handler) DetectLogos(w http.ResponseWriter, r *http.Request) {
 
 	if header.Size > maxImageSize {
 		slog.Warn("画像ファイルサイズ超過", "size", header.Size, "max", maxImageSize, "remote_addr", httpx.ClientIP(r))
-		httpx.WriteJSON(w, http.StatusRequestEntityTooLarge, api.ErrorResponse{Error: "画像サイズが上限（10MB）を超えています"})
+		httpx.WriteJSON(w, http.StatusRequestEntityTooLarge, api.ErrorResponse{Error: "image size exceeds the limit (10MB)"})
 		return
 	}
 
 	imageData, err := io.ReadAll(io.LimitReader(file, maxImageSize+1))
 	if err != nil {
 		slog.Error("画像データの読み取りに失敗", "error", err)
-		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "画像の読み込みに失敗しました"})
+		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "failed to read image"})
 		return
 	}
 
 	logos, err := h.uc.DetectLogos(r.Context(), imageData)
 	if err != nil {
 		slog.Error("ロゴ検出に失敗", "error", err)
-		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "ロゴ検出に失敗しました"})
+		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "logo detection failed"})
 		return
 	}
 
@@ -111,7 +111,7 @@ func (h *Handler) AnalyzeCompany(w http.ResponseWriter, r *http.Request) {
 	analysis, err := h.uc.AnalyzeCompany(r.Context(), req.CompanyName)
 	if err != nil {
 		slog.Error("企業分析に失敗", "error", err, "company", req.CompanyName)
-		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "企業分析に失敗しました"})
+		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "company analysis failed"})
 		return
 	}
 

--- a/internal/feature/logodetection/logodetectionhttp/handler_test.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler_test.go
@@ -86,7 +86,7 @@ func TestLogoDetectionHandler_DetectLogos(t *testing.T) {
 			},
 			mockFunc:       nil,
 			expectedStatus: http.StatusBadRequest,
-			expectedBody:   `{"error":"画像ファイルが必要です"}`,
+			expectedBody:   `{"error":"image file is required"}`,
 		},
 		{
 			name: "error: usecase returns error",
@@ -98,7 +98,7 @@ func TestLogoDetectionHandler_DetectLogos(t *testing.T) {
 				return nil, errors.New("vision API error")
 			},
 			expectedStatus: http.StatusBadGateway,
-			expectedBody:   `{"error":"ロゴ検出に失敗しました"}`,
+			expectedBody:   `{"error":"logo detection failed"}`,
 		},
 	}
 
@@ -158,7 +158,7 @@ func TestLogoDetectionHandler_AnalyzeCompany(t *testing.T) {
 				return nil, errors.New("gemini API error")
 			},
 			expectedStatus: http.StatusBadGateway,
-			expectedBody:   `{"error":"企業分析に失敗しました"}`,
+			expectedBody:   `{"error":"company analysis failed"}`,
 		},
 	}
 


### PR DESCRIPTION
## 概要

クライアントへ返すエラーメッセージの一貫性を調査したところ、`logodetection` ハンドラーのみ日本語と英語が混在していました（他の全フィーチャー・ミドルウェアは英語で統一）。多数派である英語に統一します。

## 背景

- ボディ形式（`{"error":"..."}`）・共通ヘルパー（`httpx.WriteJSON`）・ステータスコードはプロジェクト全体で一貫していた
- 一方、エラーメッセージの言語は英語84% / 日本語16%で、日本語は `logodetection` に集中
- 同一ハンドラー内ですら混在していた（例: `AnalyzeCompany` は `invalid request`(英) と `企業分析に失敗しました`(日) が併存）

## 変更内容

### コード（`logodetectionhttp/handler.go`）
| 旧（日本語） | 新（英語） |
|---|---|
| 画像サイズが上限（10MB）を超えています | `image size exceeds the limit (10MB)` |
| 画像ファイルが必要です | `image file is required` |
| 画像の読み込みに失敗しました | `failed to read image` |
| ロゴ検出に失敗しました | `logo detection failed` |
| 企業分析に失敗しました | `company analysis failed` |

### テスト
- `handler_test.go` の期待値を上記に合わせて更新

### ドキュメント（`docs/features/logodetection.md`）
- クライアント向けエラーレスポンス例を英語に更新
- 実態と乖離していた `企業名が必要です` を、実際にバリデーションミドルウェアが返す `invalid request` に修正

## 補足

`slog` のサーバー内部ログ文言や、コード・ドキュメントの説明文はプロジェクト全体で日本語に統一されているため変更していません（クライアントには出力されないため）。

## テスト

- [x] `go test ./internal/feature/logodetection/...` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)