### PR TITLE
test: symbollistのテストを米国株データに変更し検証力の低いケースを整理

### DIFF
--- a/internal/feature/symbollist/repository_test.go
+++ b/internal/feature/symbollist/repository_test.go
@@ -32,7 +32,7 @@ func seedSymbol(t *testing.T, db *sql.DB, code, name, market string, isActive bo
 	t.Helper()
 	row := db.QueryRowContext(context.Background(),
 		`INSERT INTO symbols (code, name, market, timezone, is_active)
-		 VALUES ($1, $2, $3, 'Asia/Tokyo', $4)
+		 VALUES ($1, $2, $3, 'America/New_York', $4)
 		 RETURNING created_at, updated_at`,
 		code, name, market, isActive,
 	)
@@ -40,7 +40,7 @@ func seedSymbol(t *testing.T, db *sql.DB, code, name, market string, isActive bo
 		Code:     code,
 		Name:     name,
 		Market:   market,
-		Timezone: "Asia/Tokyo",
+		Timezone: "America/New_York",
 		IsActive: isActive,
 	}
 	require.NoError(t, row.Scan(&s.CreatedAt, &s.UpdatedAt), "failed to seed symbol")
@@ -95,23 +95,23 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 		{
 			name: "success: returns active symbols sorted by code",
 			setupFunc: func(t *testing.T, db *sql.DB) {
-				seedSymbol(t, db, "9984.T", "SoftBank Group", "TSE", true)
-				seedSymbol(t, db, "6758.T", "Sony Group", "TSE", true)
-				seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
+				seedSymbol(t, db, "NVDA", "NVIDIA Corporation", "NASDAQ", true)
+				seedSymbol(t, db, "AAPL", "Apple Inc.", "NASDAQ", true)
+				seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 			},
 			expectedCount: 3,
-			expectedCodes: []string{"6758.T", "7203.T", "9984.T"},
+			expectedCodes: []string{"AAPL", "MSFT", "NVDA"},
 		},
 		{
 			name: "success: excludes inactive symbols",
 			setupFunc: func(t *testing.T, db *sql.DB) {
-				seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
-				inactive := seedSymbol(t, db, "6758.T", "Sony Group", "TSE", true)
+				seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
+				inactive := seedSymbol(t, db, "AAPL", "Apple Inc.", "NASDAQ", true)
 				updateSymbolActive(t, db, inactive, false)
-				seedSymbol(t, db, "9984.T", "SoftBank Group", "TSE", true)
+				seedSymbol(t, db, "NVDA", "NVIDIA Corporation", "NASDAQ", true)
 			},
 			expectedCount: 2,
-			expectedCodes: []string{"7203.T", "9984.T"},
+			expectedCodes: []string{"MSFT", "NVDA"},
 		},
 		{
 			name:          "success: returns empty list when no symbols",
@@ -122,9 +122,9 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 		{
 			name: "success: returns empty list when all symbols are inactive",
 			setupFunc: func(t *testing.T, db *sql.DB) {
-				s1 := seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
+				s1 := seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 				updateSymbolActive(t, db, s1, false)
-				s2 := seedSymbol(t, db, "6758.T", "Sony Group", "TSE", true)
+				s2 := seedSymbol(t, db, "AAPL", "Apple Inc.", "NASDAQ", true)
 				updateSymbolActive(t, db, s2, false)
 			},
 			expectedCount: 0,
@@ -133,10 +133,10 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 		{
 			name: "success: returns single active symbol",
 			setupFunc: func(t *testing.T, db *sql.DB) {
-				seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
+				seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 			},
 			expectedCount: 1,
-			expectedCodes: []string{"7203.T"},
+			expectedCodes: []string{"MSFT"},
 		},
 	}
 
@@ -163,16 +163,16 @@ func TestSymbolRepository_ListActive_FieldValues(t *testing.T) {
 	db := setupTestDB(t)
 	repo := NewRepository(db)
 
-	seedSymbol(t, db, "7203.T", "Toyota Motor Corporation", "Tokyo Stock Exchange", true)
+	seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 	symbols, err := repo.ListActive(context.Background())
 	require.NoError(t, err)
 	require.Len(t, symbols, 1)
 
 	got := symbols[0]
-	assert.Equal(t, "7203.T", got.Code)
-	assert.Equal(t, "Toyota Motor Corporation", got.Name)
-	assert.Equal(t, "Tokyo Stock Exchange", got.Market)
-	assert.Equal(t, "Asia/Tokyo", got.Timezone)
+	assert.Equal(t, "MSFT", got.Code)
+	assert.Equal(t, "Microsoft Corporation", got.Name)
+	assert.Equal(t, "NASDAQ", got.Market)
+	assert.Equal(t, "America/New_York", got.Timezone)
 	assert.Nil(t, got.LogoURL)
 	assert.Nil(t, got.LogoUpdatedAt)
 	assert.True(t, got.IsActive)
@@ -285,7 +285,7 @@ func TestSymbolRepository_ContextCancellation(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)
 	repo := NewRepository(db)
-	seedSymbol(t, db, "7203.T", "Toyota Motor", "TSE", true)
+	seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/feature/symbollist/repository_test.go
+++ b/internal/feature/symbollist/repository_test.go
@@ -75,21 +75,12 @@ func updateSymbolActive(t *testing.T, db *sql.DB, symbol *Symbol, isActive bool)
 	require.NoError(t, err, "failed to update symbol active status")
 }
 
-func TestNewSymbolRepository(t *testing.T) {
-	t.Parallel()
-	db := setupTestDB(t)
-	repo := NewRepository(db)
-	assert.NotNil(t, repo)
-	assert.NotNil(t, repo.db)
-}
-
 func TestSymbolRepository_ListActive(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name          string
 		setupFunc     func(t *testing.T, db *sql.DB)
-		expectedCount int
 		expectedCodes []string
 	}{
 		{
@@ -99,7 +90,6 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 				seedSymbol(t, db, "AAPL", "Apple Inc.", "NASDAQ", true)
 				seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 			},
-			expectedCount: 3,
 			expectedCodes: []string{"AAPL", "MSFT", "NVDA"},
 		},
 		{
@@ -110,13 +100,11 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 				updateSymbolActive(t, db, inactive, false)
 				seedSymbol(t, db, "NVDA", "NVIDIA Corporation", "NASDAQ", true)
 			},
-			expectedCount: 2,
 			expectedCodes: []string{"MSFT", "NVDA"},
 		},
 		{
 			name:          "success: returns empty list when no symbols",
 			setupFunc:     func(t *testing.T, db *sql.DB) {},
-			expectedCount: 0,
 			expectedCodes: []string{},
 		},
 		{
@@ -127,7 +115,6 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 				s2 := seedSymbol(t, db, "AAPL", "Apple Inc.", "NASDAQ", true)
 				updateSymbolActive(t, db, s2, false)
 			},
-			expectedCount: 0,
 			expectedCodes: []string{},
 		},
 		{
@@ -135,7 +122,6 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 			setupFunc: func(t *testing.T, db *sql.DB) {
 				seedSymbol(t, db, "MSFT", "Microsoft Corporation", "NASDAQ", true)
 			},
-			expectedCount: 1,
 			expectedCodes: []string{"MSFT"},
 		},
 	}
@@ -150,10 +136,11 @@ func TestSymbolRepository_ListActive(t *testing.T) {
 			}
 			symbols, err := repo.ListActive(context.Background())
 			require.NoError(t, err)
-			assert.Len(t, symbols, tt.expectedCount)
-			for i, expectedCode := range tt.expectedCodes {
-				assert.Equal(t, expectedCode, symbols[i].Code)
+			gotCodes := make([]string, 0, len(symbols))
+			for _, s := range symbols {
+				gotCodes = append(gotCodes, s.Code)
 			}
+			assert.Equal(t, tt.expectedCodes, gotCodes)
 		})
 	}
 }
@@ -290,7 +277,6 @@ func TestSymbolRepository_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err := repo.ListActive(ctx)
-	if err != nil {
-		assert.ErrorIs(t, err, context.Canceled)
-	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
 }

--- a/internal/feature/symbollist/symbollisthttp/handler_test.go
+++ b/internal/feature/symbollist/symbollisthttp/handler_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/symbollist/symbollisthttp"
 )
 
-func strPtr(s string) *string {
-	return &s
-}
-
 // mockUsecase はUsecaseインターフェースのモック実装です。
 type mockUsecase struct {
 	ListActiveSymbolsFunc func(ctx context.Context) ([]symbollist.Symbol, error)
@@ -30,18 +26,10 @@ func (m *mockUsecase) ListActiveSymbols(ctx context.Context) ([]symbollist.Symbo
 	return nil, nil
 }
 
-// TestNewSymbolHandler はNewHandlerコンストラクタが正しくインスタンスを生成することを検証します。
-func TestNewSymbolHandler(t *testing.T) {
-	t.Parallel()
-
-	mockUC := &mockUsecase{}
-	h := symbollisthttp.NewHandler(mockUC)
-
-	assert.NotNil(t, h, "handler should not be nil")
-}
-
 // TestSymbolHandler_List はListハンドラーの各種シナリオをテーブル駆動テストで検証します。
 func TestSymbolHandler_List(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name               string
 		mockListActiveFunc func(ctx context.Context) ([]symbollist.Symbol, error)
@@ -49,15 +37,16 @@ func TestSymbolHandler_List(t *testing.T) {
 		expectedBody       string
 	}{
 		{
+			// expectedBodyとの完全一致検証により、内部フィールド（Market, IsActive）が公開されないことも担保する
 			name: "success: returns list of symbols",
 			mockListActiveFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{Code: "7203.T", Name: "Toyota Motor", Market: "TSE", LogoURL: strPtr("https://api.twelvedata.com/logo/toyota.com"), IsActive: true},
-					{Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
+					{Code: "AAPL", Name: "Apple Inc.", Market: "NASDAQ", LogoURL: new("https://api.twelvedata.com/logo/apple.com"), IsActive: true},
+					{Code: "MSFT", Name: "Microsoft Corporation", Market: "NASDAQ", IsActive: true},
 				}, nil
 			},
 			expectedStatus: http.StatusOK,
-			expectedBody:   `[{"code":"7203.T","name":"Toyota Motor","logo_url":"https://api.twelvedata.com/logo/toyota.com"},{"code":"6758.T","name":"Sony Group","logo_url":null}]`,
+			expectedBody:   `[{"code":"AAPL","name":"Apple Inc.","logo_url":"https://api.twelvedata.com/logo/apple.com"},{"code":"MSFT","name":"Microsoft Corporation","logo_url":null}]`,
 		},
 		{
 			name: "success: returns empty list when no symbols",
@@ -71,14 +60,14 @@ func TestSymbolHandler_List(t *testing.T) {
 			name: "success: returns single symbol",
 			mockListActiveFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
+					{Code: "NVDA", Name: "NVIDIA Corporation", Market: "NASDAQ", IsActive: true},
 				}, nil
 			},
 			expectedStatus: http.StatusOK,
-			expectedBody:   `[{"code":"9984.T","name":"SoftBank Group","logo_url":null}]`,
+			expectedBody:   `[{"code":"NVDA","name":"NVIDIA Corporation","logo_url":null}]`,
 		},
 		{
-			name: "failure: usecase returns error",
+			name: "error: usecase returns error",
 			mockListActiveFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return nil, errors.New("database connection failed")
 			},
@@ -113,37 +102,4 @@ func TestSymbolHandler_List(t *testing.T) {
 			assert.JSONEq(t, tt.expectedBody, w.Body.String())
 		})
 	}
-}
-
-// TestSymbolHandler_List_DTOConversion はレスポンスに公開DTOフィールドのみが含まれ、内部フィールドが公開されないことを検証します。
-func TestSymbolHandler_List_DTOConversion(t *testing.T) {
-	t.Parallel()
-
-	// レスポンスに公開DTOフィールドのみが含まれることを検証（Market、IsActiveは含まれない）
-	mockUC := &mockUsecase{
-		ListActiveSymbolsFunc: func(ctx context.Context) ([]symbollist.Symbol, error) {
-			return []symbollist.Symbol{
-				{
-					Code:     "TEST.T",
-					Name:     "Test Company",
-					Market:   "NYSE",
-					LogoURL:  strPtr("https://api.twelvedata.com/logo/test.com"),
-					IsActive: true,
-				},
-			}, nil
-		},
-	}
-	h := symbollisthttp.NewHandler(mockUC)
-
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/symbols", nil)
-
-	h.List(w, req)
-
-	assert.Equal(t, http.StatusOK, w.Code)
-	assert.JSONEq(t, `[{"code":"TEST.T","name":"Test Company","logo_url":"https://api.twelvedata.com/logo/test.com"}]`, w.Body.String())
-	// 内部フィールドが公開されていないことを検証
-	assert.NotContains(t, w.Body.String(), "NYSE")
-	assert.NotContains(t, w.Body.String(), "is_active")
-	assert.NotContains(t, w.Body.String(), "sort_key")
 }

--- a/internal/feature/symbollist/usecase_test.go
+++ b/internal/feature/symbollist/usecase_test.go
@@ -48,13 +48,13 @@ func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 			name: "success: returns list of active symbols",
 			mockListActive: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
-					{Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
+					{Code: "AAPL", Name: "Apple Inc.", Market: "NASDAQ", IsActive: true},
+					{Code: "MSFT", Name: "Microsoft Corporation", Market: "NASDAQ", IsActive: true},
 				}, nil
 			},
 			expectedSymbols: []symbollist.Symbol{
-				{Code: "7203.T", Name: "Toyota Motor", Market: "TSE", IsActive: true},
-				{Code: "6758.T", Name: "Sony Group", Market: "TSE", IsActive: true},
+				{Code: "AAPL", Name: "Apple Inc.", Market: "NASDAQ", IsActive: true},
+				{Code: "MSFT", Name: "Microsoft Corporation", Market: "NASDAQ", IsActive: true},
 			},
 			wantErr: false,
 		},
@@ -87,11 +87,11 @@ func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 			name: "success: returns single symbol",
 			mockListActive: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return []symbollist.Symbol{
-					{Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
+					{Code: "NVDA", Name: "NVIDIA Corporation", Market: "NASDAQ", IsActive: true},
 				}, nil
 			},
 			expectedSymbols: []symbollist.Symbol{
-				{Code: "9984.T", Name: "SoftBank Group", Market: "TSE", IsActive: true},
+				{Code: "NVDA", Name: "NVIDIA Corporation", Market: "NASDAQ", IsActive: true},
 			},
 			wantErr: false,
 		},

--- a/internal/feature/symbollist/usecase_test.go
+++ b/internal/feature/symbollist/usecase_test.go
@@ -23,16 +23,6 @@ func (m *mockRepository) ListActive(ctx context.Context) ([]symbollist.Symbol, e
 	return nil, nil
 }
 
-// TestNewSymbolUsecase はNewUsecaseコンストラクタが正しくインスタンスを生成することを検証します。
-func TestNewSymbolUsecase(t *testing.T) {
-	t.Parallel()
-
-	mockRepo := &mockRepository{}
-	uc := symbollist.NewUsecase(mockRepo)
-
-	assert.NotNil(t, uc, "usecase should not be nil")
-}
-
 // TestSymbolUsecase_ListActiveSymbols はListActiveSymbolsメソッドの各種シナリオをテーブル駆動テストで検証します。
 func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 	t.Parallel()
@@ -75,25 +65,13 @@ func TestSymbolUsecase_ListActiveSymbols(t *testing.T) {
 			wantErr:         false,
 		},
 		{
-			name: "failure: repository returns error",
+			name: "error: repository returns error",
 			mockListActive: func(ctx context.Context) ([]symbollist.Symbol, error) {
 				return nil, errors.New("database connection failed")
 			},
 			expectedSymbols: nil,
 			wantErr:         true,
 			errMsg:          "database connection failed",
-		},
-		{
-			name: "success: returns single symbol",
-			mockListActive: func(ctx context.Context) ([]symbollist.Symbol, error) {
-				return []symbollist.Symbol{
-					{Code: "NVDA", Name: "NVIDIA Corporation", Market: "NASDAQ", IsActive: true},
-				}, nil
-			},
-			expectedSymbols: []symbollist.Symbol{
-				{Code: "NVDA", Name: "NVIDIA Corporation", Market: "NASDAQ", IsActive: true},
-			},
-			wantErr: false,
 		},
 	}
 


### PR DESCRIPTION
## 概要
symbollistフィーチャーのテストデータが日本株（TSE銘柄）のままだったため、実際に扱う米国株（NASDAQ銘柄）に置き換えた。あわせてレビューで見つかった検証力のないテストケース・重複ケースを整理した。

## 変更内容
- handler/usecase/repositoryテストの銘柄をAAPL/MSFT/NVDA（NASDAQ）に置き換え（コードの辞書順を維持しソート検証の構造は不変）
- `seedSymbol` のタイムゾーンを `Asia/Tokyo` から `America/New_York` に変更
- handlerテスト: 検証力のない `TestNewSymbolHandler` と、正常系ケースと重複する `TestSymbolHandler_List_DTOConversion` を削除。関数レベルの `t.Parallel()` を追加、ケース名プレフィックスを `error:` に統一
- usecaseテスト: 検証力のない `TestNewSymbolUsecase` を削除、正常系と重複するケースを削除、ケース名プレフィックスを `error:` に統一
- repositoryテスト: 検証力のない `TestNewSymbolRepository` を削除
- repositoryテスト: `TestSymbolRepository_ContextCancellation` の `if err != nil` 分岐を外し、エラーが返らない場合にテストが確実に失敗するよう修正
- repositoryテスト: `TestSymbolRepository_ListActive` の冗長な `expectedCount` フィールドを削除し、実際のコード列を比較する形に変更（件数不一致時のindex out of range panicも回避）

## テスト
- `go test ./internal/feature/symbollist/... -race -cover`（全パス、カバレッジ低下なし）
- `golangci-lint run internal/feature/symbollist/... --timeout=5m`（0 issues）