### PR TITLE
chore: Goを1.26.4から1.26.5に更新

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.5"
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.5"
 
       - name: Run go-arch-lint
         run: go tool go-arch-lint check
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.5"
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -139,7 +139,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.5"
 
       - name: Run build
         run: go build ./...
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.26.x"
+          go-version: "1.26.5"
 
       - name: Run migrations
         env:

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/docker/Dockerfile.api.dev
+++ b/docker/Dockerfile.api.dev
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 WORKDIR /app
 

--- a/docker/Dockerfile.batch
+++ b/docker/Dockerfile.batch
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download

--- a/docker/Dockerfile.migrate
+++ b/docker/Dockerfile.migrate
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/UCHIDAnobuhiro/stock-backend
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/vision/v2 v2.14.0


### PR DESCRIPTION
## 概要
govulncheckが検出したGo標準ライブラリ`crypto/tls`の脆弱性（GO-2026-5856、Encrypted Client Hello利用時のプライバシー漏洩）を解消するため、Goのバージョンを1.26.4から1.26.5に更新した。

## 変更内容
- `go.mod` の `go` ディレクティブを1.26.5に更新
- `docker/Dockerfile.api` / `Dockerfile.api.dev` / `Dockerfile.batch` / `Dockerfile.migrate` のベースイメージを `golang:1.26.5-alpine` に更新

## 関連issue
- #287 のCI（Vulnerability Scan）が本更新前のGo 1.26.4に起因して失敗していたため、その解消を目的とする

## テスト
- `go build ./...`（成功）
- `go test ./... -race`（全パス）
- `govulncheck ./...`（GO-2026-5856解消、"No vulnerabilities found"を確認）
- `golangci-lint run --timeout=5m`（0 issues）
- `go tool go-arch-lint check`（No warnings found）