### PR TITLE
feat(security): 本番構成でHSTSヘッダーを付与する

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -160,6 +160,7 @@ func run() int {
 			AllowedOrigins:   cfg.Server.CORSOrigins,
 			GCPProjectID:     cfg.Server.GCPProjectID,
 			JWTSecret:        cfg.Server.JWTSecret,
+			SecureCookie:     cfg.Server.SecureCookie,
 		},
 	)
 

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -37,6 +37,8 @@ type Config struct {
 	AllowedOrigins   []string
 	GCPProjectID     string
 	JWTSecret        string
+	// SecureCookie が true（本番・TLS終端）のとき HSTS ヘッダーを有効化する。
+	SecureCookie bool
 }
 
 // NewRouter はすべてのアプリケーションルートを設定したHTTPハンドラー（chiルーター）を生成します。
@@ -57,7 +59,7 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 		AllowCredentials: true,
 		MaxAge:           int((12 * time.Hour).Seconds()),
 	}))
-	r.Use(httpmw.SecurityHeaders())
+	r.Use(httpmw.SecurityHeaders(cfg.SecureCookie))
 
 	// ヘルスチェックエンドポイント（バージョンなし）。
 	// Health はメソッドごとの分岐を自身で行うため、全メソッドを単一ハンドラーで処理する。

--- a/internal/transport/middleware/security_headers.go
+++ b/internal/transport/middleware/security_headers.go
@@ -3,9 +3,17 @@ package middleware
 
 import "net/http"
 
+// hstsValue は HSTS（HTTP Strict Transport Security）の値です。
+// max-age は2年（63072000秒）。サブドメインも対象に含めます。
+const hstsValue = "max-age=63072000; includeSubDomains"
+
 // SecurityHeaders はセキュリティ関連のHTTPレスポンスヘッダーを設定するミドルウェアを返します。
 // このAPIサーバーはJSONのみを返すため、CSPは最も制限的な設定を使用します。
-func SecurityHeaders() func(http.Handler) http.Handler {
+//
+// enableHSTS が true の場合、Strict-Transport-Security ヘッダーを付与します。
+// TLS を終端する本番構成（COOKIE_SECURE=true / APP_ENV=production）でのみ有効化し、
+// 平文HTTPで開発する際に誤って HSTS をブラウザにキャッシュさせないようにします。
+func SecurityHeaders(enableHSTS bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			h := w.Header()
@@ -13,6 +21,9 @@ func SecurityHeaders() func(http.Handler) http.Handler {
 			h.Set("X-Frame-Options", "DENY")
 			h.Set("Referrer-Policy", "strict-origin-when-cross-origin")
 			h.Set("Content-Security-Policy", "default-src 'none'")
+			if enableHSTS {
+				h.Set("Strict-Transport-Security", hstsValue)
+			}
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/internal/transport/middleware/security_headers_test.go
+++ b/internal/transport/middleware/security_headers_test.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecurityHeaders(t *testing.T) {
+	t.Parallel()
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("共通のセキュリティヘッダーを常に設定する", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		SecurityHeaders(false)(next).ServeHTTP(rec, req)
+
+		h := rec.Header()
+		assert.Equal(t, "nosniff", h.Get("X-Content-Type-Options"))
+		assert.Equal(t, "DENY", h.Get("X-Frame-Options"))
+		assert.Equal(t, "strict-origin-when-cross-origin", h.Get("Referrer-Policy"))
+		assert.Equal(t, "default-src 'none'", h.Get("Content-Security-Policy"))
+	})
+
+	t.Run("enableHSTS=false のとき HSTS を付与しない", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		SecurityHeaders(false)(next).ServeHTTP(rec, req)
+
+		assert.Empty(t, rec.Header().Get("Strict-Transport-Security"))
+	})
+
+	t.Run("enableHSTS=true のとき HSTS を付与する", func(t *testing.T) {
+		t.Parallel()
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		SecurityHeaders(true)(next).ServeHTTP(rec, req)
+
+		assert.Equal(t, "max-age=63072000; includeSubDomains", rec.Header().Get("Strict-Transport-Security"))
+	})
+}


### PR DESCRIPTION
## 概要
`SecurityHeaders` ミドルウェアに `Strict-Transport-Security`（HSTS）が欠如しており、TLS終端構成で中間者によるダウングレード余地が残っていた。本番（TLS終端）構成でのみ HSTS ヘッダーを付与するよう修正する。

## 変更内容
- `SecurityHeaders` に `enableHSTS` 引数を追加し、`true` のとき `Strict-Transport-Security: max-age=63072000; includeSubDomains` を設定
- `router.Config` に `SecureCookie` を追加し、本番シグナルとして HSTS 有効化に配線（`cmd/api/main.go`）
- 平文HTTP開発時にブラウザへ HSTS をキャッシュさせないため、`SecureCookie=false` では未付与
- 共通セキュリティヘッダー・HSTS の有無を検証するユニットテストを追加

## 設計判断
issue では `COOKIE_SECURE=true` / `APP_ENV=production` 時に付与とあるが、既存の `cfg.Server.SecureCookie` がまさにその両条件から導出される本番シグナルのため、新たな環境変数を増やさずこれを再利用した。

## 関連issue
- closes #195

## テスト
- `security_headers_test.go` に共通ヘッダー設定・HSTS有無（enableHSTS true/false）の3ケースを追加
- `go build ./...` / `go test ./internal/transport/middleware/...` / `go tool go-arch-lint check` がすべて通過