### PR TITLE
refactor: symbols/candles/oauth_accountsの未使用idカラムを削除

### DIFF
--- a/db/migrations/00002_drop_surrogate_keys.sql
+++ b/db/migrations/00002_drop_surrogate_keys.sql
@@ -1,0 +1,37 @@
+-- +goose Up
+
+ALTER TABLE symbols DROP CONSTRAINT symbols_pkey;
+ALTER TABLE symbols ADD CONSTRAINT symbols_pkey PRIMARY KEY USING INDEX idx_symbols_code;
+ALTER TABLE symbols DROP COLUMN id;
+
+ALTER TABLE candles DROP CONSTRAINT candles_pkey;
+ALTER TABLE candles ADD CONSTRAINT candles_pkey PRIMARY KEY USING INDEX candle_sym_int_time;
+ALTER TABLE candles DROP COLUMN id;
+
+ALTER TABLE oauth_accounts DROP CONSTRAINT oauth_accounts_pkey;
+ALTER TABLE oauth_accounts ADD CONSTRAINT oauth_accounts_pkey PRIMARY KEY USING INDEX idx_oauth_provider_uid;
+ALTER TABLE oauth_accounts DROP COLUMN id;
+
+-- +goose Down
+
+ALTER TABLE oauth_accounts ADD COLUMN id BIGSERIAL;
+ALTER TABLE oauth_accounts DROP CONSTRAINT oauth_accounts_pkey;
+ALTER TABLE oauth_accounts ADD PRIMARY KEY (id);
+CREATE UNIQUE INDEX idx_oauth_provider_uid ON oauth_accounts (provider, provider_uid);
+
+ALTER TABLE candles ADD COLUMN id BIGSERIAL;
+ALTER TABLE candles DROP CONSTRAINT candles_pkey;
+ALTER TABLE candles ADD PRIMARY KEY (id);
+CREATE UNIQUE INDEX candle_sym_int_time ON candles (symbol_code, "interval", "time");
+
+-- symbols_pkey（現在はcode）を candles/watchlists のFKが参照しているため、
+-- CASCADEで一旦FKごと落とし、id移行後に再作成する。
+ALTER TABLE symbols ADD COLUMN id BIGSERIAL;
+ALTER TABLE symbols DROP CONSTRAINT symbols_pkey CASCADE;
+ALTER TABLE symbols ADD PRIMARY KEY (id);
+CREATE UNIQUE INDEX idx_symbols_code ON symbols (code);
+
+ALTER TABLE candles
+    ADD CONSTRAINT fk_candles_symbol FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT;
+ALTER TABLE watchlists
+    ADD CONSTRAINT fk_watchlists_symbol FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT;

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -5,9 +5,9 @@
 | Name | Columns | Comment | Type |
 | ---- | ------- | ------- | ---- |
 | [public.users](public.users.md) | 5 |  | BASE TABLE |
-| [public.oauth_accounts](public.oauth_accounts.md) | 5 |  | BASE TABLE |
-| [public.symbols](public.symbols.md) | 10 |  | BASE TABLE |
-| [public.candles](public.candles.md) | 9 |  | BASE TABLE |
+| [public.oauth_accounts](public.oauth_accounts.md) | 4 |  | BASE TABLE |
+| [public.symbols](public.symbols.md) | 9 |  | BASE TABLE |
+| [public.candles](public.candles.md) | 8 |  | BASE TABLE |
 | [public.watchlists](public.watchlists.md) | 6 |  | BASE TABLE |
 
 ## Relations
@@ -28,14 +28,12 @@ erDiagram
   timestamp_with_time_zone updated_at ""
 }
 "public.oauth_accounts" {
-  bigint id ""
   bigint user_id FK ""
   varchar_32_ provider ""
   varchar_255_ provider_uid ""
   timestamp_with_time_zone created_at ""
 }
 "public.symbols" {
-  bigint id ""
   varchar_20_ code ""
   varchar_255_ name ""
   varchar_100_ market ""
@@ -47,7 +45,6 @@ erDiagram
   timestamp_with_time_zone updated_at ""
 }
 "public.candles" {
-  bigint id ""
   varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -4,7 +4,6 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | bigint | nextval('candles_id_seq'::regclass) | false |  |  |  |
 | symbol_code | varchar(20) |  | false |  | [public.symbols](public.symbols.md) |  |
 | interval | varchar(16) |  | false |  |  |  |
 | time | timestamp with time zone |  | false |  |  |  |
@@ -20,22 +19,20 @@
 | ---- | ---- | ---------- |
 | candles_close_not_null | n | NOT NULL close |
 | candles_high_not_null | n | NOT NULL high |
-| candles_id_not_null | n | NOT NULL id |
 | candles_interval_not_null | n | NOT NULL "interval" |
 | candles_low_not_null | n | NOT NULL low |
 | candles_open_not_null | n | NOT NULL open |
 | candles_symbol_code_not_null | n | NOT NULL symbol_code |
 | candles_time_not_null | n | NOT NULL "time" |
 | candles_volume_not_null | n | NOT NULL volume |
+| candles_pkey | PRIMARY KEY | PRIMARY KEY (symbol_code, "interval", "time") |
 | fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
-| candles_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
-| candles_pkey | CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id) |
-| candle_sym_int_time | CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol_code, "interval", "time") |
+| candles_pkey | CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (symbol_code, "interval", "time") |
 
 ## Relations
 
@@ -45,7 +42,6 @@ erDiagram
 "public.candles" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.candles" {
-  bigint id ""
   varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""
@@ -56,7 +52,6 @@ erDiagram
   bigint volume ""
 }
 "public.symbols" {
-  bigint id ""
   varchar_20_ code ""
   varchar_255_ name ""
   varchar_100_ market ""

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -25,8 +25,8 @@
 | candles_symbol_code_not_null | n | NOT NULL symbol_code |
 | candles_time_not_null | n | NOT NULL "time" |
 | candles_volume_not_null | n | NOT NULL volume |
-| candles_pkey | PRIMARY KEY | PRIMARY KEY (symbol_code, "interval", "time") |
 | fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
+| candles_pkey | PRIMARY KEY | PRIMARY KEY (symbol_code, "interval", "time") |
 
 ## Indexes
 

--- a/docs/schema/public.oauth_accounts.md
+++ b/docs/schema/public.oauth_accounts.md
@@ -4,7 +4,6 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | bigint | nextval('oauth_accounts_id_seq'::regclass) | false |  |  |  |
 | user_id | bigint |  | false |  | [public.users](public.users.md) |  |
 | provider | varchar(32) |  | false |  |  |  |
 | provider_uid | varchar(255) |  | false |  |  |  |
@@ -15,20 +14,18 @@
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
 | oauth_accounts_created_at_not_null | n | NOT NULL created_at |
-| oauth_accounts_id_not_null | n | NOT NULL id |
 | oauth_accounts_provider_not_null | n | NOT NULL provider |
 | oauth_accounts_provider_uid_not_null | n | NOT NULL provider_uid |
 | oauth_accounts_user_id_not_null | n | NOT NULL user_id |
 | fk_oauth_accounts_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
-| oauth_accounts_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| oauth_accounts_pkey | PRIMARY KEY | PRIMARY KEY (provider, provider_uid) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
-| oauth_accounts_pkey | CREATE UNIQUE INDEX oauth_accounts_pkey ON public.oauth_accounts USING btree (id) |
 | idx_oauth_accounts_user_id | CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (user_id) |
-| idx_oauth_provider_uid | CREATE UNIQUE INDEX idx_oauth_provider_uid ON public.oauth_accounts USING btree (provider, provider_uid) |
+| oauth_accounts_pkey | CREATE UNIQUE INDEX oauth_accounts_pkey ON public.oauth_accounts USING btree (provider, provider_uid) |
 
 ## Relations
 
@@ -38,7 +35,6 @@ erDiagram
 "public.oauth_accounts" }o--|| "public.users" : "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
 
 "public.oauth_accounts" {
-  bigint id ""
   bigint user_id FK ""
   varchar_32_ provider ""
   varchar_255_ provider_uid ""

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -4,7 +4,6 @@
 
 | Name | Type | Default | Nullable | Children | Parents | Comment |
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
-| id | bigint | nextval('symbols_id_seq'::regclass) | false |  |  |  |
 | code | varchar(20) |  | false | [public.candles](public.candles.md) [public.watchlists](public.watchlists.md) |  |  |
 | name | varchar(255) |  | false |  |  |  |
 | market | varchar(100) |  | false |  |  |  |
@@ -21,20 +20,18 @@
 | ---- | ---- | ---------- |
 | symbols_code_not_null | n | NOT NULL code |
 | symbols_created_at_not_null | n | NOT NULL created_at |
-| symbols_id_not_null | n | NOT NULL id |
 | symbols_is_active_not_null | n | NOT NULL is_active |
 | symbols_market_not_null | n | NOT NULL market |
 | symbols_name_not_null | n | NOT NULL name |
 | symbols_timezone_not_null | n | NOT NULL timezone |
 | symbols_updated_at_not_null | n | NOT NULL updated_at |
-| symbols_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| symbols_pkey | PRIMARY KEY | PRIMARY KEY (code) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
-| symbols_pkey | CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (id) |
-| idx_symbols_code | CREATE UNIQUE INDEX idx_symbols_code ON public.symbols USING btree (code) |
+| symbols_pkey | CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (code) |
 
 ## Relations
 
@@ -45,7 +42,6 @@ erDiagram
 "public.watchlists" }o--|| "public.symbols" : "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT"
 
 "public.symbols" {
-  bigint id ""
   varchar_20_ code ""
   varchar_255_ name ""
   varchar_100_ market ""
@@ -57,7 +53,6 @@ erDiagram
   timestamp_with_time_zone updated_at ""
 }
 "public.candles" {
-  bigint id ""
   varchar_20_ symbol_code FK ""
   varchar_16_ interval ""
   timestamp_with_time_zone time ""

--- a/docs/schema/public.users.md
+++ b/docs/schema/public.users.md
@@ -43,7 +43,6 @@ erDiagram
   timestamp_with_time_zone updated_at ""
 }
 "public.oauth_accounts" {
-  bigint id ""
   bigint user_id FK ""
   varchar_32_ provider ""
   varchar_255_ provider_uid ""

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -22,8 +22,8 @@
 | watchlists_updated_at_not_null | n | NOT NULL updated_at |
 | watchlists_user_id_not_null | n | NOT NULL user_id |
 | fk_watchlists_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
-| fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 
 ## Indexes
 
@@ -58,7 +58,6 @@ erDiagram
   timestamp_with_time_zone updated_at ""
 }
 "public.symbols" {
-  bigint id ""
   varchar_20_ code ""
   varchar_255_ name ""
   varchar_100_ market ""

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -22,8 +22,8 @@
 | watchlists_updated_at_not_null | n | NOT NULL updated_at |
 | watchlists_user_id_not_null | n | NOT NULL user_id |
 | fk_watchlists_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
-| watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 | fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
+| watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
 

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -503,18 +503,6 @@
           ]
         },
         {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "symbol_code",
-            "interval",
-            "time"
-          ]
-        },
-        {
           "name": "fk_candles_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -525,6 +513,18 @@
           ],
           "referenced_columns": [
             "code"
+          ]
+        },
+        {
+          "name": "candles_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "symbol_code",
+            "interval",
+            "time"
           ]
         }
       ]
@@ -679,16 +679,6 @@
           ]
         },
         {
-          "name": "watchlists_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.watchlists",
-          "referenced_table": "",
-          "columns": [
-            "id"
-          ]
-        },
-        {
           "name": "fk_watchlists_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -699,6 +689,16 @@
           ],
           "referenced_columns": [
             "code"
+          ]
+        },
+        {
+          "name": "watchlists_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "id"
           ]
         }
       ]

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -110,12 +110,6 @@
       "type": "BASE TABLE",
       "columns": [
         {
-          "name": "id",
-          "type": "bigint",
-          "nullable": false,
-          "default": "nextval('oauth_accounts_id_seq'::regclass)"
-        },
-        {
           "name": "user_id",
           "type": "bigint",
           "nullable": false
@@ -139,14 +133,6 @@
       ],
       "indexes": [
         {
-          "name": "oauth_accounts_pkey",
-          "def": "CREATE UNIQUE INDEX oauth_accounts_pkey ON public.oauth_accounts USING btree (id)",
-          "table": "public.oauth_accounts",
-          "columns": [
-            "id"
-          ]
-        },
-        {
           "name": "idx_oauth_accounts_user_id",
           "def": "CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (user_id)",
           "table": "public.oauth_accounts",
@@ -155,8 +141,8 @@
           ]
         },
         {
-          "name": "idx_oauth_provider_uid",
-          "def": "CREATE UNIQUE INDEX idx_oauth_provider_uid ON public.oauth_accounts USING btree (provider, provider_uid)",
+          "name": "oauth_accounts_pkey",
+          "def": "CREATE UNIQUE INDEX oauth_accounts_pkey ON public.oauth_accounts USING btree (provider, provider_uid)",
           "table": "public.oauth_accounts",
           "columns": [
             "provider",
@@ -173,16 +159,6 @@
           "referenced_table": "",
           "columns": [
             "created_at"
-          ]
-        },
-        {
-          "name": "oauth_accounts_id_not_null",
-          "type": "n",
-          "def": "NOT NULL id",
-          "table": "public.oauth_accounts",
-          "referenced_table": "",
-          "columns": [
-            "id"
           ]
         },
         {
@@ -231,11 +207,12 @@
         {
           "name": "oauth_accounts_pkey",
           "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
+          "def": "PRIMARY KEY (provider, provider_uid)",
           "table": "public.oauth_accounts",
           "referenced_table": "",
           "columns": [
-            "id"
+            "provider",
+            "provider_uid"
           ]
         }
       ]
@@ -244,12 +221,6 @@
       "name": "public.symbols",
       "type": "BASE TABLE",
       "columns": [
-        {
-          "name": "id",
-          "type": "bigint",
-          "nullable": false,
-          "default": "nextval('symbols_id_seq'::regclass)"
-        },
         {
           "name": "code",
           "type": "varchar(20)",
@@ -302,15 +273,7 @@
       "indexes": [
         {
           "name": "symbols_pkey",
-          "def": "CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (id)",
-          "table": "public.symbols",
-          "columns": [
-            "id"
-          ]
-        },
-        {
-          "name": "idx_symbols_code",
-          "def": "CREATE UNIQUE INDEX idx_symbols_code ON public.symbols USING btree (code)",
+          "def": "CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (code)",
           "table": "public.symbols",
           "columns": [
             "code"
@@ -336,16 +299,6 @@
           "referenced_table": "",
           "columns": [
             "created_at"
-          ]
-        },
-        {
-          "name": "symbols_id_not_null",
-          "type": "n",
-          "def": "NOT NULL id",
-          "table": "public.symbols",
-          "referenced_table": "",
-          "columns": [
-            "id"
           ]
         },
         {
@@ -401,11 +354,11 @@
         {
           "name": "symbols_pkey",
           "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
+          "def": "PRIMARY KEY (code)",
           "table": "public.symbols",
           "referenced_table": "",
           "columns": [
-            "id"
+            "code"
           ]
         }
       ]
@@ -414,12 +367,6 @@
       "name": "public.candles",
       "type": "BASE TABLE",
       "columns": [
-        {
-          "name": "id",
-          "type": "bigint",
-          "nullable": false,
-          "default": "nextval('candles_id_seq'::regclass)"
-        },
         {
           "name": "symbol_code",
           "type": "varchar(20)",
@@ -465,15 +412,7 @@
       "indexes": [
         {
           "name": "candles_pkey",
-          "def": "CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (id)",
-          "table": "public.candles",
-          "columns": [
-            "id"
-          ]
-        },
-        {
-          "name": "candle_sym_int_time",
-          "def": "CREATE UNIQUE INDEX candle_sym_int_time ON public.candles USING btree (symbol_code, \"interval\", \"time\")",
+          "def": "CREATE UNIQUE INDEX candles_pkey ON public.candles USING btree (symbol_code, \"interval\", \"time\")",
           "table": "public.candles",
           "columns": [
             "symbol_code",
@@ -501,16 +440,6 @@
           "referenced_table": "",
           "columns": [
             "high"
-          ]
-        },
-        {
-          "name": "candles_id_not_null",
-          "type": "n",
-          "def": "NOT NULL id",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "id"
           ]
         },
         {
@@ -574,6 +503,18 @@
           ]
         },
         {
+          "name": "candles_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "symbol_code",
+            "interval",
+            "time"
+          ]
+        },
+        {
           "name": "fk_candles_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -584,16 +525,6 @@
           ],
           "referenced_columns": [
             "code"
-          ]
-        },
-        {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "id"
           ]
         }
       ]
@@ -748,6 +679,16 @@
           ]
         },
         {
+          "name": "watchlists_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
           "name": "fk_watchlists_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -758,16 +699,6 @@
           ],
           "referenced_columns": [
             "code"
-          ]
-        },
-        {
-          "name": "watchlists_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.watchlists",
-          "referenced_table": "",
-          "columns": [
-            "id"
           ]
         }
       ]

--- a/internal/feature/auth/oauth_account.go
+++ b/internal/feature/auth/oauth_account.go
@@ -5,8 +5,6 @@ import "time"
 // OAuthAccount はOAuth2プロバイダーとユーザーを紐付けるエンティティです。
 // (provider, provider_uid) の複合ユニーク制約でプロバイダー側IDの重複を防ぎます。
 type OAuthAccount struct {
-	ID int64
-
 	// UserID は紐付けられたユーザーのIDです。
 	UserID int64
 

--- a/internal/feature/auth/oauth_test.go
+++ b/internal/feature/auth/oauth_test.go
@@ -79,7 +79,7 @@ func TestOAuthUsecase_HandleCallback_FindOrCreateUser(t *testing.T) {
 		{
 			name:            "既存OAuthAccountあり: リンクせずログイン成功",
 			providerEmail:   "user@example.com",
-			existingAccount: &auth.OAuthAccount{ID: 1, UserID: 42, Provider: providerName, ProviderUID: "google-uid-1"},
+			existingAccount: &auth.OAuthAccount{UserID: 42, Provider: providerName, ProviderUID: "google-uid-1"},
 		},
 		{
 			name:          "同メールのパスワードユーザーあり: 自動リンクを拒否",

--- a/internal/feature/auth/sqlc/models.go
+++ b/internal/feature/auth/sqlc/models.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Candle struct {
-	ID         int64
 	SymbolCode string
 	Interval   string
 	Time       time.Time
@@ -22,7 +21,6 @@ type Candle struct {
 }
 
 type OauthAccount struct {
-	ID          int64
 	UserID      int64
 	Provider    string
 	ProviderUid string
@@ -30,7 +28,6 @@ type OauthAccount struct {
 }
 
 type Symbol struct {
-	ID            int64
 	Code          string
 	Name          string
 	Market        string

--- a/internal/feature/auth/sqlc/queries.sql
+++ b/internal/feature/auth/sqlc/queries.sql
@@ -18,10 +18,10 @@ LIMIT 1;
 -- name: CreateOAuthAccount :one
 INSERT INTO oauth_accounts (user_id, provider, provider_uid)
 VALUES ($1, $2, $3)
-RETURNING id, user_id, provider, provider_uid, created_at;
+RETURNING user_id, provider, provider_uid, created_at;
 
 -- name: FindOAuthAccountByProvider :one
-SELECT id, user_id, provider, provider_uid, created_at
+SELECT user_id, provider, provider_uid, created_at
 FROM oauth_accounts
 WHERE provider = $1 AND provider_uid = $2
 LIMIT 1;

--- a/internal/feature/auth/sqlc/queries.sql.go
+++ b/internal/feature/auth/sqlc/queries.sql.go
@@ -13,7 +13,7 @@ import (
 const createOAuthAccount = `-- name: CreateOAuthAccount :one
 INSERT INTO oauth_accounts (user_id, provider, provider_uid)
 VALUES ($1, $2, $3)
-RETURNING id, user_id, provider, provider_uid, created_at
+RETURNING user_id, provider, provider_uid, created_at
 `
 
 type CreateOAuthAccountParams struct {
@@ -26,7 +26,6 @@ func (q *Queries) CreateOAuthAccount(ctx context.Context, arg CreateOAuthAccount
 	row := q.db.QueryRowContext(ctx, createOAuthAccount, arg.UserID, arg.Provider, arg.ProviderUid)
 	var i OauthAccount
 	err := row.Scan(
-		&i.ID,
 		&i.UserID,
 		&i.Provider,
 		&i.ProviderUid,
@@ -60,7 +59,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 }
 
 const findOAuthAccountByProvider = `-- name: FindOAuthAccountByProvider :one
-SELECT id, user_id, provider, provider_uid, created_at
+SELECT user_id, provider, provider_uid, created_at
 FROM oauth_accounts
 WHERE provider = $1 AND provider_uid = $2
 LIMIT 1
@@ -75,7 +74,6 @@ func (q *Queries) FindOAuthAccountByProvider(ctx context.Context, arg FindOAuthA
 	row := q.db.QueryRowContext(ctx, findOAuthAccountByProvider, arg.Provider, arg.ProviderUid)
 	var i OauthAccount
 	err := row.Scan(
-		&i.ID,
 		&i.UserID,
 		&i.Provider,
 		&i.ProviderUid,

--- a/internal/feature/auth/user_repository.go
+++ b/internal/feature/auth/user_repository.go
@@ -138,7 +138,6 @@ func userFromSQLC(m authsqlc.User) User {
 // oauthAccountFromSQLC は sqlc 生成モデルをドメインエンティティに変換します。
 func oauthAccountFromSQLC(m authsqlc.OauthAccount) OAuthAccount {
 	return OAuthAccount{
-		ID:          m.ID,
 		UserID:      m.UserID,
 		Provider:    m.Provider,
 		ProviderUID: m.ProviderUid,

--- a/internal/feature/auth/user_repository_test.go
+++ b/internal/feature/auth/user_repository_test.go
@@ -321,7 +321,7 @@ func TestUserRepository_CreateUserWithOAuthAccount(t *testing.T) {
 		err := repo.CreateUserWithOAuthAccount(context.Background(), user, acct)
 		require.NoError(t, err)
 		assert.NotZero(t, user.ID)
-		assert.NotZero(t, acct.ID)
+		assert.False(t, acct.CreatedAt.IsZero())
 		assert.Equal(t, user.ID, acct.UserID)
 	})
 
@@ -336,6 +336,6 @@ func TestUserRepository_CreateUserWithOAuthAccount(t *testing.T) {
 		err := repo.CreateUserWithOAuthAccount(context.Background(), user, acct)
 		assert.ErrorIs(t, err, ErrEmailAlreadyExists)
 		assert.Zero(t, user.ID, "user should not be persisted")
-		assert.Zero(t, acct.ID, "account should not be persisted")
+		assert.True(t, acct.CreatedAt.IsZero(), "account should not be persisted")
 	})
 }

--- a/internal/feature/candles/sqlc/models.go
+++ b/internal/feature/candles/sqlc/models.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Candle struct {
-	ID         int64
 	SymbolCode string
 	Interval   string
 	Time       time.Time
@@ -22,7 +21,6 @@ type Candle struct {
 }
 
 type OauthAccount struct {
-	ID          int64
 	UserID      int64
 	Provider    string
 	ProviderUid string
@@ -30,7 +28,6 @@ type OauthAccount struct {
 }
 
 type Symbol struct {
-	ID            int64
 	Code          string
 	Name          string
 	Market        string

--- a/internal/feature/candles/sqlc/querier.go
+++ b/internal/feature/candles/sqlc/querier.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Querier interface {
-	FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]FindCandlesLimitRow, error)
+	FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]Candle, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/feature/candles/sqlc/queries.sql.go
+++ b/internal/feature/candles/sqlc/queries.sql.go
@@ -7,7 +7,6 @@ package candlessqlc
 
 import (
 	"context"
-	"time"
 )
 
 const findCandlesLimit = `-- name: FindCandlesLimit :many
@@ -24,26 +23,15 @@ type FindCandlesLimitParams struct {
 	Limit      int32
 }
 
-type FindCandlesLimitRow struct {
-	SymbolCode string
-	Interval   string
-	Time       time.Time
-	Open       float64
-	High       float64
-	Low        float64
-	Close      float64
-	Volume     int64
-}
-
-func (q *Queries) FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]FindCandlesLimitRow, error) {
+func (q *Queries) FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]Candle, error) {
 	rows, err := q.db.QueryContext(ctx, findCandlesLimit, arg.SymbolCode, arg.Interval, arg.Limit)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []FindCandlesLimitRow{}
+	items := []Candle{}
 	for rows.Next() {
-		var i FindCandlesLimitRow
+		var i Candle
 		if err := rows.Scan(
 			&i.SymbolCode,
 			&i.Interval,

--- a/internal/feature/symbollist/repository.go
+++ b/internal/feature/symbollist/repository.go
@@ -73,7 +73,6 @@ func symbolFromSQLC(m symbollistsqlc.Symbol) Symbol {
 		logoUpdatedAt = &t
 	}
 	return Symbol{
-		ID:            m.ID,
 		Code:          m.Code,
 		Name:          m.Name,
 		Market:        m.Market,

--- a/internal/feature/symbollist/repository_test.go
+++ b/internal/feature/symbollist/repository_test.go
@@ -27,13 +27,13 @@ func setupTestDB(t *testing.T) *sql.DB {
 	return dbtest.OpenIsolatedDB(t)
 }
 
-// seedSymbol はテスト用の銘柄データをデータベースに作成し、ID 付きで返します。
+// seedSymbol はテスト用の銘柄データをデータベースに作成して返します。
 func seedSymbol(t *testing.T, db *sql.DB, code, name, market string, isActive bool) *Symbol {
 	t.Helper()
 	row := db.QueryRowContext(context.Background(),
 		`INSERT INTO symbols (code, name, market, timezone, is_active)
 		 VALUES ($1, $2, $3, 'Asia/Tokyo', $4)
-		 RETURNING id, created_at, updated_at`,
+		 RETURNING created_at, updated_at`,
 		code, name, market, isActive,
 	)
 	s := &Symbol{
@@ -43,9 +43,7 @@ func seedSymbol(t *testing.T, db *sql.DB, code, name, market string, isActive bo
 		Timezone: "Asia/Tokyo",
 		IsActive: isActive,
 	}
-	var id int64
-	require.NoError(t, row.Scan(&id, &s.CreatedAt, &s.UpdatedAt), "failed to seed symbol")
-	s.ID = id
+	require.NoError(t, row.Scan(&s.CreatedAt, &s.UpdatedAt), "failed to seed symbol")
 	return s
 }
 
@@ -63,19 +61,17 @@ func seedSymbolFull(t *testing.T, db *sql.DB, s *Symbol) {
 	row := db.QueryRowContext(context.Background(),
 		`INSERT INTO symbols (code, name, market, timezone, logo_url, logo_updated_at, is_active)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7)
-		 RETURNING id, created_at, updated_at`,
+		 RETURNING created_at, updated_at`,
 		s.Code, s.Name, s.Market, s.Timezone, logoURL, logoAt, s.IsActive,
 	)
-	var id int64
-	require.NoError(t, row.Scan(&id, &s.CreatedAt, &s.UpdatedAt))
-	s.ID = id
+	require.NoError(t, row.Scan(&s.CreatedAt, &s.UpdatedAt))
 }
 
 // updateSymbolActive は銘柄の is_active フィールドを更新します。
 func updateSymbolActive(t *testing.T, db *sql.DB, symbol *Symbol, isActive bool) {
 	t.Helper()
 	_, err := db.ExecContext(context.Background(),
-		`UPDATE symbols SET is_active = $1 WHERE id = $2`, isActive, symbol.ID)
+		`UPDATE symbols SET is_active = $1 WHERE code = $2`, isActive, symbol.Code)
 	require.NoError(t, err, "failed to update symbol active status")
 }
 
@@ -167,13 +163,12 @@ func TestSymbolRepository_ListActive_FieldValues(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewRepository(db)
 
-	expected := seedSymbol(t, db, "7203.T", "Toyota Motor Corporation", "Tokyo Stock Exchange", true)
+	seedSymbol(t, db, "7203.T", "Toyota Motor Corporation", "Tokyo Stock Exchange", true)
 	symbols, err := repo.ListActive(context.Background())
 	require.NoError(t, err)
 	require.Len(t, symbols, 1)
 
 	got := symbols[0]
-	assert.Equal(t, expected.ID, got.ID)
 	assert.Equal(t, "7203.T", got.Code)
 	assert.Equal(t, "Toyota Motor Corporation", got.Name)
 	assert.Equal(t, "Tokyo Stock Exchange", got.Market)

--- a/internal/feature/symbollist/sqlc/models.go
+++ b/internal/feature/symbollist/sqlc/models.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Candle struct {
-	ID         int64
 	SymbolCode string
 	Interval   string
 	Time       time.Time
@@ -22,7 +21,6 @@ type Candle struct {
 }
 
 type OauthAccount struct {
-	ID          int64
 	UserID      int64
 	Provider    string
 	ProviderUid string
@@ -30,7 +28,6 @@ type OauthAccount struct {
 }
 
 type Symbol struct {
-	ID            int64
 	Code          string
 	Name          string
 	Market        string

--- a/internal/feature/symbollist/sqlc/queries.sql
+++ b/internal/feature/symbollist/sqlc/queries.sql
@@ -1,5 +1,5 @@
 -- name: ListActiveSymbols :many
-SELECT id, code, name, market, timezone, logo_url, logo_updated_at, is_active, created_at, updated_at
+SELECT code, name, market, timezone, logo_url, logo_updated_at, is_active, created_at, updated_at
 FROM symbols
 WHERE is_active = TRUE
 ORDER BY code ASC;

--- a/internal/feature/symbollist/sqlc/queries.sql.go
+++ b/internal/feature/symbollist/sqlc/queries.sql.go
@@ -11,7 +11,7 @@ import (
 )
 
 const listActiveSymbols = `-- name: ListActiveSymbols :many
-SELECT id, code, name, market, timezone, logo_url, logo_updated_at, is_active, created_at, updated_at
+SELECT code, name, market, timezone, logo_url, logo_updated_at, is_active, created_at, updated_at
 FROM symbols
 WHERE is_active = TRUE
 ORDER BY code ASC
@@ -27,7 +27,6 @@ func (q *Queries) ListActiveSymbols(ctx context.Context) ([]Symbol, error) {
 	for rows.Next() {
 		var i Symbol
 		if err := rows.Scan(
-			&i.ID,
 			&i.Code,
 			&i.Name,
 			&i.Market,

--- a/internal/feature/symbollist/symbol.go
+++ b/internal/feature/symbollist/symbol.go
@@ -5,8 +5,7 @@ import "time"
 // Symbol はシステム内の株式銘柄コードを表します。
 // 銘柄コード、企業名、市場などの取引証券に関する情報を保持します。
 type Symbol struct {
-	ID            int64      // 主キー
-	Code          string     // 銘柄コード（例: "AAPL", "7203.T"）
+	Code          string     // 銘柄コード（例: "AAPL", "7203.T"）、主キー
 	Name          string     // 企業名
 	Market        string     // 市場識別子（例: "NASDAQ", "TSE"）
 	Timezone      string     // 取引所の IANA タイムゾーン（例: "America/New_York", "Asia/Tokyo"）

--- a/internal/feature/symbollist/symbollisthttp/handler_test.go
+++ b/internal/feature/symbollist/symbollisthttp/handler_test.go
@@ -52,8 +52,8 @@ func TestSymbolHandler_List(t *testing.T) {
 			name: "success: returns list of symbols",
 			mockListActiveFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{ID: 1, Code: "7203.T", Name: "Toyota Motor", Market: "TSE", LogoURL: strPtr("https://api.twelvedata.com/logo/toyota.com"), IsActive: true},
-					{ID: 2, Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
+					{Code: "7203.T", Name: "Toyota Motor", Market: "TSE", LogoURL: strPtr("https://api.twelvedata.com/logo/toyota.com"), IsActive: true},
+					{Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
 				}, nil
 			},
 			expectedStatus: http.StatusOK,
@@ -71,7 +71,7 @@ func TestSymbolHandler_List(t *testing.T) {
 			name: "success: returns single symbol",
 			mockListActiveFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{ID: 1, Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
+					{Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
 				}, nil
 			},
 			expectedStatus: http.StatusOK,
@@ -119,12 +119,11 @@ func TestSymbolHandler_List(t *testing.T) {
 func TestSymbolHandler_List_DTOConversion(t *testing.T) {
 	t.Parallel()
 
-	// レスポンスに公開DTOフィールドのみが含まれることを検証（ID、Market、IsActiveは含まれない）
+	// レスポンスに公開DTOフィールドのみが含まれることを検証（Market、IsActiveは含まれない）
 	mockUC := &mockUsecase{
 		ListActiveSymbolsFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 			return []symbollist.Symbol{
 				{
-					ID:       999,
 					Code:     "TEST.T",
 					Name:     "Test Company",
 					Market:   "NYSE",
@@ -144,7 +143,6 @@ func TestSymbolHandler_List_DTOConversion(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.JSONEq(t, `[{"code":"TEST.T","name":"Test Company","logo_url":"https://api.twelvedata.com/logo/test.com"}]`, w.Body.String())
 	// 内部フィールドが公開されていないことを検証
-	assert.NotContains(t, w.Body.String(), "999")
 	assert.NotContains(t, w.Body.String(), "NYSE")
 	assert.NotContains(t, w.Body.String(), "is_active")
 	assert.NotContains(t, w.Body.String(), "sort_key")

--- a/internal/feature/symbollist/usecase_test.go
+++ b/internal/feature/symbollist/usecase_test.go
@@ -48,13 +48,13 @@ func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 			name: "success: returns list of active symbols",
 			mockListActive: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{ID: 1, Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
-					{ID: 2, Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
+					{Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
+					{Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
 				}, nil
 			},
 			expectedSymbols: []symbollist.Symbol{
-				{ID: 1, Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
-				{ID: 2, Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
+				{Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
+				{Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
 			},
 			wantErr: false,
 		},
@@ -87,11 +87,11 @@ func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 			name: "success: returns single symbol",
 			mockListActive: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{ID: 1, Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
+					{Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
 				}, nil
 			},
 			expectedSymbols: []symbollist.Symbol{
-				{ID: 1, Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
+				{Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
 			},
 			wantErr: false,
 		},

--- a/internal/feature/watchlist/sqlc/models.go
+++ b/internal/feature/watchlist/sqlc/models.go
@@ -10,7 +10,6 @@ import (
 )
 
 type Candle struct {
-	ID         int64
 	SymbolCode string
 	Interval   string
 	Time       time.Time
@@ -22,7 +21,6 @@ type Candle struct {
 }
 
 type OauthAccount struct {
-	ID          int64
 	UserID      int64
 	Provider    string
 	ProviderUid string
@@ -30,7 +28,6 @@ type OauthAccount struct {
 }
 
 type Symbol struct {
-	ID            int64
 	Code          string
 	Name          string
 	Market        string


### PR DESCRIPTION
## 概要
symbols / candles / oauth_accounts の3テーブルでは、サロゲートキー `id (BIGSERIAL)` が本番のusecase/HTTPレスポンス/リポジトリ実装のどこからも参照されておらず、既にunique制約のある自然キー・複合キーが実質の主キーとして機能していました。不要な `id` カラムを削除し、既存のunique indexをそのままPRIMARY KEYに昇格させました。

## 変更内容
- `symbols`: `id` を削除し `code` をPRIMARY KEYに変更
- `candles`: `id` を削除し `(symbol_code, interval, time)` を複合PRIMARY KEYに変更
- `oauth_accounts`: `id` を削除し `(provider, provider_uid)` を複合PRIMARY KEYに変更
- 上記に伴い `Symbol` / `OAuthAccount` 構造体から `ID` フィールドを削除
- sqlcクエリ（`queries.sql`）から `id` の SELECT/RETURNING を除去し、生成コードを再生成
- 関連するリポジトリ実装・テスト（シード/更新/比較ロジック）を自然キーベースに修正

なお `users`（JWT・認証コンテキスト・全FKへの影響が広範囲）と `watchlists`（`WatchlistItem.id` がAPI契約上requiredでフロント影響が不明）の `id` は今回のスコープ外とし、現状維持としています。

## 破壊的変更
- DBマイグレーション（`db/migrations/00002_drop_surrogate_keys.sql`）で `symbols.id` / `candles.id` / `oauth_accounts.id` カラムを削除します。いずれのカラムもアプリケーションコード・他テーブルのFKから参照されていないことを確認済みです。
- `symbols` の主キー変更に伴い、`candles`/`watchlists` から `symbols(code)` へのFK制約を一度CASCADE削除してから再作成しています（マイグレーション内で完結、データの参照整合性への影響はありません）。
- 適用前後でのUp/Down/Upの可逆性、および実データ（candles約59,000件を含むローカルDB）での件数変化がないことを確認済みです。

## テスト
- `go build ./...`
- `go vet ./...`
- `golangci-lint run --timeout=5m`
- `go tool go-arch-lint check`
- `go test ./... -race -cover`（全パッケージPASS）
- ローカルPostgreSQLで `goose up` → `goose down` → `goose up` の可逆性を確認（データ消失なし）