### PR TITLE
fix: ログアウト時にJWTを即時失効させる（jti + Redisブラックリスト）

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -93,8 +93,9 @@ func run() int {
 	// Redisキャッシュでラップ（TTLはingest連続失敗時のセーフティネット、通常は日次ingestで上書き）
 	cachedCandleRepo := candles.NewCachingRepository(rdb, candles.DefaultCacheTTL, candleRepo, "candles")
 
-	// JWTジェネレータ
+	// JWTジェネレータ・ブラックリスト（ログアウト時の即時失効用）
 	jwtGen := jwt.NewGenerator(cfg.Server.JWTSecret, 1*time.Hour)
+	jwtBlacklist := jwt.NewBlacklist(rdb)
 
 	// Google Cloudクライアント初期化
 	visionDetector, err := vision.NewVisionLogoDetector(context.Background())
@@ -135,7 +136,7 @@ func run() int {
 	}
 
 	// ハンドラー
-	authH := authhttp.NewHandler(authUC, rateLimiter, cfg.Server.SecureCookie, watchlistUC)
+	authH := authhttp.NewHandler(authUC, rateLimiter, cfg.Server.SecureCookie, cfg.Server.JWTSecret, jwtBlacklist, watchlistUC)
 	symbolH := symbollisthttp.NewHandler(symbolUC)
 	candlesH := candleshttp.NewHandler(candlesUC)
 	logoH := logodetectionhttp.NewHandler(logoUC)
@@ -160,6 +161,7 @@ func run() int {
 			AllowedOrigins:   cfg.Server.CORSOrigins,
 			GCPProjectID:     cfg.Server.GCPProjectID,
 			JWTSecret:        cfg.Server.JWTSecret,
+			Blacklist:        jwtBlacklist,
 			SecureCookie:     cfg.Server.SecureCookie,
 		},
 	)

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -128,15 +128,23 @@ sequenceDiagram
 sequenceDiagram
     participant Client
     participant Handler as Handler
+    participant Blacklist as jwt.Blacklist<br/>(Redis)
 
     Client->>Handler: DELETE /v1/logout
+    Handler->>Handler: リクエストからJWT抽出（Cookie優先→Authorizationヘッダー）
+    alt トークンが有効（署名OK・未期限切れ）
+        Handler->>Blacklist: Revoke(jti, ttl=exp-now)
+        Note over Blacklist: jwt:blacklist:<jti> をttl付きでSET<br/>Redis未接続時は警告ログのみ（グレースフルデグレード）
+    end
     Handler->>Handler: Clear auth_token cookie (MaxAge -1)
     Handler->>Handler: Clear csrf_token cookie (MaxAge -1)
     Handler-->>Client: 200 OK {"message":"ok"}
     Note over Handler,Client: Set-Cookie: auth_token (Max-Age 0)<br/>Set-Cookie: csrf_token (Max-Age 0)
 ```
 
-**注意**: ログアウトは期限切れトークンでも動作するよう、認証不要のルートに配置されています。
+**注意**: ログアウトは期限切れトークンでも動作するよう、認証不要のルートに配置されています（失効させるべき有効なトークンがない場合、ブラックリスト登録はスキップされます）。
+
+**即時失効の仕組み（issue #263）**: JWTには生成時に`jti`（JWT ID）クレームを付与しており（`internal/transport/jwt/generator.go`）、ログアウト時に`jti`をRedisブラックリストへ登録します（`internal/transport/jwt/blacklist.go`）。認証ミドルウェア（`AuthRequired`）はリクエストごとにブラックリストを確認し、登録済みの`jti`を持つトークンを401で拒否します。ブラックリストのRedisエントリはトークンの残り有効期限と同じTTLで自動失効するため、際限なく肥大化しません。Redis未接続時は他のRedis依存コンポーネント（レートリミッター・キャッシュ）と同様にフェイルオープン（失効チェックをスキップ）します。
 
 ### OAuth2 認可開始フロー
 
@@ -346,6 +354,8 @@ sequenceDiagram
 ### DELETE /v1/logout
 
 ログアウトします（`auth_token` と `csrf_token` のCookieを削除）。認証不要です。
+リクエストが有効なJWTを保持している場合、その`jti`をRedisブラックリストへ登録し、
+有効期限（発行から1時間）を待たずに即時失効させます。
 
 **レスポンス**
 
@@ -770,7 +780,7 @@ GOOGLE_REDIRECT_URL=https://api.example.com/v1/auth/oauth/google/callback
    - `auth_token`（httpOnly）: JavaScriptから読み取り不可のためXSS攻撃でトークン窃取不可
    - `csrf_token`（非httpOnly）: JavaScriptが読み取り `X-CSRF-Token` ヘッダーにセット → CSRF攻撃を防止
    - `SameSite=Lax` 設定でクロスサイトリクエストを制限
-4. **JWTの有効期限**: 1時間で自動的に失効
+4. **JWTの有効期限**: 1時間で自動的に失効。加えて、ログアウト時は`jti`をRedisブラックリストへ登録し有効期限前でも即時失効させる（issue #263）
 5. **認証方式フォールバック**: `auth_token` Cookieを優先、存在しない場合は `Authorization: Bearer <token>` ヘッダーにフォールバック（API/curlクライアント対応）
 6. **エラーメッセージの統一化**:
    - バリデーションエラー: 汎用 "invalid request" メッセージを返却

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -37,6 +37,8 @@ type Config struct {
 	AllowedOrigins   []string
 	GCPProjectID     string
 	JWTSecret        string
+	// Blacklist はログアウト済みJWT（jti）の即時失効チェックに使用する。nil可（未失効扱い）。
+	Blacklist *jwt.Blacklist
 	// SecureCookie が true（本番・TLS終端）のとき HSTS ヘッダーを有効化する。
 	SecureCookie bool
 }
@@ -104,7 +106,7 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 		// バリデーションは認証・CSRF の後に行う（未認証/CSRF 不正は 401/403 を優先し、
 		// 認証済みリクエストのボディ/パラメータのみ spec 準拠で検証する）。
 		r.Group(func(r chi.Router) {
-			r.Use(jwt.AuthRequired(cfg.JWTSecret))
+			r.Use(jwt.AuthRequired(cfg.JWTSecret, cfg.Blacklist))
 			r.Use(csrfmw.Protect())
 			r.Use(cfg.OpenAPIValidator)
 

--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/csrf"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
 // setAuthCookie は SameSite=Lax の認証関連 Cookie をレスポンスへ設定します。
@@ -52,15 +53,18 @@ type Handler struct {
 	uc           Usecase
 	limiter      *httpratelimit.Limiter
 	secureCookie bool
+	jwtSecret    string
+	blacklist    *jwt.Blacklist
 	postHooks    []auth.UserCreatedHook
 }
 
 // NewHandler はHandlerの新しいインスタンスを生成します。
 // 依存性注入用のコンストラクタで、外部からUsecaseとレートリミッターを注入します。
 // secureCookie が true の場合、Secure属性付きのCookieを設定します（本番環境用）。
+// jwtSecret と blacklist はログアウト時のトークン即時失効（Logout）に使用します。
 // postHooks にはサインアップ後に実行するフックを任意で渡せます。
-func NewHandler(uc Usecase, limiter *httpratelimit.Limiter, secureCookie bool, postHooks ...auth.UserCreatedHook) *Handler {
-	return &Handler{uc: uc, limiter: limiter, secureCookie: secureCookie, postHooks: postHooks}
+func NewHandler(uc Usecase, limiter *httpratelimit.Limiter, secureCookie bool, jwtSecret string, blacklist *jwt.Blacklist, postHooks ...auth.UserCreatedHook) *Handler {
+	return &Handler{uc: uc, limiter: limiter, secureCookie: secureCookie, jwtSecret: jwtSecret, blacklist: blacklist, postHooks: postHooks}
 }
 
 // Signup はユーザー登録APIエンドポイントを処理します。
@@ -147,9 +151,15 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 	httpx.WriteJSON(w, http.StatusOK, api.MessageResponse{Message: "ok"})
 }
 
-// Logout はauth_tokenとcsrf_tokenのCookieを削除してログアウトします。
+// Logout はリクエストのJWTを即時失効させたうえでauth_tokenとcsrf_tokenのCookieを削除します。
 // 期限切れトークンでも動作するよう認証不要のルートに配置します。
-func (h *Handler) Logout(w http.ResponseWriter, _ *http.Request) {
+func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
+	// トークンが有効な場合のみjtiをブラックリストに登録し、有効期限前でも即時失効させる。
+	// Redis未接続時等は警告ログのみでログアウト自体は継続する（グレースフルデグレード）。
+	if err := jwt.RevokeRequestToken(r.Context(), r, h.jwtSecret, h.blacklist); err != nil {
+		slog.Warn("failed to revoke token on logout", "error", err)
+	}
+
 	// MaxAge=-1 は Max-Age=0 を出力し、ブラウザにCookieの即時削除を指示する。
 	setAuthCookie(w, "auth_token", "", -1, h.secureCookie, true)
 	setAuthCookie(w, "csrf_token", "", -1, h.secureCookie, false)

--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
@@ -16,6 +17,7 @@ import (
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/auth/authhttp"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
 // H は JSON ボディ構築用の簡易マップ型です。
@@ -159,7 +161,7 @@ func TestAuthHandler_Signup(t *testing.T) {
 			t.Parallel()
 
 			mockUC := &mockUsecase{SignupFunc: tt.mockSignupFunc}
-			h := authhttp.NewHandler(mockUC, nil, false)
+			h := authhttp.NewHandler(mockUC, nil, false, "", nil)
 
 			w := makeRequest(t, h.Signup, http.MethodPost, "/signup", tt.requestBody)
 			assertJSONResponse(t, w, tt.expectedStatus, tt.expectedBody)
@@ -180,7 +182,7 @@ func TestAuthHandler_Signup_HookFailureIsNonFatal(t *testing.T) {
 			return errors.New("watchlist init failed")
 		},
 	}
-	h := authhttp.NewHandler(mockUC, nil, false, hook)
+	h := authhttp.NewHandler(mockUC, nil, false, "", nil, hook)
 
 	w := makeRequest(t, h.Signup, http.MethodPost, "/signup", H{
 		"email":    "test@example.com",
@@ -213,7 +215,7 @@ func TestAuthHandler_Login_RateLimited(t *testing.T) {
 			return "", errors.New("should not be called")
 		},
 	}
-	h := authhttp.NewHandler(mockUC, limiter, false)
+	h := authhttp.NewHandler(mockUC, limiter, false, "", nil)
 
 	w := makeRequest(t, h.Login, http.MethodPost, "/login", H{
 		"email":    "test@example.com",
@@ -290,7 +292,7 @@ func TestAuthHandler_Login(t *testing.T) {
 			t.Parallel()
 
 			mockUC := &mockUsecase{LoginFunc: tt.mockLoginFunc}
-			h := authhttp.NewHandler(mockUC, nil, tt.secureCookie)
+			h := authhttp.NewHandler(mockUC, nil, tt.secureCookie, "", nil)
 
 			w := makeRequest(t, h.Login, http.MethodPost, "/login", tt.requestBody)
 			assertJSONResponse(t, w, tt.expectedStatus, tt.expectedBody)
@@ -317,7 +319,7 @@ func TestAuthHandler_Logout(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			h := authhttp.NewHandler(&mockUsecase{}, nil, tt.secureCookie)
+			h := authhttp.NewHandler(&mockUsecase{}, nil, tt.secureCookie, "", nil)
 
 			w := makeRequest(t, h.Logout, http.MethodDelete, "/logout", H{})
 
@@ -350,4 +352,42 @@ func TestAuthHandler_Logout(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestAuthHandler_Logout_RevokesToken はログアウト時にリクエストが保持するJWTがブラックリストへ
+// 登録され、有効期限前でも即時失効することを検証します（issue #263）。
+func TestAuthHandler_Logout_RevokesToken(t *testing.T) {
+	t.Parallel()
+
+	const secret = "logout-revoke-secret"
+	gen := jwt.NewGenerator(secret, time.Hour)
+	token, err := gen.GenerateToken(1, "test@example.com")
+	require.NoError(t, err)
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	// ttlは処理にかかる時間だけ厳密一致しないため、失効登録キーの形式のみ検証する。
+	match := mock.CustomMatch(func(_, actual []interface{}) error {
+		if len(actual) < 2 {
+			t.Fatalf("unexpected SET args: %+v", actual)
+		}
+		key, ok := actual[1].(string)
+		if !ok || !strings.HasPrefix(key, "jwt:blacklist:") {
+			t.Errorf("unexpected blacklist key: %v", actual[1])
+		}
+		return nil
+	})
+	match.ExpectSet("ignored", "1", time.Hour).SetVal("OK")
+
+	blacklist := jwt.NewBlacklist(rdb)
+	h := authhttp.NewHandler(&mockUsecase{}, nil, false, secret, blacklist)
+
+	req := httptest.NewRequest(http.MethodDelete, "/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	h.Logout(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.NoError(t, mock.ExpectationsWereMet())
 }

--- a/internal/transport/csrf/middleware_test.go
+++ b/internal/transport/csrf/middleware_test.go
@@ -116,7 +116,7 @@ func TestProtect_BearerAuthSkipsCheck(t *testing.T) {
 	t.Parallel()
 
 	next, called := newRecordingHandler()
-	chain := jwt.AuthRequired(testSecret)(Protect()(next))
+	chain := jwt.AuthRequired(testSecret, nil)(Protect()(next))
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -140,7 +140,7 @@ func TestProtect_CookieAuthWithForgedBearerStillRequiresCSRF(t *testing.T) {
 		t.Parallel()
 
 		next, called := newRecordingHandler()
-		chain := jwt.AuthRequired(testSecret)(Protect()(next))
+		chain := jwt.AuthRequired(testSecret, nil)(Protect()(next))
 
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/", nil)
@@ -158,7 +158,7 @@ func TestProtect_CookieAuthWithForgedBearerStillRequiresCSRF(t *testing.T) {
 
 		const csrfToken = "valid-csrf-token"
 		next, called := newRecordingHandler()
-		chain := jwt.AuthRequired(testSecret)(Protect()(next))
+		chain := jwt.AuthRequired(testSecret, nil)(Protect()(next))
 
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, "/", nil)

--- a/internal/transport/jwt/blacklist.go
+++ b/internal/transport/jwt/blacklist.go
@@ -1,0 +1,55 @@
+package jwt
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Blacklist はRedisを使ってログアウト済みJWTのjtiを即時失効させます。
+// rdbがnilの場合は常に「失効していない」として扱います（グレースフルデグレード）。
+type Blacklist struct {
+	rdb *redis.Client
+}
+
+// NewBlacklist はBlacklistの新しいインスタンスを生成します。
+func NewBlacklist(rdb *redis.Client) *Blacklist {
+	return &Blacklist{rdb: rdb}
+}
+
+func blacklistKey(jti string) string {
+	return fmt.Sprintf("jwt:blacklist:%s", jti)
+}
+
+// Revoke はjtiをttl付きでブラックリストに登録します。
+// ttlにはトークンの残り有効期限を渡すことで、トークンがexpを迎えるのと同時に
+// Redis上のエントリも自動的に消え、ブラックリストが際限なく肥大化しないようにします。
+// jtiが空、またはttlが0以下（=既に期限切れ）の場合は何もしません。
+func (b *Blacklist) Revoke(ctx context.Context, jti string, ttl time.Duration) error {
+	if b == nil || b.rdb == nil {
+		slog.Warn("jwt blacklist unavailable, logout will not revoke token immediately")
+		return nil
+	}
+	if jti == "" || ttl <= 0 {
+		return nil
+	}
+	return b.rdb.Set(ctx, blacklistKey(jti), "1", ttl).Err()
+}
+
+// IsRevoked はjtiがブラックリストに登録されているかを確認します。
+// Redis未接続・エラー時は「失効していない」として扱います（フェイルオープン。
+// 他のRedis依存コンポーネント（レートリミッター・キャッシュ）と同じグレースフルデグレード方針）。
+func (b *Blacklist) IsRevoked(ctx context.Context, jti string) bool {
+	if b == nil || b.rdb == nil || jti == "" {
+		return false
+	}
+	exists, err := b.rdb.Exists(ctx, blacklistKey(jti)).Result()
+	if err != nil {
+		slog.Warn("jwt blacklist check failed, allowing request", "error", err)
+		return false
+	}
+	return exists > 0
+}

--- a/internal/transport/jwt/blacklist_test.go
+++ b/internal/transport/jwt/blacklist_test.go
@@ -1,0 +1,161 @@
+package jwt
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redismock/v9"
+)
+
+// TestBlacklist_Revoke はjtiがttl付きでRedisに登録されることを検証します。
+func TestBlacklist_Revoke(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	const jti = "some-jti"
+	ttl := 30 * time.Minute
+	mock.ExpectSet(blacklistKey(jti), "1", ttl).SetVal("OK")
+
+	bl := NewBlacklist(rdb)
+	if err := bl.Revoke(context.Background(), jti, ttl); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestBlacklist_Revoke_NoopCases はjti空文字・ttl<=0の場合にRedisを呼ばないことを検証します。
+func TestBlacklist_Revoke_NoopCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		jti  string
+		ttl  time.Duration
+	}{
+		{"empty jti", "", time.Hour},
+		{"zero ttl", "some-jti", 0},
+		{"negative ttl", "some-jti", -time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rdb, mock := redismock.NewClientMock()
+			t.Cleanup(func() { _ = rdb.Close() })
+
+			bl := NewBlacklist(rdb)
+			if err := bl.Revoke(context.Background(), tt.jti, tt.ttl); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("expected no Redis calls, but: %v", err)
+			}
+		})
+	}
+}
+
+// TestBlacklist_Revoke_NilRedis はRedis未接続時にエラーを返さず何もしないことを検証します（グレースフルデグレード）。
+func TestBlacklist_Revoke_NilRedis(t *testing.T) {
+	t.Parallel()
+
+	bl := NewBlacklist(nil)
+	if err := bl.Revoke(context.Background(), "some-jti", time.Hour); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestBlacklist_IsRevoked はブラックリスト登録済み・未登録の両方を正しく判定することを検証します。
+func TestBlacklist_IsRevoked(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		exists   int64
+		expected bool
+	}{
+		{"revoked", 1, true},
+		{"not revoked", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rdb, mock := redismock.NewClientMock()
+			t.Cleanup(func() { _ = rdb.Close() })
+
+			const jti = "some-jti"
+			mock.ExpectExists(blacklistKey(jti)).SetVal(tt.exists)
+
+			bl := NewBlacklist(rdb)
+			if got := bl.IsRevoked(context.Background(), jti); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("unfulfilled mock expectations: %v", err)
+			}
+		})
+	}
+}
+
+// TestBlacklist_IsRevoked_NilRedis はRedis未接続時に「失効していない」として扱う（フェイルオープン）ことを検証します。
+func TestBlacklist_IsRevoked_NilRedis(t *testing.T) {
+	t.Parallel()
+
+	bl := NewBlacklist(nil)
+	if bl.IsRevoked(context.Background(), "some-jti") {
+		t.Error("expected IsRevoked to return false when Redis is unavailable")
+	}
+}
+
+// TestBlacklist_IsRevoked_EmptyJTI は空文字のjtiに対してRedisを呼ばず false を返すことを検証します。
+func TestBlacklist_IsRevoked_EmptyJTI(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	bl := NewBlacklist(rdb)
+	if bl.IsRevoked(context.Background(), "") {
+		t.Error("expected false for empty jti")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("expected no Redis calls, but: %v", err)
+	}
+}
+
+// TestBlacklist_IsRevoked_RedisError はRedisエラー時に「失効していない」として扱う（フェイルオープン）ことを検証します。
+func TestBlacklist_IsRevoked_RedisError(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	const jti = "some-jti"
+	mock.ExpectExists(blacklistKey(jti)).SetErr(context.DeadlineExceeded)
+
+	bl := NewBlacklist(rdb)
+	if bl.IsRevoked(context.Background(), jti) {
+		t.Error("expected false when Redis returns an error")
+	}
+}
+
+// TestBlacklist_NilReceiver はBlacklistがnilポインタでも安全に呼び出せることを検証します
+// （AuthRequiredにblacklist未設定で渡された場合の防御的実装）。
+func TestBlacklist_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var bl *Blacklist
+	if err := bl.Revoke(context.Background(), "some-jti", time.Hour); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if bl.IsRevoked(context.Background(), "some-jti") {
+		t.Error("expected false for nil Blacklist")
+	}
+}

--- a/internal/transport/jwt/generator.go
+++ b/internal/transport/jwt/generator.go
@@ -2,6 +2,8 @@
 package jwt
 
 import (
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"time"
@@ -25,12 +27,20 @@ func NewGenerator(secret string, expiration time.Duration) *Generator {
 }
 
 // GenerateToken は標準クレームを含む署名済みJWTトークンを生成します。
+// jti（JWT ID）を付与することで、ログアウト時にRedisブラックリストへ登録して
+// 有効期限前でも個々のトークンを即時失効させられるようにします。
 func (g *Generator) GenerateToken(userID int64, email string) (string, error) {
+	jti, err := generateJTI()
+	if err != nil {
+		return "", fmt.Errorf("failed to generate jti: %w", err)
+	}
+
 	claims := gojwt.MapClaims{
 		"sub":   strconv.FormatInt(userID, 10),
 		"exp":   time.Now().Add(g.expiration).Unix(),
 		"iat":   time.Now().Unix(),
 		"email": email,
+		"jti":   jti,
 	}
 
 	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
@@ -40,4 +50,13 @@ func (g *Generator) GenerateToken(userID int64, email string) (string, error) {
 	}
 
 	return signed, nil
+}
+
+// generateJTI は暗号学的に安全な32文字のhex文字列（jti）を生成します。
+func generateJTI() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
 }

--- a/internal/transport/jwt/middleware.go
+++ b/internal/transport/jwt/middleware.go
@@ -13,11 +13,38 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
 )
 
+// ExtractToken はリクエストからJWT文字列を取り出します。
+// Cookie（auth_token）を優先し、存在しない場合はAuthorizationヘッダー（Bearer）に
+// フォールバックします。トークンが見つからない場合は空文字列を返します。
+func ExtractToken(r *http.Request) (tokenStr, authSource string) {
+	// 1. auth_token Cookie を優先（Next.jsブラウザクライアント用）
+	if cookie, err := r.Cookie("auth_token"); err == nil && cookie.Value != "" {
+		return cookie.Value, AuthSourceCookie
+	}
+	// 2. Authorization: Bearer ヘッダーにフォールバック（APIクライアント・curl等）
+	auth := r.Header.Get("Authorization")
+	if strings.HasPrefix(auth, "Bearer ") {
+		return strings.TrimPrefix(auth, "Bearer "), AuthSourceBearer
+	}
+	return "", ""
+}
+
+// parseToken はJWT署名を検証し、HMACアルゴリズムで署名されたトークンのみを受理します。
+func parseToken(secret, tokenStr string) (*gojwt.Token, error) {
+	return gojwt.Parse(tokenStr, func(t *gojwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*gojwt.SigningMethodHMAC); !ok {
+			return nil, gojwt.ErrSignatureInvalid
+		}
+		return []byte(secret), nil
+	})
+}
+
 // AuthRequired はJWTトークンを検証し、認証済みユーザーのみにアクセスを制限するミドルウェアを返します。
 // 認証はCookie（auth_token）を優先し、存在しない場合はAuthorizationヘッダーにフォールバックします。
 // 署名シークレットは起動時に注入されます（環境変数の読み込みは internal/app/config に集約）。
 // secret が空の場合は全リクエストを 500（サーバー設定ミス）として扱います。
-func AuthRequired(secret string) func(http.Handler) http.Handler {
+// blacklist はログアウト済みトークン（jti）の即時失効チェックに使用します。nil可（未失効扱い）。
+func AuthRequired(secret string, blacklist *Blacklist) func(http.Handler) http.Handler {
 	if secret == "" {
 		// サーバー設定ミス（JWT_SECRETが未設定）。通常は LoadAPI が起動時に必須を
 		// 強制するため到達しないが、多層防御として全リクエストを 500 にする。
@@ -29,33 +56,14 @@ func AuthRequired(secret string) func(http.Handler) http.Handler {
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// 1. auth_token Cookie を優先（Next.jsブラウザクライアント用）
-			var tokenStr string
-			authSource := ""
-			if cookie, err := r.Cookie("auth_token"); err == nil && cookie.Value != "" {
-				tokenStr = cookie.Value
-				authSource = AuthSourceCookie
-			} else {
-				// 2. Authorization: Bearer ヘッダーにフォールバック（APIクライアント・curl等）
-				auth := r.Header.Get("Authorization")
-				if strings.HasPrefix(auth, "Bearer ") {
-					tokenStr = strings.TrimPrefix(auth, "Bearer ")
-					authSource = AuthSourceBearer
-				}
-			}
+			tokenStr, authSource := ExtractToken(r)
 			if tokenStr == "" {
 				httpx.WriteJSON(w, http.StatusUnauthorized, api.ErrorResponse{Error: "missing authentication token"})
 				return
 			}
 
 			// 3. JWT署名をパースして検証
-			token, err := gojwt.Parse(tokenStr, func(t *gojwt.Token) (interface{}, error) {
-				// 署名アルゴリズムを確認（HMACのみ許可）
-				if _, ok := t.Method.(*gojwt.SigningMethodHMAC); !ok {
-					return nil, gojwt.ErrSignatureInvalid
-				}
-				return []byte(secret), nil
-			})
+			token, err := parseToken(secret, tokenStr)
 			if err != nil || !token.Valid {
 				// 検証エラーまたは無効なトークン
 				httpx.WriteJSON(w, http.StatusUnauthorized, api.ErrorResponse{Error: "invalid token"})
@@ -74,7 +82,14 @@ func AuthRequired(secret string) func(http.Handler) http.Handler {
 				return
 			}
 
-			// 5. ユーザーIDと認証方式を context に格納し、次のハンドラーへ制御を渡す
+			// 5. ログアウトにより失効済みのトークンでないか確認
+			jti, _ := claims["jti"].(string)
+			if blacklist.IsRevoked(r.Context(), jti) {
+				httpx.WriteJSON(w, http.StatusUnauthorized, api.ErrorResponse{Error: "token has been revoked"})
+				return
+			}
+
+			// 6. ユーザーIDと認証方式を context に格納し、次のハンドラーへ制御を渡す
 			ctx := WithUserID(r.Context(), userID)
 			ctx = withAuthSource(ctx, authSource)
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/transport/jwt/middleware_test.go
+++ b/internal/transport/jwt/middleware_test.go
@@ -8,12 +8,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-redis/redismock/v9"
 	gojwt "github.com/golang-jwt/jwt/v5"
 )
 
 // runAuth はミドルウェアを実行し、レスポンスレコーダー・next が呼ばれたか・
 // next が受け取ったリクエストを返すテストヘルパーです。
 func runAuth(authHeader string, mutate func(r *http.Request)) (*httptest.ResponseRecorder, bool, *http.Request) {
+	return runAuthWithBlacklist(authHeader, nil, mutate)
+}
+
+// runAuthWithBlacklist はブラックリストを指定できる runAuth のバリエーションです。
+func runAuthWithBlacklist(authHeader string, blacklist *Blacklist, mutate func(r *http.Request)) (*httptest.ResponseRecorder, bool, *http.Request) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	if authHeader != "" {
@@ -31,7 +37,7 @@ func runAuth(authHeader string, mutate func(r *http.Request)) (*httptest.Respons
 	})
 	// シークレットは起動時注入に変更されたが、既存テストの t.Setenv パターンを維持するため
 	// ヘルパー内で env から読み取って注入する。
-	AuthRequired(os.Getenv(EnvKeyJWTSecret))(next).ServeHTTP(w, req)
+	AuthRequired(os.Getenv(EnvKeyJWTSecret), blacklist)(next).ServeHTTP(w, req)
 	return w, nextCalled, seen
 }
 
@@ -223,6 +229,59 @@ func TestAuthRequired_CookiePreferred(t *testing.T) {
 	}
 }
 
+// TestAuthRequired_RevokedToken はログアウトでブラックリストに登録済みのjtiを持つ
+// トークンが401で拒否されることを検証します（issue #263: ログアウト即時失効）。
+func TestAuthRequired_RevokedToken(t *testing.T) {
+	const testSecret = "test-secret-key-for-revoked"
+	t.Setenv(EnvKeyJWTSecret, testSecret)
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	const jti = "revoked-jti-123"
+	mock.ExpectExists(blacklistKey(jti)).SetVal(1)
+
+	token := createTokenWithJTI(testSecret, 1, time.Hour, jti)
+	blacklist := NewBlacklist(rdb)
+
+	w, nextCalled, _ := runAuthWithBlacklist("Bearer "+token, blacklist, nil)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("expected status %d, got %d", http.StatusUnauthorized, w.Code)
+	}
+	if nextCalled {
+		t.Error("expected request to be aborted (next must not be called)")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestAuthRequired_NonRevokedToken はブラックリストに登録されていないトークンが
+// 通常どおり通過することを検証します。
+func TestAuthRequired_NonRevokedToken(t *testing.T) {
+	const testSecret = "test-secret-key-for-non-revoked"
+	t.Setenv(EnvKeyJWTSecret, testSecret)
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	const jti = "active-jti-456"
+	mock.ExpectExists(blacklistKey(jti)).SetVal(0)
+
+	token := createTokenWithJTI(testSecret, 1, time.Hour, jti)
+	blacklist := NewBlacklist(rdb)
+
+	w, nextCalled, _ := runAuthWithBlacklist("Bearer "+token, blacklist, nil)
+
+	if nextCalled != true {
+		t.Errorf("expected request to pass, response: %s", w.Body.String())
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
 // createTokenWithSecret はテスト用に指定されたシークレットとユーザーIDで署名済みJWTトークンを生成します。
 func createTokenWithSecret(secret string, userID int64, expiration time.Duration) string {
 	return createTokenWithSubject(secret, strconv.FormatInt(userID, 10), expiration)
@@ -231,6 +290,21 @@ func createTokenWithSecret(secret string, userID int64, expiration time.Duration
 // createLegacyTokenWithSecret は移行前と同じ数値subjectのトークンを生成します。
 func createLegacyTokenWithSecret(secret string, userID int64, expiration time.Duration) string {
 	return createTokenWithSubject(secret, float64(userID), expiration)
+}
+
+// createTokenWithJTI はブラックリスト検証テスト用に、指定したjtiクレームを含む
+// 署名済みJWTトークンを生成します。
+func createTokenWithJTI(secret string, userID int64, expiration time.Duration, jti string) string {
+	claims := gojwt.MapClaims{
+		"sub":   strconv.FormatInt(userID, 10),
+		"exp":   time.Now().Add(expiration).Unix(),
+		"iat":   time.Now().Unix(),
+		"email": "test@example.com",
+		"jti":   jti,
+	}
+	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
+	signed, _ := token.SignedString([]byte(secret))
+	return signed
 }
 
 func createTokenWithSubject(secret string, subject any, expiration time.Duration) string {

--- a/internal/transport/jwt/revoke.go
+++ b/internal/transport/jwt/revoke.go
@@ -1,0 +1,43 @@
+package jwt
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	gojwt "github.com/golang-jwt/jwt/v5"
+)
+
+// RevokeRequestToken はリクエストに含まれるJWT（Cookie優先、次にAuthorizationヘッダー）を
+// 検証し、有効なトークンであればjtiをブラックリストに登録して有効期限前でも即時失効させます。
+// トークンが存在しない・署名が無効・既に期限切れの場合は失効させる対象がないため何もせず nil を返します
+// （ログアウトはCookie削除が主目的であり、それらのケースでも成功扱いにしてよいため）。
+func RevokeRequestToken(ctx context.Context, r *http.Request, secret string, blacklist *Blacklist) error {
+	tokenStr, _ := ExtractToken(r)
+	if tokenStr == "" {
+		return nil
+	}
+
+	token, err := parseToken(secret, tokenStr)
+	if err != nil || !token.Valid {
+		return nil
+	}
+
+	claims, ok := token.Claims.(gojwt.MapClaims)
+	if !ok {
+		return nil
+	}
+
+	jti, _ := claims["jti"].(string)
+	if jti == "" {
+		return nil
+	}
+
+	expUnix, ok := claims["exp"].(float64)
+	if !ok {
+		return nil
+	}
+	ttl := time.Until(time.Unix(int64(expUnix), 0))
+
+	return blacklist.Revoke(ctx, jti, ttl)
+}

--- a/internal/transport/jwt/revoke_test.go
+++ b/internal/transport/jwt/revoke_test.go
@@ -1,0 +1,95 @@
+package jwt
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-redis/redismock/v9"
+)
+
+// TestRevokeRequestToken_ValidToken は有効なトークンを持つリクエストに対し、
+// jtiがブラックリストへ登録される（Revokeが呼ばれる）ことを検証します。
+func TestRevokeRequestToken_ValidToken(t *testing.T) {
+	t.Parallel()
+
+	const testSecret = "test-secret-for-revoke-request"
+	const jti = "logout-jti-1"
+	token := createTokenWithJTI(testSecret, 1, time.Hour, jti)
+
+	rdb, mock := redismock.NewClientMock()
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	// ttl はリクエスト処理にかかる時間の分だけ厳密な一致が期待できないため、
+	// キーが一致していることのみを CustomMatch で検証する。
+	match := mock.CustomMatch(func(_, actual []interface{}) error {
+		if len(actual) < 2 {
+			t.Fatalf("unexpected SET args: %+v", actual)
+		}
+		if actual[1] != blacklistKey(jti) {
+			t.Errorf("expected key %q, got %v", blacklistKey(jti), actual[1])
+		}
+		return nil
+	})
+	match.ExpectSet("ignored", "1", time.Hour).SetVal("OK")
+
+	req := httptest.NewRequest(http.MethodDelete, "/logout", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	bl := NewBlacklist(rdb)
+	if err := RevokeRequestToken(context.Background(), req, testSecret, bl); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestRevokeRequestToken_NoopCases はトークンなし・不正トークン・期限切れトークンの場合に
+// Redisへ書き込まず、エラーも返さないことを検証します（ログアウトはCookie削除が主目的のため）。
+func TestRevokeRequestToken_NoopCases(t *testing.T) {
+	t.Parallel()
+
+	const testSecret = "test-secret-for-revoke-noop"
+
+	tests := []struct {
+		name   string
+		mutate func(r *http.Request)
+	}{
+		{"no token", func(r *http.Request) {}},
+		{"malformed token", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer not-a-valid-token")
+		}},
+		{"wrong secret", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+createTokenWithJTI("wrong-secret", 1, time.Hour, "jti"))
+		}},
+		{"expired token", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+createTokenWithJTI(testSecret, 1, -time.Hour, "jti"))
+		}},
+		{"missing jti", func(r *http.Request) {
+			r.Header.Set("Authorization", "Bearer "+createTokenWithSecret(testSecret, 1, time.Hour))
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rdb, mock := redismock.NewClientMock()
+			t.Cleanup(func() { _ = rdb.Close() })
+
+			req := httptest.NewRequest(http.MethodDelete, "/logout", nil)
+			tt.mutate(req)
+
+			bl := NewBlacklist(rdb)
+			if err := RevokeRequestToken(context.Background(), req, testSecret, bl); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("expected no Redis calls, but: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
`DELETE /v1/logout` はCookie削除のみでJWT自体を失効させておらず、ログアウト後も直前のJWTをAuthorizationヘッダーに付ければ有効期限（1時間）まで通常どおりリクエストが通ってしまう問題を修正した。JWTに`jti`（JWT ID）クレームを付与し、ログアウト時にRedisブラックリストへ登録することで即時失効させる。

## 変更内容
- `Generator.GenerateToken` に `jti` クレームを付与（`internal/transport/jwt/generator.go`）
- `jwt.Blacklist` を追加し、`jti` をttl付きでRedisへ登録・照会（`internal/transport/jwt/blacklist.go`）。Redis未接続時は他のRedis依存コンポーネント（レートリミッター・キャッシュ）と同様にフェイルオープン
- `AuthRequired` にブラックリスト照会を追加し、失効済みトークンを401で拒否
- `RevokeRequestToken` を追加し、ログアウト時にリクエストが保持するトークンを検証してブラックリストへ登録（`internal/transport/jwt/revoke.go`）
- `authhttp.Handler.Logout` でトークン即時失効を実行するよう変更
- `router.Config` / `main.go` にブラックリストを配線
- `docs/features/auth.md` に即時失効の仕組みを追記

## 破壊的変更
外部公開APIの変更はなし。内部関数シグネチャの変更のみ:
- `jwt.AuthRequired(secret)` → `jwt.AuthRequired(secret, blacklist)`
- `authhttp.NewHandler(uc, limiter, secureCookie, postHooks...)` → `authhttp.NewHandler(uc, limiter, secureCookie, jwtSecret, blacklist, postHooks...)`

呼び出し元（`main.go`・テスト）は全て追随済み。

## 関連issue
- closes #263

## テスト
- `go build ./...` / `go vet ./...` / `golangci-lint run` / `go tool go-arch-lint check` すべて成功
- `go test ./... -race -cover` 全パッケージ成功
- ブラックリスト登録・照会（Redisモック）、失効済みトークンの拒否、ログアウト時の即時失効を新規テストで検証