### PR TITLE
fix: メールアドレスを保存・検索の前段で正規化する

### DIFF
--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
@@ -108,7 +107,8 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// メールベースのレートリミットチェック
-	key := fmt.Sprintf("rl:login:email:%s", strings.ToLower(req.Email))
+	// 実際のユーザー検索（usecase）と同じ正規化を用い、バケットを一致させる。
+	key := fmt.Sprintf("rl:login:email:%s", auth.NormalizeEmail(req.Email))
 	result := h.limiter.Allow(r.Context(), key, loginEmailLimit, loginEmailWindow)
 	if !result.Allowed {
 		slog.Warn("login rate limit exceeded",

--- a/internal/feature/auth/email.go
+++ b/internal/feature/auth/email.go
@@ -1,0 +1,11 @@
+package auth
+
+import "strings"
+
+// NormalizeEmail はメールアドレスを保存・検索の前段で正規化します。
+// 前後の空白を除去し、すべて小文字化することで、
+// `User@Example.com ` と `user@example.com` を同一のメールとして扱います。
+// これにより重複アカウントの作成や OAuth 自動リンクの不一致を防ぎます。
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/internal/feature/auth/email_test.go
+++ b/internal/feature/auth/email_test.go
@@ -1,0 +1,34 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/auth"
+)
+
+// TestNormalizeEmail は小文字化・前後空白除去が行われることを検証します。
+func TestNormalizeEmail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "大文字を小文字化", input: "User@Example.com", want: "user@example.com"},
+		{name: "前後の空白を除去", input: "  user@example.com  ", want: "user@example.com"},
+		{name: "大文字と空白の混在", input: "\tUser@Example.COM\n", want: "user@example.com"},
+		{name: "正規化済みはそのまま", input: "user@example.com", want: "user@example.com"},
+		{name: "空白のみは空文字列", input: "   ", want: ""},
+		{name: "空文字列", input: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := auth.NormalizeEmail(tt.input); got != tt.want {
+				t.Errorf("NormalizeEmail(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/feature/auth/oauth.go
+++ b/internal/feature/auth/oauth.go
@@ -96,6 +96,9 @@ func (uc *oauthUsecase) HandleCallback(ctx context.Context, providerName, code, 
 	if err != nil {
 		return "", fmt.Errorf("oauth code exchange failed: %w", err)
 	}
+	// プロバイダー返却メールを正規化し、自動リンク・新規作成・JWT 生成を
+	// すべて正規化済みメールで行う（大小文字違いによる重複アカウントを防ぐ）。
+	info.Email = NormalizeEmail(info.Email)
 	if info.Email == "" {
 		return "", ErrOAuthEmailUnavailable
 	}

--- a/internal/feature/auth/oauth_test.go
+++ b/internal/feature/auth/oauth_test.go
@@ -1,0 +1,131 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/auth"
+)
+
+// mockOAuthProvider は OAuthProvider インターフェースのモック実装です。
+type mockOAuthProvider struct {
+	ExchangeCodeFunc func(ctx context.Context, code, codeVerifier string) (*auth.OAuthUserInfo, error)
+}
+
+func (m *mockOAuthProvider) AuthorizationURL(state, codeChallenge string) string { return "" }
+
+func (m *mockOAuthProvider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*auth.OAuthUserInfo, error) {
+	return m.ExchangeCodeFunc(ctx, code, codeVerifier)
+}
+
+// mockOAuthStateStore は OAuthStateStore インターフェースのモック実装です。
+type mockOAuthStateStore struct {
+	ConsumeStateFunc func(ctx context.Context, state string) (string, error)
+}
+
+func (m *mockOAuthStateStore) SaveState(ctx context.Context, state, codeVerifier string, ttl time.Duration) error {
+	return nil
+}
+
+func (m *mockOAuthStateStore) ConsumeState(ctx context.Context, state string) (string, error) {
+	return m.ConsumeStateFunc(ctx, state)
+}
+
+// mockOAuthAccountRepository は OAuthAccountRepository インターフェースのモック実装です。
+type mockOAuthAccountRepository struct {
+	FindByProviderFunc func(ctx context.Context, provider, providerUID string) (*auth.OAuthAccount, error)
+	CreateFunc         func(ctx context.Context, account *auth.OAuthAccount) error
+}
+
+func (m *mockOAuthAccountRepository) FindByProvider(ctx context.Context, provider, providerUID string) (*auth.OAuthAccount, error) {
+	return m.FindByProviderFunc(ctx, provider, providerUID)
+}
+
+func (m *mockOAuthAccountRepository) Create(ctx context.Context, account *auth.OAuthAccount) error {
+	return m.CreateFunc(ctx, account)
+}
+
+// mockOAuthUserCreator は OAuthUserCreator インターフェースのモック実装です。
+type mockOAuthUserCreator struct {
+	CreateUserWithOAuthAccountFunc func(ctx context.Context, user *auth.User, account *auth.OAuthAccount) error
+}
+
+func (m *mockOAuthUserCreator) CreateUserWithOAuthAccount(ctx context.Context, user *auth.User, account *auth.OAuthAccount) error {
+	return m.CreateUserWithOAuthAccountFunc(ctx, user, account)
+}
+
+// TestOAuthUsecase_HandleCallback_NormalizesEmailForAutoLink は、プロバイダーが
+// 既存ユーザーと大小文字違いのメールを返した場合でも、正規化済みメールで検索され
+// 既存ユーザーへ自動リンクされる（新規作成されない）ことを検証します。
+func TestOAuthUsecase_HandleCallback_NormalizesEmailForAutoLink(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "google"
+	existingUser := &auth.User{ID: 42, Email: "user@example.com"}
+
+	var lookupEmail string
+	var linkedUserID int64
+	creatorCalled := false
+
+	users := &mockUserRepository{
+		FindByEmailFunc: func(ctx context.Context, email string) (*auth.User, error) {
+			lookupEmail = email
+			// 正規化済みメールで一致する既存ユーザーを返す
+			if email == existingUser.Email {
+				return existingUser, nil
+			}
+			return nil, auth.ErrUserNotFound
+		},
+	}
+	oauthAccts := &mockOAuthAccountRepository{
+		FindByProviderFunc: func(ctx context.Context, provider, providerUID string) (*auth.OAuthAccount, error) {
+			// 既存 OAuthAccount なし
+			return nil, auth.ErrUserNotFound
+		},
+		CreateFunc: func(ctx context.Context, account *auth.OAuthAccount) error {
+			linkedUserID = account.UserID
+			return nil
+		},
+	}
+	creator := &mockOAuthUserCreator{
+		CreateUserWithOAuthAccountFunc: func(ctx context.Context, user *auth.User, account *auth.OAuthAccount) error {
+			creatorCalled = true
+			return nil
+		},
+	}
+	stateStore := &mockOAuthStateStore{
+		ConsumeStateFunc: func(ctx context.Context, state string) (string, error) {
+			return "code-verifier", nil
+		},
+	}
+	provider := &mockOAuthProvider{
+		ExchangeCodeFunc: func(ctx context.Context, code, codeVerifier string) (*auth.OAuthUserInfo, error) {
+			// プロバイダーは大小文字・空白違いのメールを返す
+			return &auth.OAuthUserInfo{ProviderUID: "google-uid-1", Email: "  User@Example.COM "}, nil
+		},
+	}
+
+	uc := auth.NewOAuthUsecase(
+		users, oauthAccts, creator, stateStore,
+		&mockJWTGenerator{},
+		map[string]auth.OAuthProvider{providerName: provider},
+	)
+
+	token, err := uc.HandleCallback(context.Background(), providerName, "code", "state")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Error("token is empty")
+	}
+	if lookupEmail != existingUser.Email {
+		t.Errorf("FindByEmail called with %q, want %q", lookupEmail, existingUser.Email)
+	}
+	if creatorCalled {
+		t.Error("expected auto-link to existing user, but a new user was created")
+	}
+	if linkedUserID != existingUser.ID {
+		t.Errorf("linked OAuthAccount.UserID = %d, want %d", linkedUserID, existingUser.ID)
+	}
+}

--- a/internal/feature/auth/usecase.go
+++ b/internal/feature/auth/usecase.go
@@ -142,6 +142,9 @@ func validatePassword(password string) error {
 // Signup はハッシュ化されたパスワードで新規ユーザーを登録します。
 // 成功時に作成されたユーザーのIDを返します。
 func (u *usecase) Signup(ctx context.Context, email, password string) (int64, error) {
+	// メールアドレスを正規化（小文字化・trim）してから保存する。
+	email = NormalizeEmail(email)
+
 	// パスワード強度を検証
 	if err := validatePassword(password); err != nil {
 		return 0, err
@@ -170,6 +173,9 @@ func (u *usecase) Login(ctx context.Context, email, password string) (string, er
 	if len(password) > maxPasswordLength {
 		return "", ErrInvalidCredentials
 	}
+
+	// 保存時と同じ正規化を施してから検索する（ケース依存の不一致を防ぐ）。
+	email = NormalizeEmail(email)
 
 	// メールアドレスでユーザーを検索
 	user, err := u.users.FindByEmail(ctx, email)

--- a/internal/feature/auth/usecase_test.go
+++ b/internal/feature/auth/usecase_test.go
@@ -342,6 +342,56 @@ func TestAuthUsecase_Login(t *testing.T) {
 	}
 }
 
+// TestAuthUsecase_Signup_NormalizesEmail はサインアップ時にメールアドレスが
+// 小文字化・trim されてリポジトリに保存されることを検証します（重複アカウント防止）。
+func TestAuthUsecase_Signup_NormalizesEmail(t *testing.T) {
+	t.Parallel()
+
+	var storedEmail string
+	mockRepo := &mockUserRepository{
+		CreateFunc: func(ctx context.Context, user *auth.User) error {
+			storedEmail = user.Email
+			return nil
+		},
+	}
+	uc := auth.NewUsecase(mockRepo, &mockJWTGenerator{}, testPepper)
+
+	if _, err := uc.Signup(context.Background(), "  User@Example.COM ", "password12345"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if storedEmail != "user@example.com" {
+		t.Errorf("stored email = %q, want %q", storedEmail, "user@example.com")
+	}
+}
+
+// TestAuthUsecase_Login_NormalizesEmail はログイン時に正規化済みメールアドレスで
+// ユーザー検索が行われることを検証します（レート制限キーとの不整合を防ぐ）。
+func TestAuthUsecase_Login_NormalizesEmail(t *testing.T) {
+	t.Parallel()
+
+	testUser := createTestUser(t, 1, "user@example.com", "password12345")
+
+	var lookupEmail string
+	mockRepo := &mockUserRepository{
+		FindByEmailFunc: func(ctx context.Context, email string) (*auth.User, error) {
+			lookupEmail = email
+			return testUser, nil
+		},
+	}
+	uc := auth.NewUsecase(mockRepo, &mockJWTGenerator{}, testPepper)
+
+	token, err := uc.Login(context.Background(), "  User@Example.COM ", "password12345")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Error("token is empty")
+	}
+	if lookupEmail != "user@example.com" {
+		t.Errorf("FindByEmail called with %q, want %q", lookupEmail, "user@example.com")
+	}
+}
+
 // TestAuthUsecase_PepperApplied はペッパーが正しくパスワードに適用されることを検証します。
 func TestAuthUsecase_PepperApplied(t *testing.T) {
 	t.Parallel()

--- a/internal/infra/logging/email.go
+++ b/internal/infra/logging/email.go
@@ -23,6 +23,6 @@ func (e HashedEmail) LogValue() slog.Value {
 	if e == "" {
 		return slog.StringValue("")
 	}
-	sum := sha256.Sum256([]byte(strings.ToLower(string(e))))
+	sum := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(string(e)))))
 	return slog.StringValue(hex.EncodeToString(sum[:])[:hashedEmailLen])
 }

--- a/internal/infra/logging/email_test.go
+++ b/internal/infra/logging/email_test.go
@@ -54,6 +54,18 @@ func TestHashedEmail_CaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestHashedEmail_TrimSpace は前後の空白の有無で同一ハッシュを返すことを検証します。
+// usecase 側の正規化（trim + 小文字化）とログ相関を一致させるため。
+func TestHashedEmail_TrimSpace(t *testing.T) {
+	t.Parallel()
+
+	a := HashedEmail("  User@Example.com  ").LogValue().String()
+	b := HashedEmail("user@example.com").LogValue().String()
+	if a != b {
+		t.Errorf("whitespace/case mismatch: %q != %q", a, b)
+	}
+}
+
 // TestHashedEmail_Deterministic は同一入力が常に同一ハッシュを返すことを検証します。
 // 連続失敗・レート制限ログの相関解析が成立する前提条件。
 func TestHashedEmail_Deterministic(t *testing.T) {


### PR DESCRIPTION
## 概要
メールアドレスを保存・検索時に正規化していなかったため、`User@example.com` と `user@example.com` が別アカウントとして扱われ、重複アカウントや OAuth 自動リンクの不一致が起こりうる問題を修正します。アプリ層（auth usecase 境界）で email を一貫して小文字化・trim します。

## 変更内容
- `internal/feature/auth/email.go`（新規）: 正規化の単一情報源 `NormalizeEmail(email)`（小文字化 + trim）を追加
- `usecase.go`: `Signup`（保存前）・`Login`（検索前）で email を正規化
- `oauth.go`: `HandleCallback` で `info.Email` を正規化し、自動リンク・新規作成・JWT 生成すべてに反映
- `authhttp/handler.go`: レート制限キーを `auth.NormalizeEmail` に統一（不要になった `strings` import を削除）
- `infra/logging/email.go`: ログハッシュに `TrimSpace` を追加（前後空白差でもハッシュを一致させる）

DB スキーマ・既存データは変更していません（アプリ層のみの対応）。

## 関連issue
- closes #197

## テスト
- `email_test.go`（auth）: `NormalizeEmail` の単体テスト
- `usecase_test.go`: Signup の保存値が正規化される / Login が正規化済みメールで検索することを検証
- `oauth_test.go`（新規）: プロバイダーが大小文字違いのメールを返しても、正規化済みメールで既存ユーザーへ自動リンクされ重複作成されないことを検証
- `logging/email_test.go`: 前後空白違いでも同一ハッシュになることを検証
- `go test ./internal/feature/auth/... ./internal/infra/logging/... -race` 全パス / `go-arch-lint check` 違反なし / `golangci-lint` 0 issues

## レビューポイント
- OAuth コールバックで正規化を空チェックの前段に置いたことで、trim 後に空になるメールも `ErrOAuthEmailUnavailable` で弾けることを確認