### PR TITLE
fix(security): JWT_SECRET/PASSWORD_PEPPERに最低長32バイトを要求する

### DIFF
--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -38,8 +38,9 @@ func TestRun_ReturnsTwoWhenConfigInvalid(t *testing.T) {
 
 func TestRun_ReturnsOneWhenDBConfigInvalid(t *testing.T) {
 	clearEnv(t)
-	t.Setenv(jwt.EnvKeyJWTSecret, "secret")
-	t.Setenv(auth.EnvKeyPasswordPepper, "pepper")
+	// 最低長(32 バイト)を満たす値で config 検証を通し、DB 設定不備で失敗させる
+	t.Setenv(jwt.EnvKeyJWTSecret, "0123456789abcdef0123456789abcdef")
+	t.Setenv(auth.EnvKeyPasswordPepper, "0123456789abcdef0123456789abcdef")
 	t.Setenv("DB_USER", "")
 
 	if got := run(); got != 1 {

--- a/docker/example.env
+++ b/docker/example.env
@@ -29,7 +29,9 @@ RUN_MIGRATIONS=true
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # JWT
-JWT_SECRET=your_jwt_secret_here
+# 32 バイト以上必須（未満だと起動時に fail-fast し終了コード 2）。
+# 生成例: openssl rand -base64 48
+JWT_SECRET=your_jwt_secret_here_change_me_min_32_bytes
 
 # Cookie Secure フラグ（本番環境では true に変更すること）
 # true: HTTPS のみで Cookie を送信（本番必須）
@@ -37,7 +39,9 @@ JWT_SECRET=your_jwt_secret_here
 COOKIE_SECURE=false
 
 # Password Pepper（パスワードハッシュ用ペッパー）
-PASSWORD_PEPPER=your_password_pepper_here
+# 32 バイト以上必須（未満だと起動時に fail-fast し終了コード 2）。
+# 生成例: openssl rand -base64 48
+PASSWORD_PEPPER=your_password_pepper_here_change_me_min_32
 
 # twelvedata
 TWELVE_DATA_API_KEY=your_twelvedata_api_key_here

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -33,6 +33,9 @@ const (
 	defaultIngestTimeoutHours = 3
 	// defaultMaxFailureRate は *_MAX_FAILURE_RATE のデフォルト値。
 	defaultMaxFailureRate = 0.2
+	// minSecretLength は JWT_SECRET / PASSWORD_PEPPER に要求する最低バイト数。
+	// HS256 署名鍵の総当たり偽造を防ぐため 32 バイト以上を必須とする。
+	minSecretLength = 32
 )
 
 // Config はアプリケーション全体の設定を保持します。
@@ -178,10 +181,16 @@ func readServer(warn *[]string) (ServerConfig, error) {
 	if jwtSecret == "" {
 		return ServerConfig{}, fmt.Errorf("%s is required", jwt.EnvKeyJWTSecret)
 	}
+	if len(jwtSecret) < minSecretLength {
+		return ServerConfig{}, fmt.Errorf("%s must be at least %d bytes", jwt.EnvKeyJWTSecret, minSecretLength)
+	}
 
 	passwordPepper := os.Getenv(auth.EnvKeyPasswordPepper)
 	if passwordPepper == "" {
 		return ServerConfig{}, fmt.Errorf("%s is required", auth.EnvKeyPasswordPepper)
+	}
+	if len(passwordPepper) < minSecretLength {
+		return ServerConfig{}, fmt.Errorf("%s must be at least %d bytes", auth.EnvKeyPasswordPepper, minSecretLength)
 	}
 
 	// COOKIE_SECURE を優先し、未設定なら APP_ENV=production をフォールバックとして使用

--- a/internal/app/config/load_test.go
+++ b/internal/app/config/load_test.go
@@ -7,6 +7,9 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
+// validSecret は最低長(minSecretLength=32)を満たすテスト用シークレット。
+const validSecret = "0123456789abcdef0123456789abcdef" // 32 バイト
+
 // clearServerEnv は設定検証に関わる環境変数をすべて空にし、テストを決定的にする。
 func clearServerEnv(t *testing.T) {
 	t.Helper()
@@ -31,24 +34,51 @@ func clearServerEnv(t *testing.T) {
 func TestLoadAPI(t *testing.T) {
 	t.Run("JWT_SECRET 未設定はエラー", func(t *testing.T) {
 		clearServerEnv(t)
-		t.Setenv(auth.EnvKeyPasswordPepper, "pepper")
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
 		if _, err := LoadAPI(); err == nil {
 			t.Fatal("expected error when JWT_SECRET is missing, got nil")
 		}
 	})
 
+	t.Run("JWT_SECRET が短すぎる場合はエラー", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret[:minSecretLength-1])
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
+		if _, err := LoadAPI(); err == nil {
+			t.Fatalf("expected error when JWT_SECRET is shorter than %d bytes, got nil", minSecretLength)
+		}
+	})
+
 	t.Run("PASSWORD_PEPPER 未設定はエラー", func(t *testing.T) {
 		clearServerEnv(t)
-		t.Setenv(jwt.EnvKeyJWTSecret, "secret")
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
 		if _, err := LoadAPI(); err == nil {
 			t.Fatal("expected error when PASSWORD_PEPPER is missing, got nil")
 		}
 	})
 
+	t.Run("PASSWORD_PEPPER が短すぎる場合はエラー", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret[:minSecretLength-1])
+		if _, err := LoadAPI(); err == nil {
+			t.Fatalf("expected error when PASSWORD_PEPPER is shorter than %d bytes, got nil", minSecretLength)
+		}
+	})
+
+	t.Run("ちょうど最低長で成功", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret[:minSecretLength])
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret[:minSecretLength])
+		if _, err := LoadAPI(); err != nil {
+			t.Fatalf("unexpected error for %d-byte secrets: %v", minSecretLength, err)
+		}
+	})
+
 	t.Run("必須のみ設定で成功・デフォルト適用", func(t *testing.T) {
 		clearServerEnv(t)
-		t.Setenv(jwt.EnvKeyJWTSecret, "secret")
-		t.Setenv(auth.EnvKeyPasswordPepper, "pepper")
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
 
 		cfg, err := LoadAPI()
 		if err != nil {
@@ -67,8 +97,8 @@ func TestLoadAPI(t *testing.T) {
 
 	t.Run("APP_ENV=production で secureCookie が true", func(t *testing.T) {
 		clearServerEnv(t)
-		t.Setenv(jwt.EnvKeyJWTSecret, "secret")
-		t.Setenv(auth.EnvKeyPasswordPepper, "pepper")
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
 		t.Setenv("APP_ENV", "production")
 
 		cfg, err := LoadAPI()
@@ -82,8 +112,8 @@ func TestLoadAPI(t *testing.T) {
 
 	t.Run("不正な COOKIE_SECURE は Warnings に記録しデフォルト動作", func(t *testing.T) {
 		clearServerEnv(t)
-		t.Setenv(jwt.EnvKeyJWTSecret, "secret")
-		t.Setenv(auth.EnvKeyPasswordPepper, "pepper")
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
 		t.Setenv("COOKIE_SECURE", "notabool")
 
 		cfg, err := LoadAPI()


### PR DESCRIPTION
## 概要
`JWT_SECRET` と `PASSWORD_PEPPER` は起動時に空文字チェックのみで、弱い／短い値でもサーバが起動していた。HS256 署名のため弱い `JWT_SECRET` はトークン偽造＝認証バイパスに直結するため、起動時に最低長を検証して fail-fast させる。

## 変更内容
- `readServer`（`internal/app/config/config.go`）で `JWT_SECRET` / `PASSWORD_PEPPER` に最低 32 バイトを要求し、満たさなければ `LoadAPI` がエラーを返す（`run()` が終了コード 2 で fail-fast）
- 最低長定数 `minSecretLength = 32` を追加
- 検証ロジックは設定読み込み層の 1 箇所に集約（generator / auth usecase 側は変更なし）
- テスト追加: 短すぎる場合のエラー（JWT/PEPPER 各々）、ちょうど 32 バイトでの成功
- `docker/example.env` のプレースホルダを更新し、「32 バイト以上必須」「`openssl rand -base64 48`」のコメントを追記

## 関連issue
- closes #192

## テスト
- `go test ./internal/app/config/... ./cmd/api/...` 全ケース PASS
- `go build ./...` 成功 / `golangci-lint` 0 issues

## レビューポイント
- 最低長を 32 バイトとした（issue で例示された値・SHA-256 出力長と同じ）
- 既存の成功パステスト・DB 失敗テストが使っていた短い固定値を 32 バイトに更新済み