### PR TITLE
fix(watchlist): 並び替えで部分リスト指定時の500を400に

### DIFF
--- a/internal/feature/watchlist/errors.go
+++ b/internal/feature/watchlist/errors.go
@@ -11,4 +11,8 @@ var (
 
 	// ErrNotInWatchlist は削除対象の銘柄がウォッチリストに存在しない場合のエラーです。
 	ErrNotInWatchlist = errors.New("symbol not in watchlist")
+
+	// ErrReorderCodesMismatch は並び替えの codes がユーザーの watchlist 全件と
+	// 一致しない（過不足・重複あり）場合のエラーです。
+	ErrReorderCodesMismatch = errors.New("reorder codes do not match watchlist")
 )

--- a/internal/feature/watchlist/usecase.go
+++ b/internal/feature/watchlist/usecase.go
@@ -68,7 +68,36 @@ func (u *usecase) RemoveSymbol(ctx context.Context, userID int64, symbolCode str
 }
 
 // ReorderSymbols はウォッチリストの並び順を更新します。
+// orderedCodes はユーザーの watchlist 全件と過不足・重複なく一致する必要があります。
+// 一致しない場合は ErrReorderCodesMismatch を返します。これは部分リストを渡した際に
+// 更新対象外レコードと sort_key が衝突し、(user_id, sort_key) UNIQUE 制約違反で
+// トランザクションが失敗する（500）のを防ぐためです。
 func (u *usecase) ReorderSymbols(ctx context.Context, userID int64, orderedCodes []string) error {
+	existing, err := u.repo.ListByUser(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("listing watchlist: %w", err)
+	}
+
+	if len(orderedCodes) != len(existing) {
+		return ErrReorderCodesMismatch
+	}
+
+	existingCodes := make(map[string]struct{}, len(existing))
+	for _, e := range existing {
+		existingCodes[e.SymbolCode] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(orderedCodes))
+	for _, code := range orderedCodes {
+		if _, dup := seen[code]; dup {
+			return ErrReorderCodesMismatch
+		}
+		if _, ok := existingCodes[code]; !ok {
+			return ErrReorderCodesMismatch
+		}
+		seen[code] = struct{}{}
+	}
+
 	entries := make([]UserSymbol, 0, len(orderedCodes))
 	for i, code := range orderedCodes {
 		entries = append(entries, UserSymbol{

--- a/internal/feature/watchlist/usecase_test.go
+++ b/internal/feature/watchlist/usecase_test.go
@@ -276,10 +276,21 @@ func TestWatchlistUsecase_RemoveSymbol(t *testing.T) {
 func TestWatchlistUsecase_ReorderSymbols(t *testing.T) {
 	t.Parallel()
 
+	// listByUserFunc は指定したコード群を sort_key 昇順の watchlist として返すヘルパーです。
+	listByUserFunc := func(codes ...string) func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+		return func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+			entries := make([]watchlist.UserSymbol, 0, len(codes))
+			for i, code := range codes {
+				entries = append(entries, watchlist.UserSymbol{UserID: userID, SymbolCode: code, SortKey: i})
+			}
+			return entries, nil
+		}
+	}
+
 	t.Run("success: assigns sequential sort keys in order", func(t *testing.T) {
 		t.Parallel()
 
-		repo := &mockRepository{}
+		repo := &mockRepository{ListByUserFunc: listByUserFunc("AAPL", "MSFT", "GOOGL")}
 		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
 
 		err := uc.ReorderSymbols(context.Background(), 42, []string{"MSFT", "AAPL", "GOOGL"})
@@ -292,10 +303,10 @@ func TestWatchlistUsecase_ReorderSymbols(t *testing.T) {
 		}, repo.UpdatedEntries)
 	})
 
-	t.Run("success: empty order produces empty entries", func(t *testing.T) {
+	t.Run("success: empty order with empty watchlist produces empty entries", func(t *testing.T) {
 		t.Parallel()
 
-		repo := &mockRepository{}
+		repo := &mockRepository{ListByUserFunc: listByUserFunc()}
 		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
 
 		err := uc.ReorderSymbols(context.Background(), 42, []string{})
@@ -304,10 +315,62 @@ func TestWatchlistUsecase_ReorderSymbols(t *testing.T) {
 		assert.Empty(t, repo.UpdatedEntries)
 	})
 
+	t.Run("failure: partial list returns ErrReorderCodesMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{ListByUserFunc: listByUserFunc("AAPL", "MSFT", "GOOGL")}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{"GOOGL", "AAPL"})
+
+		assert.ErrorIs(t, err, watchlist.ErrReorderCodesMismatch)
+		assert.Nil(t, repo.UpdatedEntries)
+	})
+
+	t.Run("failure: unknown code returns ErrReorderCodesMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{ListByUserFunc: listByUserFunc("AAPL", "MSFT")}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{"AAPL", "TSLA"})
+
+		assert.ErrorIs(t, err, watchlist.ErrReorderCodesMismatch)
+		assert.Nil(t, repo.UpdatedEntries)
+	})
+
+	t.Run("failure: duplicate code returns ErrReorderCodesMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{ListByUserFunc: listByUserFunc("AAPL", "MSFT")}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{"AAPL", "AAPL"})
+
+		assert.ErrorIs(t, err, watchlist.ErrReorderCodesMismatch)
+		assert.Nil(t, repo.UpdatedEntries)
+	})
+
+	t.Run("failure: ListByUser returns error", func(t *testing.T) {
+		t.Parallel()
+
+		repo := &mockRepository{
+			ListByUserFunc: func(ctx context.Context, userID int64) ([]watchlist.UserSymbol, error) {
+				return nil, errors.New("list failed")
+			},
+		}
+		uc := watchlist.NewUsecase(repo, &mockSymbolExistsChecker{})
+
+		err := uc.ReorderSymbols(context.Background(), 42, []string{"AAPL"})
+
+		assert.ErrorContains(t, err, "list failed")
+	})
+
 	t.Run("failure: repository returns error", func(t *testing.T) {
 		t.Parallel()
 
 		repo := &mockRepository{
+			ListByUserFunc: listByUserFunc("AAPL"),
 			UpdateSortKeysFunc: func(ctx context.Context, userID int64, entries []watchlist.UserSymbol) error {
 				return errors.New("update failed")
 			},

--- a/internal/feature/watchlist/watchlisthttp/handler.go
+++ b/internal/feature/watchlist/watchlisthttp/handler.go
@@ -145,8 +145,13 @@ func (h *Handler) Reorder(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := h.uc.ReorderSymbols(r.Context(), userID, req.Codes); err != nil {
-		slog.Error("failed to reorder watchlist", "error", err, "userID", userID)
-		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
+		switch {
+		case errors.Is(err, watchlist.ErrReorderCodesMismatch):
+			httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: err.Error()})
+		default:
+			slog.Error("failed to reorder watchlist", "error", err, "userID", userID)
+			httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
+		}
 		return
 	}
 

--- a/internal/feature/watchlist/watchlisthttp/handler_test.go
+++ b/internal/feature/watchlist/watchlisthttp/handler_test.go
@@ -421,6 +421,15 @@ func TestWatchlistHandler_Reorder(t *testing.T) {
 			expectedBody:   `{"error":"invalid symbol code"}`,
 		},
 		{
+			name: "error: codes mismatch returns 400",
+			body: `{"codes":["AAPL"]}`,
+			mockReorder: func(ctx context.Context, userID int64, orderedCodes []string) error {
+				return watchlist.ErrReorderCodesMismatch
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"reorder codes do not match watchlist"}`,
+		},
+		{
 			name: "error: usecase returns internal error",
 			body: `{"codes":["AAPL"]}`,
 			mockReorder: func(ctx context.Context, userID int64, orderedCodes []string) error {


### PR DESCRIPTION
## 概要

`ReorderSymbols` に入力バリデーションを追加し、渡された `codes` がユーザーの watchlist 全件と過不足・重複なく一致することを保証します。これにより、部分リストを渡した際の `(user_id, sort_key)` UNIQUE 制約違反による 500 エラーを防ぎます。

Closes #199

## 問題

`ReorderSymbols` はリクエストで渡された `codes` のみ `sort_key` を再採番します。watchlist 全件でない**部分リスト**を渡すと、更新対象外の既存レコードの `sort_key` と衝突し、`(user_id, sort_key)` の UNIQUE 制約違反でトランザクションが失敗して 500 になっていました。

例: 既存 A=0, B=1, C=2 のとき `[C, A]` のみ渡すと最終的に C=0, A=1 となり、更新されない B=1 と衝突します。本来はクリーンな 400 バリデーションエラーを返すべきでした。

## 主な変更

- **新しいエラー型**: バリデーション失敗用に `errors.go` へ `ErrReorderCodesMismatch` を追加
- **usecase バリデーション**: `usecase.go` の `ReorderSymbols` を強化
  - `ListByUser` でユーザーの watchlist 全件を取得
  - 渡された `codes` が既存と過不足・重複なく一致するか検証
  - 不一致なら `ErrReorderCodesMismatch` を返す
- **HTTP ハンドラー**: `watchlisthttp/handler.go` で `ErrReorderCodesMismatch` を 500 ではなく HTTP 400 (Bad Request) にマッピング
- **テスト**:
  - `listByUserFunc` ヘルパーを追加してテストセットアップを簡素化
  - 失敗ケースを追加（部分リスト・未知コード・重複コード・`ListByUser` エラー）
  - 既存テストを新ヘルパーと現実的なモックデータに更新

## バリデーションロジック

1. 件数一致: `len(orderedCodes) == len(existing)`
2. 重複なし: 各コードが入力に1回だけ出現
3. 未知コードなし: 渡された全コードがユーザーの watchlist に存在
4. 不足なし: 件数一致＋重複なし＋全件が既存に含まれることで集合一致を保証

リポジトリの2フェーズ更新ロジックは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012xFXBBwbqfLLU6AxpnVoBC