### PR TITLE
fix: logo系エンドポイントにIP別・ユーザー別のレート制限（各10回/日）を追加

### DIFF
--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -110,8 +110,16 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 
 			r.Get("/candles/{code}", h.Candles.GetCandlesHandler)
 			r.Get("/symbols", h.Symbol.List)
-			r.Post("/logo/detect", h.Logo.DetectLogos)
-			r.Post("/logo/analyze", h.Logo.AnalyzeCompany)
+
+			// Gemini/Vision API のコスト制御のため、logo 系エンドポイント合算で
+			// 1 IP あたり 10回/日 に制限する。
+			logoRateLimit := httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
+				Prefix: "rl:logo:ip",
+				Limit:  10,
+				Window: 24 * time.Hour,
+			})
+			r.With(logoRateLimit).Post("/logo/detect", h.Logo.DetectLogos)
+			r.With(logoRateLimit).Post("/logo/analyze", h.Logo.AnalyzeCompany)
 			r.Get("/watchlist", h.Watchlist.List)
 			r.Post("/watchlist", h.Watchlist.Add)
 			r.Delete("/watchlist/{code}", h.Watchlist.Remove)

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -112,14 +112,20 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 			r.Get("/symbols", h.Symbol.List)
 
 			// Gemini/Vision API のコスト制御のため、logo 系エンドポイント合算で
-			// 1 IP あたり 10回/日 に制限する。
-			logoRateLimit := httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
+			// IP別・ユーザー別それぞれ 10回/日 に制限する。
+			// IP別はアカウント切り替えによる回避、ユーザー別はIP変更による回避を防ぐ。
+			logoIPRateLimit := httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
 				Prefix: "rl:logo:ip",
 				Limit:  10,
 				Window: 24 * time.Hour,
 			})
-			r.With(logoRateLimit).Post("/logo/detect", h.Logo.DetectLogos)
-			r.With(logoRateLimit).Post("/logo/analyze", h.Logo.AnalyzeCompany)
+			logoUserRateLimit := httpratelimit.ByUser(cfg.Limiter, httpratelimit.UserRateLimitConfig{
+				Prefix: "rl:logo:user",
+				Limit:  10,
+				Window: 24 * time.Hour,
+			})
+			r.With(logoIPRateLimit, logoUserRateLimit).Post("/logo/detect", h.Logo.DetectLogos)
+			r.With(logoIPRateLimit, logoUserRateLimit).Post("/logo/analyze", h.Logo.AnalyzeCompany)
 			r.Get("/watchlist", h.Watchlist.List)
 			r.Post("/watchlist", h.Watchlist.Add)
 			r.Delete("/watchlist/{code}", h.Watchlist.Remove)

--- a/internal/transport/httpratelimit/middleware.go
+++ b/internal/transport/httpratelimit/middleware.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
 // IPRateLimitConfig はIPベースのレートリミットの設定を保持します。
@@ -30,6 +31,50 @@ func ByIP(limiter *Limiter, cfg IPRateLimitConfig) func(http.Handler) http.Handl
 				slog.Warn("rate limit exceeded",
 					"type", "ip",
 					"ip", ip,
+					"prefix", cfg.Prefix,
+				)
+				w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
+				httpx.WriteJSON(w, http.StatusTooManyRequests, api.ErrorResponse{
+					Error: "too many requests",
+				})
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// UserRateLimitConfig は認証済みユーザーIDベースのレートリミットの設定を保持します。
+type UserRateLimitConfig struct {
+	Prefix string        // Redisキーのプレフィックス（例: "rl:logo:user"）
+	Limit  int           // ウィンドウ内の最大リクエスト数
+	Window time.Duration // スライディングウィンドウの時間幅
+}
+
+// ByUser は jwt.AuthRequired が context に格納した認証済みユーザーIDをキーとする
+// レートリミットミドルウェアを返します。jwt.AuthRequired の後段に配置してください。
+// context にユーザーIDが存在しない場合は警告ログを出力してリクエストを通過させます
+// （グレースフルデグレード）。
+func ByUser(limiter *Limiter, cfg UserRateLimitConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID, ok := jwt.UserIDFromContext(r.Context())
+			if !ok {
+				slog.Warn("user id not found in context, skipping rate limit",
+					"type", "user",
+					"prefix", cfg.Prefix,
+				)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			key := fmt.Sprintf("%s:%d", cfg.Prefix, userID)
+			result := limiter.Allow(r.Context(), key, cfg.Limit, cfg.Window)
+
+			if !result.Allowed {
+				slog.Warn("rate limit exceeded",
+					"type", "user",
+					"user_id", userID,
 					"prefix", cfg.Prefix,
 				)
 				w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))

--- a/internal/transport/httpratelimit/middleware_test.go
+++ b/internal/transport/httpratelimit/middleware_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
 // okHandler はレートリミットを通過した場合に呼ばれる終端ハンドラーです。
@@ -85,6 +87,92 @@ func TestByIP_RateLimited(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "too many requests", body["error"])
 
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestByUser_Allowed はレートリミット内のリクエストがユーザーIDキーで判定され、
+// ハンドラーまで到達し200を返すことを検証します。
+func TestByUser_Allowed(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	setupEvalMock(mock, "rl:test:user:42", 1, 0) // allowed=1, count=0
+
+	limiter := NewLimiter(rdb)
+	cfg := UserRateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: time.Minute}
+
+	called := false
+	h := ByUser(limiter, cfg)(okHandler(&called))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req = req.WithContext(jwt.WithUserID(req.Context(), 42))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called, "ハンドラーが呼ばれるべき")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestByUser_RateLimited はレートリミット超過時に429とRetry-Afterヘッダーが返され、
+// ハンドラーが呼ばれないことを検証します。
+func TestByUser_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	setupEvalMock(mock, "rl:test:user:42", 0, 10) // allowed=0, count=10 (at limit)
+
+	limiter := NewLimiter(rdb)
+	cfg := UserRateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: time.Minute}
+
+	handlerCalled := false
+	h := ByUser(limiter, cfg)(okHandler(&handlerCalled))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	req = req.WithContext(jwt.WithUserID(req.Context(), 42))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.False(t, handlerCalled, "ハンドラーは呼ばれるべきではない")
+
+	// Retry-Afterヘッダーの検証
+	assert.Equal(t, "60", w.Header().Get("Retry-After"))
+
+	// レスポンスボディの検証
+	var body map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "too many requests", body["error"])
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestByUser_NoUserID_Allowed はcontextにユーザーIDが存在しない場合に、
+// Redisを呼ばずにリクエストを通過させることを検証します（グレースフルデグレード）。
+func TestByUser_NoUserID_Allowed(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	limiter := NewLimiter(rdb)
+	cfg := UserRateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: time.Minute}
+
+	called := false
+	h := ByUser(limiter, cfg)(okHandler(&called))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called)
+	// モックに期待値を設定していないため、Redisが呼ばれていればここで失敗する
 	assert.NoError(t, mock.ExpectationsWereMet())
 }
 


### PR DESCRIPTION
## 概要
`/v1/logo/detect`・`/v1/logo/analyze` にはJWT認証はあるもののレート制限がなく、認証済みユーザーが連打すると Gemini/Vision API の呼び出しコストが青天井になる問題を修正します。IP別とユーザー別の制限を併用し、アカウント切り替え・IP変更のどちらによる回避も防ぎます。

## 変更内容
- `internal/app/router/router.go` の logo 系2ルートに `httpratelimit.ByIP`（既存）と `httpratelimit.ByUser`（新規）を併用で適用
  - IP別: Prefix `rl:logo:ip` を両ルートで共有し、2エンドポイント合算で 1 IP あたり 10回/日
  - ユーザー別: Prefix `rl:logo:user` を両ルートで共有し、2エンドポイント合算で 1 ユーザーあたり 10回/日
- `internal/transport/httpratelimit/middleware.go` に `ByUser` ミドルウェアを新規追加
  - `jwt.AuthRequired` が context に格納したユーザーIDをキー（`rl:logo:user:<userID>`）に使用
  - context にユーザーIDがない場合は警告ログを出して通過（グレースフルデグレード）
- ミドルウェア順序は 認証 → CSRF → OpenAPIバリデーション → IP制限 → ユーザー制限（認証済みリクエストのみカウントを消費）

## 関連issue
- closes #262

## テスト
- `ByUser` のユニットテストを3ケース追加（制限内で通過・429 + Retry-After・ユーザーIDなしで通過）
- `go build ./...` / `go test ./internal/transport/httpratelimit/... -race` / `golangci-lint run` / `go tool go-arch-lint check` すべてパス

## レビューポイント
- 制限値（IP別・ユーザー別とも合算 10回/日）と、detect/analyze でカウントを共有する設計の妥当性
- `httpratelimit` → `jwt` の依存追加（同じ `transport` コンポーネント内のため go-arch-lint 上は許可済み）
- Redis 障害時は既存の `Limiter.Allow` がグレースフルデグレード（許可＋警告ログ）するため追加対応なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)