### PR TITLE
fix: oauth_accountsの一意制約・updated_atとsymbolsの部分インデックスを追加

### DIFF
--- a/db/migrations/00001_init_schema.sql
+++ b/db/migrations/00001_init_schema.sql
@@ -14,7 +14,9 @@ CREATE TABLE oauth_accounts (
     provider        VARCHAR(32)  NOT NULL,
     provider_uid    VARCHAR(255) NOT NULL,
     created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
     CONSTRAINT oauth_accounts_pkey PRIMARY KEY (provider, provider_uid),
+    CONSTRAINT uq_oauth_accounts_user_provider UNIQUE (user_id, provider),
     CONSTRAINT fk_oauth_accounts_user
         FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );
@@ -31,6 +33,7 @@ CREATE TABLE symbols (
     created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
     updated_at      TIMESTAMPTZ  NOT NULL DEFAULT now()
 );
+CREATE INDEX idx_symbols_active ON symbols (code) WHERE is_active;
 
 CREATE TABLE candles (
     symbol_code     VARCHAR(20)    NOT NULL,

--- a/docs/schema/README.md
+++ b/docs/schema/README.md
@@ -5,7 +5,7 @@
 | Name | Columns | Comment | Type |
 | ---- | ------- | ------- | ---- |
 | [public.users](public.users.md) | 5 |  | BASE TABLE |
-| [public.oauth_accounts](public.oauth_accounts.md) | 4 |  | BASE TABLE |
+| [public.oauth_accounts](public.oauth_accounts.md) | 5 |  | BASE TABLE |
 | [public.symbols](public.symbols.md) | 9 |  | BASE TABLE |
 | [public.candles](public.candles.md) | 8 |  | BASE TABLE |
 | [public.watchlists](public.watchlists.md) | 6 |  | BASE TABLE |
@@ -32,6 +32,7 @@ erDiagram
   varchar_32_ provider ""
   varchar_255_ provider_uid ""
   timestamp_with_time_zone created_at ""
+  timestamp_with_time_zone updated_at ""
 }
 "public.symbols" {
   varchar_20_ code ""

--- a/docs/schema/public.oauth_accounts.md
+++ b/docs/schema/public.oauth_accounts.md
@@ -8,6 +8,7 @@
 | provider | varchar(32) |  | false |  |  |  |
 | provider_uid | varchar(255) |  | false |  |  |  |
 | created_at | timestamp with time zone | now() | false |  |  |  |
+| updated_at | timestamp with time zone | now() | false |  |  |  |
 
 ## Constraints
 
@@ -16,15 +17,18 @@
 | oauth_accounts_created_at_not_null | n | NOT NULL created_at |
 | oauth_accounts_provider_not_null | n | NOT NULL provider |
 | oauth_accounts_provider_uid_not_null | n | NOT NULL provider_uid |
+| oauth_accounts_updated_at_not_null | n | NOT NULL updated_at |
 | oauth_accounts_user_id_not_null | n | NOT NULL user_id |
 | fk_oauth_accounts_user | FOREIGN KEY | FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE |
 | oauth_accounts_pkey | PRIMARY KEY | PRIMARY KEY (provider, provider_uid) |
+| uq_oauth_accounts_user_provider | UNIQUE | UNIQUE (user_id, provider) |
 
 ## Indexes
 
 | Name | Definition |
 | ---- | ---------- |
 | oauth_accounts_pkey | CREATE UNIQUE INDEX oauth_accounts_pkey ON public.oauth_accounts USING btree (provider, provider_uid) |
+| uq_oauth_accounts_user_provider | CREATE UNIQUE INDEX uq_oauth_accounts_user_provider ON public.oauth_accounts USING btree (user_id, provider) |
 | idx_oauth_accounts_user_id | CREATE INDEX idx_oauth_accounts_user_id ON public.oauth_accounts USING btree (user_id) |
 
 ## Relations
@@ -39,6 +43,7 @@ erDiagram
   varchar_32_ provider ""
   varchar_255_ provider_uid ""
   timestamp_with_time_zone created_at ""
+  timestamp_with_time_zone updated_at ""
 }
 "public.users" {
   bigint id ""

--- a/docs/schema/public.symbols.md
+++ b/docs/schema/public.symbols.md
@@ -32,6 +32,7 @@
 | Name | Definition |
 | ---- | ---------- |
 | symbols_pkey | CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (code) |
+| idx_symbols_active | CREATE INDEX idx_symbols_active ON public.symbols USING btree (code) WHERE is_active |
 
 ## Relations
 

--- a/docs/schema/public.users.md
+++ b/docs/schema/public.users.md
@@ -47,6 +47,7 @@ erDiagram
   varchar_32_ provider ""
   varchar_255_ provider_uid ""
   timestamp_with_time_zone created_at ""
+  timestamp_with_time_zone updated_at ""
 }
 "public.watchlists" {
   bigint id ""

--- a/docs/schema/schema.json
+++ b/docs/schema/schema.json
@@ -129,6 +129,12 @@
           "type": "timestamp with time zone",
           "nullable": false,
           "default": "now()"
+        },
+        {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "nullable": false,
+          "default": "now()"
         }
       ],
       "indexes": [
@@ -139,6 +145,15 @@
           "columns": [
             "provider",
             "provider_uid"
+          ]
+        },
+        {
+          "name": "uq_oauth_accounts_user_provider",
+          "def": "CREATE UNIQUE INDEX uq_oauth_accounts_user_provider ON public.oauth_accounts USING btree (user_id, provider)",
+          "table": "public.oauth_accounts",
+          "columns": [
+            "user_id",
+            "provider"
           ]
         },
         {
@@ -182,6 +197,16 @@
           ]
         },
         {
+          "name": "oauth_accounts_updated_at_not_null",
+          "type": "n",
+          "def": "NOT NULL updated_at",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "updated_at"
+          ]
+        },
+        {
           "name": "oauth_accounts_user_id_not_null",
           "type": "n",
           "def": "NOT NULL user_id",
@@ -213,6 +238,17 @@
           "columns": [
             "provider",
             "provider_uid"
+          ]
+        },
+        {
+          "name": "uq_oauth_accounts_user_provider",
+          "type": "UNIQUE",
+          "def": "UNIQUE (user_id, provider)",
+          "table": "public.oauth_accounts",
+          "referenced_table": "",
+          "columns": [
+            "user_id",
+            "provider"
           ]
         }
       ]
@@ -274,6 +310,14 @@
         {
           "name": "symbols_pkey",
           "def": "CREATE UNIQUE INDEX symbols_pkey ON public.symbols USING btree (code)",
+          "table": "public.symbols",
+          "columns": [
+            "code"
+          ]
+        },
+        {
+          "name": "idx_symbols_active",
+          "def": "CREATE INDEX idx_symbols_active ON public.symbols USING btree (code) WHERE is_active",
           "table": "public.symbols",
           "columns": [
             "code"

--- a/internal/feature/auth/oauth_account.go
+++ b/internal/feature/auth/oauth_account.go
@@ -16,4 +16,5 @@ type OAuthAccount struct {
 	ProviderUID string
 
 	CreatedAt time.Time
+	UpdatedAt time.Time
 }

--- a/internal/feature/auth/sqlc/models.go
+++ b/internal/feature/auth/sqlc/models.go
@@ -25,6 +25,7 @@ type OauthAccount struct {
 	Provider    string
 	ProviderUid string
 	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type Symbol struct {

--- a/internal/feature/auth/sqlc/queries.sql
+++ b/internal/feature/auth/sqlc/queries.sql
@@ -18,10 +18,10 @@ LIMIT 1;
 -- name: CreateOAuthAccount :one
 INSERT INTO oauth_accounts (user_id, provider, provider_uid)
 VALUES ($1, $2, $3)
-RETURNING user_id, provider, provider_uid, created_at;
+RETURNING user_id, provider, provider_uid, created_at, updated_at;
 
 -- name: FindOAuthAccountByProvider :one
-SELECT user_id, provider, provider_uid, created_at
+SELECT user_id, provider, provider_uid, created_at, updated_at
 FROM oauth_accounts
 WHERE provider = $1 AND provider_uid = $2
 LIMIT 1;

--- a/internal/feature/auth/sqlc/queries.sql.go
+++ b/internal/feature/auth/sqlc/queries.sql.go
@@ -13,7 +13,7 @@ import (
 const createOAuthAccount = `-- name: CreateOAuthAccount :one
 INSERT INTO oauth_accounts (user_id, provider, provider_uid)
 VALUES ($1, $2, $3)
-RETURNING user_id, provider, provider_uid, created_at
+RETURNING user_id, provider, provider_uid, created_at, updated_at
 `
 
 type CreateOAuthAccountParams struct {
@@ -30,6 +30,7 @@ func (q *Queries) CreateOAuthAccount(ctx context.Context, arg CreateOAuthAccount
 		&i.Provider,
 		&i.ProviderUid,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }
@@ -59,7 +60,7 @@ func (q *Queries) CreateUser(ctx context.Context, arg CreateUserParams) (User, e
 }
 
 const findOAuthAccountByProvider = `-- name: FindOAuthAccountByProvider :one
-SELECT user_id, provider, provider_uid, created_at
+SELECT user_id, provider, provider_uid, created_at, updated_at
 FROM oauth_accounts
 WHERE provider = $1 AND provider_uid = $2
 LIMIT 1
@@ -78,6 +79,7 @@ func (q *Queries) FindOAuthAccountByProvider(ctx context.Context, arg FindOAuthA
 		&i.Provider,
 		&i.ProviderUid,
 		&i.CreatedAt,
+		&i.UpdatedAt,
 	)
 	return i, err
 }

--- a/internal/feature/auth/user_repository.go
+++ b/internal/feature/auth/user_repository.go
@@ -142,6 +142,7 @@ func oauthAccountFromSQLC(m authsqlc.OauthAccount) OAuthAccount {
 		Provider:    m.Provider,
 		ProviderUID: m.ProviderUid,
 		CreatedAt:   m.CreatedAt,
+		UpdatedAt:   m.UpdatedAt,
 	}
 }
 

--- a/internal/feature/candles/sqlc/models.go
+++ b/internal/feature/candles/sqlc/models.go
@@ -25,6 +25,7 @@ type OauthAccount struct {
 	Provider    string
 	ProviderUid string
 	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type Symbol struct {

--- a/internal/feature/symbollist/sqlc/models.go
+++ b/internal/feature/symbollist/sqlc/models.go
@@ -25,6 +25,7 @@ type OauthAccount struct {
 	Provider    string
 	ProviderUid string
 	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type Symbol struct {

--- a/internal/feature/watchlist/sqlc/models.go
+++ b/internal/feature/watchlist/sqlc/models.go
@@ -25,6 +25,7 @@ type OauthAccount struct {
 	Provider    string
 	ProviderUid string
 	CreatedAt   time.Time
+	UpdatedAt   time.Time
 }
 
 type Symbol struct {


### PR DESCRIPTION
## 概要
DBテーブルレビューで指摘された軽微な改善点3件（oauth_accountsの重複防止制約不足、updated_at列の欠如、symbolsの検索用インデックス不足）を修正しました。

## 変更内容
- `oauth_accounts` に `UNIQUE(user_id, provider)` 制約を追加（将来、同一ユーザーが同一プロバイダーを複数リンクする実装が入っても重複を防げるようにする予防的な制約）
- `oauth_accounts` に `updated_at` 列を追加（users/symbols/watchlistsと同様のカラム構成に統一。現時点で更新処理は未実装）
- `symbols.is_active` に対する部分インデックス `idx_symbols_active` を追加（`ListActiveSymbols` クエリの検索効率向上）
- 上記スキーマ変更に伴い、authのsqlcクエリ・ドメインモデル・repositoryに `UpdatedAt` を反映し、`go tool sqlc generate` で関連パッケージを再生成
- `tbls doc` でスキーマドキュメント（`docs/schema/`）を再生成

本番未デプロイのスキーマのため、新規マイグレーションファイルは作らず既存の `db/migrations/00001_init_schema.sql` に直接反映しています。

## テスト
- `go build ./...`
- `go test ./... -race`（全パッケージ）
- `golangci-lint run --timeout=5m`
- `go tool goose down` → `up` を2周し、マイグレーションの可逆性を確認
- `tbls diff --config docs/tbls.yml` で差分なしを確認（CIのschema-doc-checkと同等）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>