### PR TITLE
chore: Dependabotのスケジュールを週次から毎日に変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,18 @@
 # Dependabot 設定。
-# Go モジュールと GitHub Actions の依存を週次でチェックし、更新 PR を自動作成する。
+# Go モジュールと GitHub Actions の依存を毎日チェックし、更新 PR を自動作成する。
 # セキュリティアドバイザリ該当の更新はスケジュールに関係なく即時 PR が作成される。
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 999
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 999


### PR DESCRIPTION
## 概要
Dependabotによる依存関係チェックの頻度を週次から毎日に変更し、同時に開けるPR数の上限も緩和する。

## 変更内容
- gomod / github-actions 両エコシステムの `schedule.interval` を `weekly` から `daily` に変更
- 週次専用の `day: monday` 設定を削除
- `open-pull-requests-limit` を `5` から `999` に変更（実質上限なし）

## テスト
- 設定ファイルの変更のみのため、YAML構文の目視確認を実施