### PR TITLE
fix(auth): サインアップ後処理フック失敗を非致命的にする

### DIFF
--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -82,11 +82,11 @@ func (h *Handler) Signup(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteJSON(w, http.StatusConflict, api.ErrorResponse{Error: "signup failed"})
 		return
 	}
+	// 後処理フック呼び出し（例: ウォッチリスト初期化）
+	// フック失敗はユーザー作成自体には影響しないため非致命的とし、ログのみ記録する。
 	for _, hook := range h.postHooks {
 		if err := hook.OnUserCreated(r.Context(), userID); err != nil {
 			slog.Error("post-signup hook failed", "error", err, "userID", userID)
-			httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "signup failed"})
-			return
 		}
 	}
 	slog.Info("user signup successful", "email_hash", logging.HashedEmail(req.Email), "remote_addr", httpx.ClientIP(r))

--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -43,6 +43,21 @@ func (m *mockUsecase) Login(ctx context.Context, email, password string) (string
 	return "", errors.New("login failed") // デフォルト: 失敗
 }
 
+// mockPostHook は auth.UserCreatedHook インターフェースのモック実装です。
+type mockPostHook struct {
+	OnUserCreatedFunc func(ctx context.Context, userID int64) error
+	called            bool
+}
+
+// OnUserCreated はサインアップ後フックのモック実装です。
+func (m *mockPostHook) OnUserCreated(ctx context.Context, userID int64) error {
+	m.called = true
+	if m.OnUserCreatedFunc != nil {
+		return m.OnUserCreatedFunc(ctx, userID)
+	}
+	return nil
+}
+
 // makeRequest はHTTPリクエストを作成し、指定ハンドラーを直接実行するヘルパー関数です。
 func makeRequest(t *testing.T, handler http.HandlerFunc, method, path string, body H) *httptest.ResponseRecorder {
 	t.Helper()
@@ -150,6 +165,30 @@ func TestAuthHandler_Signup(t *testing.T) {
 			assertJSONResponse(t, w, tt.expectedStatus, tt.expectedBody)
 		})
 	}
+}
+
+// TestAuthHandler_Signup_HookFailureIsNonFatal はサインアップ後フックが失敗しても
+// ユーザー作成が成功している限り 201 を返す（非致命的扱い）ことを検証します（issue #196）。
+func TestAuthHandler_Signup_HookFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	mockUC := &mockUsecase{
+		SignupFunc: func(ctx context.Context, email, password string) (int64, error) { return 1, nil },
+	}
+	hook := &mockPostHook{
+		OnUserCreatedFunc: func(ctx context.Context, userID int64) error {
+			return errors.New("watchlist init failed")
+		},
+	}
+	h := authhttp.NewHandler(mockUC, nil, false, hook)
+
+	w := makeRequest(t, h.Signup, http.MethodPost, "/signup", H{
+		"email":    "test@example.com",
+		"password": "password12345",
+	})
+
+	assertJSONResponse(t, w, http.StatusCreated, H{"message": "ok"})
+	assert.True(t, hook.called, "後処理フックが呼ばれること")
 }
 
 // TestAuthHandler_Login_RateLimited はメールベースのレートリミット超過時に429が返されることを検証します。


### PR DESCRIPTION
## 概要
通常サインアップでユーザー作成後の後処理フック（watchlist のデフォルト銘柄初期化）が失敗すると 500 を返して中断していたが、ユーザーは既に作成済みのため再サインアップが 409（メール重複）となり復旧不能状態が残っていた。OAuth フローに倣い、フック失敗を非致命的（ログ記録のみ・成功レスポンス継続）に統一する。

## 変更内容
- `authhttp/handler.go` の Signup ハンドラで、後処理フック失敗時の 500 返却 + 中断を削除し、`slog.Error` でログ記録のみ行って 201 Created へ継続するように変更
- 後処理フックのコメントを OAuth 側（`oauth.go`）の文言・構造に統一
- フック失敗時でも 201 が返ることを検証する `TestAuthHandler_Signup_HookFailureIsNonFatal` を追加

## 関連issue
- closes #196

## テスト
- `go test ./internal/feature/auth/...` で新規テスト含めパス
- `go build ./...` / `golangci-lint run`（0 issues）/ `go tool go-arch-lint check`（No warnings）を確認

## レビューポイント
- フック失敗時に watchlist が空のままユーザー登録が完了する挙動で問題ないか（issue の提案方針どおり、OAuth と同じ非致命的ポリシーに統一）