### PR TITLE
fix: TwelveData APIキーをAuthorizationヘッダーで送信

### DIFF
--- a/internal/feature/candles/twelvedata/logo.go
+++ b/internal/feature/candles/twelvedata/logo.go
@@ -20,7 +20,6 @@ type logoResponse struct {
 func (t *TwelveDataMarket) GetLogoURL(ctx context.Context, symbol string) (string, error) {
 	q := url.Values{}
 	q.Set("symbol", symbol)
-	q.Set("apikey", t.cfg.TwelveDataAPIKey)
 
 	u := fmt.Sprintf("%s/logo?%s", t.cfg.BaseURL, q.Encode())
 	res, err := t.doRequestWithRetry(ctx, http.MethodGet, u)

--- a/internal/feature/candles/twelvedata/logo_test.go
+++ b/internal/feature/candles/twelvedata/logo_test.go
@@ -18,8 +18,11 @@ func TestTwelveDataMarket_GetLogoURL_Success(t *testing.T) {
 		if r.URL.Query().Get("symbol") != "AAPL" {
 			t.Errorf("expected symbol AAPL, got %s", r.URL.Query().Get("symbol"))
 		}
-		if r.URL.Query().Get("apikey") != "test-key" {
-			t.Errorf("expected apikey test-key, got %s", r.URL.Query().Get("apikey"))
+		if r.Header.Get("Authorization") != "apikey test-key" {
+			t.Errorf("expected Authorization header 'apikey test-key', got %s", r.Header.Get("Authorization"))
+		}
+		if r.URL.Query().Get("apikey") != "" {
+			t.Errorf("expected apikey not present in query, got %s", r.URL.Query().Get("apikey"))
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/internal/feature/candles/twelvedata/repository.go
+++ b/internal/feature/candles/twelvedata/repository.go
@@ -42,7 +42,6 @@ func (t *TwelveDataMarket) GetTimeSeries(ctx context.Context, symbol, interval s
 	q.Set("symbol", symbol)
 	q.Set("interval", interval)
 	q.Set("outputsize", strconv.Itoa(outputsize))
-	q.Set("apikey", t.cfg.TwelveDataAPIKey)
 
 	// URLを生成
 	u := fmt.Sprintf("%s/time_series?%s", t.cfg.BaseURL, q.Encode())
@@ -137,6 +136,7 @@ func (t *TwelveDataMarket) doRequestWithRetry(ctx context.Context, method, urlSt
 		if err != nil {
 			return nil, err
 		}
+		req.Header.Set("Authorization", "apikey "+t.cfg.TwelveDataAPIKey)
 
 		res, err := t.client.Do(req)
 		if err != nil {

--- a/internal/feature/candles/twelvedata/repository_test.go
+++ b/internal/feature/candles/twelvedata/repository_test.go
@@ -58,6 +58,12 @@ func TestTwelveDataMarket_GetTimeSeries_Success(t *testing.T) {
 		if r.URL.Query().Get("outputsize") != "100" {
 			t.Errorf("expected outputsize 100, got %s", r.URL.Query().Get("outputsize"))
 		}
+		if r.Header.Get("Authorization") != "apikey test-key" {
+			t.Errorf("expected Authorization header 'apikey test-key', got %s", r.Header.Get("Authorization"))
+		}
+		if r.URL.Query().Get("apikey") != "" {
+			t.Errorf("expected apikey not present in query, got %s", r.URL.Query().Get("apikey"))
+		}
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## 概要
TwelveData APIキーがURLクエリパラメータで送信されており、ネットワークエラー時に `*url.Error` 経由でエラーログにAPIキーが漏洩し得る問題を修正しました。TwelveData公式が正式サポートする `Authorization: apikey <KEY>` ヘッダー方式に切り替えます。

## 変更内容
- `GetTimeSeries` / `GetLogoURL` のURLクエリからの `apikey` パラメータ設定を削除
- 両メソッドが共有する `doRequestWithRetry` 内でリクエスト生成直後に `Authorization: apikey <KEY>` ヘッダーを設定（`auth/google_provider.go` などと同じ `req.Header.Set` スタイルに統一）
- `logo_test.go` / `repository_test.go` にAuthorizationヘッダーの検証と、クエリパラメータに `apikey` が含まれないことの検証を追加

## 関連issue
- closes #264

## テスト
- `go test ./internal/feature/candles/... -race -cover`
- `go build ./...`
- `golangci-lint run --timeout=5m`
- `go tool go-arch-lint check`