### PR TITLE
refactor: candlesのFindCandlesAll分岐と重複コードを削除

### DIFF
--- a/internal/feature/candles/errors.go
+++ b/internal/feature/candles/errors.go
@@ -1,0 +1,9 @@
+package candles
+
+import "fmt"
+
+// ErrInvalidOutputSize は outputsize が許容範囲（1〜MaxOutputSize）外の場合に返されます。
+// HTTP 経由では api/openapi.yaml の minimum/maximum 制約と openapivalidate
+// ミドルウェアにより到達しないはずですが、リポジトリ層自身の不変条件として
+// 防御的に検証します（Redis 障害時のフォールバックや将来の非HTTP呼び出し元を想定）。
+var ErrInvalidOutputSize = fmt.Errorf("outputsize must be between 1 and %d", MaxOutputSize)

--- a/internal/feature/candles/repository.go
+++ b/internal/feature/candles/repository.go
@@ -67,6 +67,9 @@ func (r *dbRepository) UpsertBatch(ctx context.Context, candles []Candle) error 
 // Find は指定された銘柄とインターバルのローソク足データを取得します。
 // 結果は時間の降順でソートされ、outputsize 件で制限されます。
 func (r *dbRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
+	if outputsize <= 0 || outputsize > MaxOutputSize {
+		return nil, fmt.Errorf("find candles: %w", ErrInvalidOutputSize)
+	}
 	rows, err := r.q.FindCandlesLimit(ctx, candlessqlc.FindCandlesLimitParams{
 		SymbolCode: symbol,
 		Interval:   interval,

--- a/internal/feature/candles/repository.go
+++ b/internal/feature/candles/repository.go
@@ -65,35 +65,12 @@ func (r *dbRepository) UpsertBatch(ctx context.Context, candles []Candle) error 
 }
 
 // Find は指定された銘柄とインターバルのローソク足データを取得します。
-// 結果は時間の降順でソートされ、outputsize > 0 のときのみ件数で制限されます。
+// 結果は時間の降順でソートされ、outputsize 件で制限されます。
 func (r *dbRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
-	if outputsize > 0 {
-		rows, err := r.q.FindCandlesLimit(ctx, candlessqlc.FindCandlesLimitParams{
-			SymbolCode: symbol,
-			Interval:   interval,
-			Limit:      int32(outputsize),
-		})
-		if err != nil {
-			return nil, err
-		}
-		out := make([]Candle, 0, len(rows))
-		for _, row := range rows {
-			out = append(out, Candle{
-				SymbolCode: row.SymbolCode,
-				Interval:   row.Interval,
-				Time:       row.Time,
-				Open:       row.Open,
-				High:       row.High,
-				Low:        row.Low,
-				Close:      row.Close,
-				Volume:     row.Volume,
-			})
-		}
-		return out, nil
-	}
-	rows, err := r.q.FindCandlesAll(ctx, candlessqlc.FindCandlesAllParams{
+	rows, err := r.q.FindCandlesLimit(ctx, candlessqlc.FindCandlesLimitParams{
 		SymbolCode: symbol,
 		Interval:   interval,
+		Limit:      int32(outputsize),
 	})
 	if err != nil {
 		return nil, err

--- a/internal/feature/candles/repository_test.go
+++ b/internal/feature/candles/repository_test.go
@@ -214,17 +214,6 @@ func TestCandleRepository_Find(t *testing.T) {
 			},
 		},
 		{
-			name: "success: outputsize 0 returns all", symbol: "AAPL", interval: "1day", outputsize: 0,
-			setupFunc: func(t *testing.T, db *sql.DB) {
-				for i := 0; i < 5; i++ {
-					seedCandle(t, db, "AAPL", "1day", baseTime.AddDate(0, 0, i))
-				}
-			},
-			validateFunc: func(t *testing.T, candles []Candle) {
-				assert.Len(t, candles, 5)
-			},
-		},
-		{
 			name: "success: results ordered by time descending", symbol: "AAPL", interval: "1day", outputsize: 10,
 			setupFunc: func(t *testing.T, db *sql.DB) {
 				seedCandle(t, db, "AAPL", "1day", baseTime)

--- a/internal/feature/candles/repository_test.go
+++ b/internal/feature/candles/repository_test.go
@@ -161,6 +161,7 @@ func TestCandleRepository_Find(t *testing.T) {
 		symbol       string
 		interval     string
 		outputsize   int
+		wantErr      error
 		setupFunc    func(t *testing.T, db *sql.DB)
 		validateFunc func(t *testing.T, candles []Candle)
 	}{
@@ -226,6 +227,24 @@ func TestCandleRepository_Find(t *testing.T) {
 				assert.True(t, candles[1].Time.After(candles[2].Time))
 			},
 		},
+		{
+			name: "error: outputsize zero returns ErrInvalidOutputSize", symbol: "AAPL", interval: "1day", outputsize: 0,
+			wantErr: ErrInvalidOutputSize,
+		},
+		{
+			name: "error: negative outputsize returns ErrInvalidOutputSize", symbol: "AAPL", interval: "1day", outputsize: -1,
+			wantErr: ErrInvalidOutputSize,
+		},
+		{
+			name: "error: outputsize exceeding MaxOutputSize returns ErrInvalidOutputSize", symbol: "AAPL", interval: "1day", outputsize: MaxOutputSize + 1,
+			wantErr: ErrInvalidOutputSize,
+		},
+		{
+			name: "success: outputsize equal to MaxOutputSize is allowed", symbol: "AAPL", interval: "1day", outputsize: MaxOutputSize,
+			validateFunc: func(t *testing.T, candles []Candle) {
+				assert.Empty(t, candles)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -237,6 +256,10 @@ func TestCandleRepository_Find(t *testing.T) {
 				tt.setupFunc(t, db)
 			}
 			candles, err := repo.Find(context.Background(), tt.symbol, tt.interval, tt.outputsize)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			if tt.validateFunc != nil {
 				tt.validateFunc(t, candles)

--- a/internal/feature/candles/sqlc/querier.go
+++ b/internal/feature/candles/sqlc/querier.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Querier interface {
-	FindCandlesAll(ctx context.Context, arg FindCandlesAllParams) ([]FindCandlesAllRow, error)
 	FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]FindCandlesLimitRow, error)
 }
 

--- a/internal/feature/candles/sqlc/queries.sql
+++ b/internal/feature/candles/sqlc/queries.sql
@@ -1,9 +1,3 @@
--- name: FindCandlesAll :many
-SELECT symbol_code, "interval", "time", open, high, low, close, volume
-FROM candles
-WHERE symbol_code = $1 AND "interval" = $2
-ORDER BY "time" DESC;
-
 -- name: FindCandlesLimit :many
 SELECT symbol_code, "interval", "time", open, high, low, close, volume
 FROM candles

--- a/internal/feature/candles/sqlc/queries.sql.go
+++ b/internal/feature/candles/sqlc/queries.sql.go
@@ -10,61 +10,6 @@ import (
 	"time"
 )
 
-const findCandlesAll = `-- name: FindCandlesAll :many
-SELECT symbol_code, "interval", "time", open, high, low, close, volume
-FROM candles
-WHERE symbol_code = $1 AND "interval" = $2
-ORDER BY "time" DESC
-`
-
-type FindCandlesAllParams struct {
-	SymbolCode string
-	Interval   string
-}
-
-type FindCandlesAllRow struct {
-	SymbolCode string
-	Interval   string
-	Time       time.Time
-	Open       float64
-	High       float64
-	Low        float64
-	Close      float64
-	Volume     int64
-}
-
-func (q *Queries) FindCandlesAll(ctx context.Context, arg FindCandlesAllParams) ([]FindCandlesAllRow, error) {
-	rows, err := q.db.QueryContext(ctx, findCandlesAll, arg.SymbolCode, arg.Interval)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []FindCandlesAllRow{}
-	for rows.Next() {
-		var i FindCandlesAllRow
-		if err := rows.Scan(
-			&i.SymbolCode,
-			&i.Interval,
-			&i.Time,
-			&i.Open,
-			&i.High,
-			&i.Low,
-			&i.Close,
-			&i.Volume,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const findCandlesLimit = `-- name: FindCandlesLimit :many
 SELECT symbol_code, "interval", "time", open, high, low, close, volume
 FROM candles

--- a/internal/feature/candles/usecase.go
+++ b/internal/feature/candles/usecase.go
@@ -42,6 +42,7 @@ func NewUsecase(candle Repository) *usecase {
 // GetCandles は指定された銘柄と時間間隔のローソク足データを取得します。
 // interval / outputsize の妥当性は OpenAPI バリデーションミドルウェアと handler が
 // 検証済みのため、ここでは丸めやデフォルト化は行わず受け取った値をそのまま使います。
+// （リポジトリ層は outputsize が 1〜MaxOutputSize の範囲外であることを不変条件違反として別途防御的に検証します）
 func (cu *usecase) GetCandles(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 	cs, err := cu.candle.Find(ctx, symbol, interval, outputsize)
 	if err != nil {


### PR DESCRIPTION
## 概要
candles の `Find` 実装で発生していた `FindCandlesLimit` / `FindCandlesAll` の重複コードを解消し、単一クエリ・分岐なしの実装に統合しました。加えて、レビュー指摘を受けて `dbRepository.Find` に `outputsize` の範囲チェックを追加し、リポジトリ層がHTTP層のバリデーションに依存せず不変条件を守れるようにしました。

## 変更内容
- `internal/feature/candles/sqlc/queries.sql` から `FindCandlesAll` クエリを削除し、`sqlc generate` で生成コード（`querier.go` / `queries.sql.go`）を再生成
- `repository.go` の `Find` を、`outputsize > 0` 分岐を削除して常に `FindCandlesLimit` のみを呼ぶ単一パスの実装に統合
- `repository_test.go` から、到達不能だった `outputsize=0` を検証するテストケースを削除
- `errors.go`（新規）に `ErrInvalidOutputSize` センチネルエラーを追加し、`repository.go` の `Find` に `outputsize` が `1〜MaxOutputSize` の範囲外の場合にエラーを返すガード節を追加
- `usecase.go` のdocコメントに、リポジトリ層でも防御的検証を行う旨を追記
- `repository_test.go` に、範囲外（0・負数・上限超過）および上限ちょうどのテストケースを追加

## テスト
- `go build ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `go tool go-arch-lint check`
- `go test ./internal/feature/candles/... -v -race`（testcontainers使用、全PASS）

## レビューポイント
- `outputsize <= 0`（旧 `FindCandlesAll`）の分岐は、OpenAPI仕様（`outputsize: minimum=1, maximum=5000, default=200`）によるバリデーションと、`CachingRepository.Find` が常に正の値（検証済みoutputsizeまたはMaxOutputSize=5000）のみを渡す構成により、本番のHTTP経路では到達不可能です
- ただし `CachingRepository.Find` の Redis 未設定時のパススルー（`c.rdb == nil` の分岐）は `outputsize` を無検証のまま転送する実際に到達しうる経路であり、将来HTTP以外の呼び出し元が追加された場合の安全網として、リポジトリ層自体にも範囲チェックを追加しました
- `caching_repository.go` の `sliceCandles` ヘルパーは独立した防御的チェック（`outputsize<=0` を「全件返す」として扱う）のため、今回は変更していません。この結果、`CachingRepository.Find` のキャッシュヒット時とキャッシュミス/Redis未設定時とで `outputsize<=0` の挙動は異なりますが、いずれの経路でも本番のHTTP経路では到達不可能なため、既知のトレードオフとして許容しています
