### PR TITLE
refactor: usersテーブルのpasswordカラムをpassword_hashにリネーム

### DIFF
--- a/db/migrations/00003_rename_users_password_to_password_hash.sql
+++ b/db/migrations/00003_rename_users_password_to_password_hash.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE users RENAME COLUMN password TO password_hash;
+
+-- +goose Down
+
+ALTER TABLE users RENAME COLUMN password_hash TO password;

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -23,7 +23,7 @@ erDiagram
 "public.users" {
   bigint id ""
   varchar_255_ email ""
-  varchar_255_ password ""
+  varchar_255_ password_hash ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
 }

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -25,8 +25,8 @@
 | candles_symbol_code_not_null | n | NOT NULL symbol_code |
 | candles_time_not_null | n | NOT NULL "time" |
 | candles_volume_not_null | n | NOT NULL volume |
-| fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | candles_pkey | PRIMARY KEY | PRIMARY KEY (symbol_code, "interval", "time") |
+| fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 
 ## Indexes
 

--- a/docs/schema/public.candles.md
+++ b/docs/schema/public.candles.md
@@ -25,8 +25,8 @@
 | candles_symbol_code_not_null | n | NOT NULL symbol_code |
 | candles_time_not_null | n | NOT NULL "time" |
 | candles_volume_not_null | n | NOT NULL volume |
-| candles_pkey | PRIMARY KEY | PRIMARY KEY (symbol_code, "interval", "time") |
 | fk_candles_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
+| candles_pkey | PRIMARY KEY | PRIMARY KEY (symbol_code, "interval", "time") |
 
 ## Indexes
 

--- a/docs/schema/public.oauth_accounts.md
+++ b/docs/schema/public.oauth_accounts.md
@@ -43,7 +43,7 @@ erDiagram
 "public.users" {
   bigint id ""
   varchar_255_ email ""
-  varchar_255_ password ""
+  varchar_255_ password_hash ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
 }

--- a/docs/schema/public.users.md
+++ b/docs/schema/public.users.md
@@ -6,7 +6,7 @@
 | ---- | ---- | ------- | -------- | -------- | ------- | ------- |
 | id | bigint | nextval('users_id_seq'::regclass) | false | [public.oauth_accounts](public.oauth_accounts.md) [public.watchlists](public.watchlists.md) |  |  |
 | email | varchar(255) |  | false |  |  |  |
-| password | varchar(255) |  | true |  |  |  |
+| password_hash | varchar(255) |  | true |  |  |  |
 | created_at | timestamp with time zone | now() | false |  |  |  |
 | updated_at | timestamp with time zone | now() | false |  |  |  |
 
@@ -38,7 +38,7 @@ erDiagram
 "public.users" {
   bigint id ""
   varchar_255_ email ""
-  varchar_255_ password ""
+  varchar_255_ password_hash ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
 }

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -22,8 +22,8 @@
 | watchlists_updated_at_not_null | n | NOT NULL updated_at |
 | watchlists_user_id_not_null | n | NOT NULL user_id |
 | fk_watchlists_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
-| fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 | watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |
+| fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
 
 ## Indexes
 
@@ -53,7 +53,7 @@ erDiagram
 "public.users" {
   bigint id ""
   varchar_255_ email ""
-  varchar_255_ password ""
+  varchar_255_ password_hash ""
   timestamp_with_time_zone created_at ""
   timestamp_with_time_zone updated_at ""
 }

--- a/docs/schema/public.watchlists.md
+++ b/docs/schema/public.watchlists.md
@@ -22,8 +22,8 @@
 | watchlists_updated_at_not_null | n | NOT NULL updated_at |
 | watchlists_user_id_not_null | n | NOT NULL user_id |
 | fk_watchlists_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
-| watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 | fk_watchlists_symbol | FOREIGN KEY | FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT |
+| watchlists_pkey | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
 

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -503,18 +503,6 @@
           ]
         },
         {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "symbol_code",
-            "interval",
-            "time"
-          ]
-        },
-        {
           "name": "fk_candles_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -525,6 +513,18 @@
           ],
           "referenced_columns": [
             "code"
+          ]
+        },
+        {
+          "name": "candles_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "symbol_code",
+            "interval",
+            "time"
           ]
         }
       ]
@@ -679,16 +679,6 @@
           ]
         },
         {
-          "name": "watchlists_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.watchlists",
-          "referenced_table": "",
-          "columns": [
-            "id"
-          ]
-        },
-        {
           "name": "fk_watchlists_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -699,6 +689,16 @@
           ],
           "referenced_columns": [
             "code"
+          ]
+        },
+        {
+          "name": "watchlists_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "id"
           ]
         }
       ]

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -17,7 +17,7 @@
           "nullable": false
         },
         {
-          "name": "password",
+          "name": "password_hash",
           "type": "varchar(255)",
           "nullable": true
         },
@@ -503,6 +503,18 @@
           ]
         },
         {
+          "name": "candles_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
+          "table": "public.candles",
+          "referenced_table": "",
+          "columns": [
+            "symbol_code",
+            "interval",
+            "time"
+          ]
+        },
+        {
           "name": "fk_candles_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -513,18 +525,6 @@
           ],
           "referenced_columns": [
             "code"
-          ]
-        },
-        {
-          "name": "candles_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (symbol_code, \"interval\", \"time\")",
-          "table": "public.candles",
-          "referenced_table": "",
-          "columns": [
-            "symbol_code",
-            "interval",
-            "time"
           ]
         }
       ]
@@ -679,6 +679,16 @@
           ]
         },
         {
+          "name": "watchlists_pkey",
+          "type": "PRIMARY KEY",
+          "def": "PRIMARY KEY (id)",
+          "table": "public.watchlists",
+          "referenced_table": "",
+          "columns": [
+            "id"
+          ]
+        },
+        {
           "name": "fk_watchlists_symbol",
           "type": "FOREIGN KEY",
           "def": "FOREIGN KEY (symbol_code) REFERENCES symbols(code) ON DELETE RESTRICT",
@@ -689,16 +699,6 @@
           ],
           "referenced_columns": [
             "code"
-          ]
-        },
-        {
-          "name": "watchlists_pkey",
-          "type": "PRIMARY KEY",
-          "def": "PRIMARY KEY (id)",
-          "table": "public.watchlists",
-          "referenced_table": "",
-          "columns": [
-            "id"
           ]
         }
       ]

--- a/internal/feature/auth/oauth.go
+++ b/internal/feature/auth/oauth.go
@@ -147,7 +147,7 @@ func (uc *oauthUsecase) findOrCreateUser(ctx context.Context, providerName strin
 		return 0, ErrOAuthEmailConflict
 	}
 
-	// 新規ユーザー作成（OAuth専用: Password = nil）
+	// 新規ユーザー作成（OAuth専用: PasswordHash = nil）
 	// UserとOAuthAccountをトランザクション内で原子的に作成し、
 	// 片方だけ残る不整合を防ぐ。
 	newUser := &User{Email: info.Email}

--- a/internal/feature/auth/oauth_test.go
+++ b/internal/feature/auth/oauth_test.go
@@ -84,13 +84,13 @@ func TestOAuthUsecase_HandleCallback_FindOrCreateUser(t *testing.T) {
 		{
 			name:          "同メールのパスワードユーザーあり: 自動リンクを拒否",
 			providerEmail: "user@example.com",
-			existingUser:  &auth.User{ID: 42, Email: "user@example.com", Password: &password},
+			existingUser:  &auth.User{ID: 42, Email: "user@example.com", PasswordHash: &password},
 			wantErr:       auth.ErrOAuthEmailConflict,
 		},
 		{
 			name:          "同メールのOAuth専用ユーザーあり（別プロバイダー登録）: 自動リンクを拒否",
 			providerEmail: "user@example.com",
-			existingUser:  &auth.User{ID: 42, Email: "user@example.com", Password: nil},
+			existingUser:  &auth.User{ID: 42, Email: "user@example.com", PasswordHash: nil},
 			wantErr:       auth.ErrOAuthEmailConflict,
 		},
 		{
@@ -101,7 +101,7 @@ func TestOAuthUsecase_HandleCallback_FindOrCreateUser(t *testing.T) {
 		{
 			name:            "正規化済みメールで検索され拒否される（大小文字・空白違い）",
 			providerEmail:   "  User@Example.COM ",
-			existingUser:    &auth.User{ID: 42, Email: "user@example.com", Password: &password},
+			existingUser:    &auth.User{ID: 42, Email: "user@example.com", PasswordHash: &password},
 			wantErr:         auth.ErrOAuthEmailConflict,
 			wantLookupEmail: "user@example.com",
 		},

--- a/internal/feature/auth/sqlc/models.go
+++ b/internal/feature/auth/sqlc/models.go
@@ -40,11 +40,11 @@ type Symbol struct {
 }
 
 type User struct {
-	ID        int64
-	Email     string
-	Password  sql.NullString
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID           int64
+	Email        string
+	PasswordHash sql.NullString
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type Watchlist struct {

--- a/internal/feature/auth/sqlc/queries.sql
+++ b/internal/feature/auth/sqlc/queries.sql
@@ -1,16 +1,16 @@
 -- name: CreateUser :one
-INSERT INTO users (email, password)
+INSERT INTO users (email, password_hash)
 VALUES ($1, $2)
-RETURNING id, email, password, created_at, updated_at;
+RETURNING id, email, password_hash, created_at, updated_at;
 
 -- name: FindUserByEmail :one
-SELECT id, email, password, created_at, updated_at
+SELECT id, email, password_hash, created_at, updated_at
 FROM users
 WHERE email = $1
 LIMIT 1;
 
 -- name: FindUserByID :one
-SELECT id, email, password, created_at, updated_at
+SELECT id, email, password_hash, created_at, updated_at
 FROM users
 WHERE id = $1
 LIMIT 1;

--- a/internal/feature/auth/sqlc/queries.sql.go
+++ b/internal/feature/auth/sqlc/queries.sql.go
@@ -35,23 +35,23 @@ func (q *Queries) CreateOAuthAccount(ctx context.Context, arg CreateOAuthAccount
 }
 
 const createUser = `-- name: CreateUser :one
-INSERT INTO users (email, password)
+INSERT INTO users (email, password_hash)
 VALUES ($1, $2)
-RETURNING id, email, password, created_at, updated_at
+RETURNING id, email, password_hash, created_at, updated_at
 `
 
 type CreateUserParams struct {
-	Email    string
-	Password sql.NullString
+	Email        string
+	PasswordHash sql.NullString
 }
 
 func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, error) {
-	row := q.db.QueryRowContext(ctx, createUser, arg.Email, arg.Password)
+	row := q.db.QueryRowContext(ctx, createUser, arg.Email, arg.PasswordHash)
 	var i User
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
-		&i.Password,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -83,7 +83,7 @@ func (q *Queries) FindOAuthAccountByProvider(ctx context.Context, arg FindOAuthA
 }
 
 const findUserByEmail = `-- name: FindUserByEmail :one
-SELECT id, email, password, created_at, updated_at
+SELECT id, email, password_hash, created_at, updated_at
 FROM users
 WHERE email = $1
 LIMIT 1
@@ -95,7 +95,7 @@ func (q *Queries) FindUserByEmail(ctx context.Context, email string) (User, erro
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
-		&i.Password,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)
@@ -103,7 +103,7 @@ func (q *Queries) FindUserByEmail(ctx context.Context, email string) (User, erro
 }
 
 const findUserByID = `-- name: FindUserByID :one
-SELECT id, email, password, created_at, updated_at
+SELECT id, email, password_hash, created_at, updated_at
 FROM users
 WHERE id = $1
 LIMIT 1
@@ -115,7 +115,7 @@ func (q *Queries) FindUserByID(ctx context.Context, id int64) (User, error) {
 	err := row.Scan(
 		&i.ID,
 		&i.Email,
-		&i.Password,
+		&i.PasswordHash,
 		&i.CreatedAt,
 		&i.UpdatedAt,
 	)

--- a/internal/feature/auth/usecase.go
+++ b/internal/feature/auth/usecase.go
@@ -156,7 +156,7 @@ func (u *usecase) Signup(ctx context.Context, email, password string) (int64, er
 		return 0, fmt.Errorf("failed to hash password: %w", err)
 	}
 	hashedStr := string(hashed)
-	user := &User{Email: email, Password: &hashedStr}
+	user := &User{Email: email, PasswordHash: &hashedStr}
 	if err := u.users.Create(ctx, user); err != nil {
 		return 0, err
 	}
@@ -183,8 +183,8 @@ func (u *usecase) Login(ctx context.Context, email, password string) (string, er
 	// ユーザーが存在しない場合のタイミング攻撃緩和用ダミーハッシュ
 	// bcrypt.CompareHashAndPasswordが常に呼ばれることを保証する
 	passwordHash := u.dummyHash
-	if err == nil && user.Password != nil {
-		passwordHash = *user.Password
+	if err == nil && user.PasswordHash != nil {
+		passwordHash = *user.PasswordHash
 	}
 
 	// タイミング攻撃防止のため、常にパスワードを検証

--- a/internal/feature/auth/usecase_test.go
+++ b/internal/feature/auth/usecase_test.go
@@ -90,9 +90,9 @@ func createTestUser(t *testing.T, id int64, email, password string) *auth.User {
 	}
 	hashedStr := string(hashedPassword)
 	return &auth.User{
-		ID:       id,
-		Email:    email,
-		Password: &hashedStr,
+		ID:           id,
+		Email:        email,
+		PasswordHash: &hashedStr,
 	}
 }
 
@@ -205,7 +205,7 @@ func TestAuthUsecase_Signup(t *testing.T) {
 			mockRepo := &mockUserRepository{
 				CreateFunc: func(ctx context.Context, user *auth.User) error {
 					if tt.verifyBcryptHash {
-						verifyBcryptHash(t, *user.Password, tt.password)
+						verifyBcryptHash(t, *user.PasswordHash, tt.password)
 					}
 					if tt.repositoryErr != nil {
 						return tt.repositoryErr
@@ -402,13 +402,13 @@ func TestAuthUsecase_PepperApplied(t *testing.T) {
 		mockRepo := &mockUserRepository{
 			CreateFunc: func(ctx context.Context, user *auth.User) error {
 				// 生パスワードではハッシュが一致しないことを確認
-				err := bcrypt.CompareHashAndPassword([]byte(*user.Password), []byte("password12345"))
+				err := bcrypt.CompareHashAndPassword([]byte(*user.PasswordHash), []byte("password12345"))
 				if err == nil {
 					t.Error("hash should not match raw password when pepper is applied")
 				}
 				// ペッパー適用済みパスワードでは一致することを確認
 				peppered := pepperPasswordForTest("password12345", testPepper)
-				if err := bcrypt.CompareHashAndPassword([]byte(*user.Password), []byte(peppered)); err != nil {
+				if err := bcrypt.CompareHashAndPassword([]byte(*user.PasswordHash), []byte(peppered)); err != nil {
 					t.Errorf("hash should match peppered password: %v", err)
 				}
 				return nil
@@ -432,7 +432,7 @@ func TestAuthUsecase_PepperApplied(t *testing.T) {
 
 		mockRepo := &mockUserRepository{
 			CreateFunc: func(ctx context.Context, user *auth.User) error {
-				storedHash = *user.Password
+				storedHash = *user.PasswordHash
 				return nil
 			},
 		}

--- a/internal/feature/auth/user.go
+++ b/internal/feature/auth/user.go
@@ -12,10 +12,10 @@ type User struct {
 	// 全ユーザー間で一意である必要があります。
 	Email string
 
-	// Password はユーザーのハッシュ化されたパスワードです。
+	// PasswordHash はユーザーのハッシュ化されたパスワードです。
 	// 平文パスワードを保存してはなりません。
 	// OAuth専用ユーザーはパスワードを持たないため nil になります。
-	Password *string
+	PasswordHash *string
 
 	// CreatedAt はユーザーが作成された日時です。
 	CreatedAt time.Time

--- a/internal/feature/auth/user_repository.go
+++ b/internal/feature/auth/user_repository.go
@@ -37,8 +37,8 @@ func (r *userRepository) Create(ctx context.Context, u *User) error {
 		return errors.New("user is nil")
 	}
 	row, err := r.q.CreateUser(ctx, authsqlc.CreateUserParams{
-		Email:    u.Email,
-		Password: toNullString(u.Password),
+		Email:        u.Email,
+		PasswordHash: toNullString(u.PasswordHash),
 	})
 	if err != nil {
 		return mapEmailUniqueErr(err)
@@ -93,8 +93,8 @@ func (r *userRepository) CreateUserWithOAuthAccount(ctx context.Context, user *U
 
 	qtx := r.q.WithTx(tx)
 	userRow, err := qtx.CreateUser(ctx, authsqlc.CreateUserParams{
-		Email:    user.Email,
-		Password: toNullString(user.Password),
+		Email:        user.Email,
+		PasswordHash: toNullString(user.PasswordHash),
 	})
 	if err != nil {
 		return mapEmailUniqueErr(err)
@@ -122,16 +122,16 @@ func (r *userRepository) CreateUserWithOAuthAccount(ctx context.Context, user *U
 // userFromSQLC は sqlc 生成モデルをドメインエンティティに変換します。
 func userFromSQLC(m authsqlc.User) User {
 	var pwd *string
-	if m.Password.Valid {
-		s := m.Password.String
+	if m.PasswordHash.Valid {
+		s := m.PasswordHash.String
 		pwd = &s
 	}
 	return User{
-		ID:        m.ID,
-		Email:     m.Email,
-		Password:  pwd,
-		CreatedAt: m.CreatedAt,
-		UpdatedAt: m.UpdatedAt,
+		ID:           m.ID,
+		Email:        m.Email,
+		PasswordHash: pwd,
+		CreatedAt:    m.CreatedAt,
+		UpdatedAt:    m.UpdatedAt,
 	}
 }
 

--- a/internal/feature/auth/user_repository_test.go
+++ b/internal/feature/auth/user_repository_test.go
@@ -33,8 +33,8 @@ func seedUser(t *testing.T, db *sql.DB, email, password string) *User {
 	t.Helper()
 	repo := NewUserRepository(db)
 	user := &User{
-		Email:    email,
-		Password: &password,
+		Email:        email,
+		PasswordHash: &password,
 	}
 	err := repo.Create(context.Background(), user)
 	require.NoError(t, err, "failed to seed user")
@@ -65,8 +65,8 @@ func TestUserRepository_Create(t *testing.T) {
 		{
 			name: "success: user creation",
 			user: &User{
-				Email:    "test@example.com",
-				Password: ptrStr("hashed_password"),
+				Email:        "test@example.com",
+				PasswordHash: ptrStr("hashed_password"),
 			},
 			wantErr: false,
 			validateFunc: func(t *testing.T, user *User) {
@@ -78,8 +78,8 @@ func TestUserRepository_Create(t *testing.T) {
 		{
 			name: "failure: duplicate email returns ErrEmailAlreadyExists",
 			user: &User{
-				Email:    "duplicate@example.com",
-				Password: ptrStr("password2"),
+				Email:        "duplicate@example.com",
+				PasswordHash: ptrStr("password2"),
 			},
 			wantErr:     true,
 			expectedErr: ErrEmailAlreadyExists,
@@ -140,7 +140,7 @@ func TestUserRepository_FindByEmail(t *testing.T) {
 				assert.NotNil(t, found, "user is nil")
 				assert.Equal(t, expected.ID, found.ID)
 				assert.Equal(t, expected.Email, found.Email)
-				assert.Equal(t, expected.Password, found.Password)
+				assert.Equal(t, expected.PasswordHash, found.PasswordHash)
 			},
 		},
 		{
@@ -169,7 +169,7 @@ func TestUserRepository_FindByEmail(t *testing.T) {
 				assert.NotNil(t, found, "user is nil")
 				assert.Equal(t, expected.ID, found.ID)
 				assert.Equal(t, "user2@example.com", found.Email)
-				assert.Equal(t, ptrStr("pass2"), found.Password)
+				assert.Equal(t, ptrStr("pass2"), found.PasswordHash)
 			},
 		},
 	}
@@ -221,7 +221,7 @@ func TestUserRepository_FindByID(t *testing.T) {
 				assert.NotNil(t, found, "user is nil")
 				assert.Equal(t, expected.ID, found.ID)
 				assert.Equal(t, expected.Email, found.Email)
-				assert.Equal(t, expected.Password, found.Password)
+				assert.Equal(t, expected.PasswordHash, found.PasswordHash)
 			},
 		},
 		{
@@ -249,7 +249,7 @@ func TestUserRepository_FindByID(t *testing.T) {
 				assert.NotNil(t, found, "user is nil")
 				assert.Equal(t, expected.ID, found.ID)
 				assert.Equal(t, "user2@example.com", found.Email)
-				assert.Equal(t, ptrStr("pass2"), found.Password)
+				assert.Equal(t, ptrStr("pass2"), found.PasswordHash)
 			},
 		},
 	}
@@ -290,8 +290,8 @@ func TestUserRepository_Timestamps(t *testing.T) {
 	repo := NewUserRepository(db)
 
 	user := &User{
-		Email:    "timestamp@example.com",
-		Password: ptrStr("password"),
+		Email:        "timestamp@example.com",
+		PasswordHash: ptrStr("password"),
 	}
 	err := repo.Create(context.Background(), user)
 	require.NoError(t, err)

--- a/internal/feature/candles/sqlc/models.go
+++ b/internal/feature/candles/sqlc/models.go
@@ -40,11 +40,11 @@ type Symbol struct {
 }
 
 type User struct {
-	ID        int64
-	Email     string
-	Password  sql.NullString
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID           int64
+	Email        string
+	PasswordHash sql.NullString
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type Watchlist struct {

--- a/internal/feature/symbollist/sqlc/models.go
+++ b/internal/feature/symbollist/sqlc/models.go
@@ -40,11 +40,11 @@ type Symbol struct {
 }
 
 type User struct {
-	ID        int64
-	Email     string
-	Password  sql.NullString
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID           int64
+	Email        string
+	PasswordHash sql.NullString
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type Watchlist struct {

--- a/internal/feature/watchlist/repository_test.go
+++ b/internal/feature/watchlist/repository_test.go
@@ -30,9 +30,9 @@ func setupTestDB(t *testing.T) (*sql.DB, userIDs) {
 	ctx := context.Background()
 	users := userIDs{}
 	require.NoError(t, db.QueryRowContext(ctx,
-		`INSERT INTO users (email, password) VALUES ('u1@example.com', 'p') RETURNING id`).Scan(&users.u1))
+		`INSERT INTO users (email, password_hash) VALUES ('u1@example.com', 'p') RETURNING id`).Scan(&users.u1))
 	require.NoError(t, db.QueryRowContext(ctx,
-		`INSERT INTO users (email, password) VALUES ('u2@example.com', 'p') RETURNING id`).Scan(&users.u2))
+		`INSERT INTO users (email, password_hash) VALUES ('u2@example.com', 'p') RETURNING id`).Scan(&users.u2))
 
 	_, err := db.ExecContext(ctx,
 		`INSERT INTO symbols (code, name, market, timezone) VALUES

--- a/internal/feature/watchlist/sqlc/models.go
+++ b/internal/feature/watchlist/sqlc/models.go
@@ -40,11 +40,11 @@ type Symbol struct {
 }
 
 type User struct {
-	ID        int64
-	Email     string
-	Password  sql.NullString
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID           int64
+	Email        string
+	PasswordHash sql.NullString
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type Watchlist struct {


### PR DESCRIPTION
## 概要
usersテーブルの`password`カラムは実際にはbcryptハッシュ値を保存しており、生パスワードではない。命名の実態を正しく反映するため`password_hash`にリネームした。

## 変更内容
- 新規マイグレーション（`00003_rename_users_password_to_password_hash.sql`）で`ALTER TABLE users RENAME COLUMN password TO password_hash`を追加
- `internal/feature/auth/sqlc/queries.sql`を修正し、`sqlc generate`で生成コードを更新
- ドメインモデル`auth.User.Password`を`PasswordHash`にリネームし、`user_repository.go`・`usecase.go`・`oauth.go`を追従修正
- 関連テスト（`user_repository_test.go` / `usecase_test.go` / `oauth_test.go`）を追従修正
- `internal/feature/watchlist/repository_test.go`内の生SQL（`INSERT INTO users`）も`password_hash`に修正
- `docs/schema/`配下のtbls生成ドキュメントを再生成

## 破壊的変更
- DBカラムのリネームを伴うため、マイグレーション適用とアプリケーションのデプロイ順序に注意が必要（旧コードが稼働中に本マイグレーションを適用すると`password`カラム参照でエラーになる）

## テスト
- `go build ./...`
- `go test ./... -race -cover`（全パッケージPASS）
- `golangci-lint run --timeout=5m`（0 issues）
- `go tool go-arch-lint check`（OK）
- `tbls diff --config docs/tbls.yml`（差分なし）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>