### PR TITLE
fix(candles): UpsertBatchのキャッシュ競合で古いデータが最大7日残る問題を修正

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -90,7 +90,8 @@ func run() int {
 	candleRepo := candles.NewRepository(sqlDB)
 	watchlistRepo := watchlist.NewRepository(sqlDB)
 
-	// Redisキャッシュでラップ（TTLはingest連続失敗時のセーフティネット、通常は日次ingestで上書き）
+	// Redisキャッシュでラップ（ingestのUpsertBatchは対象キーをDELするのみで、再構築は
+	// 次回Findのcache-miss時に行われる。TTLはDEL失敗時や競合による汚染時のセーフティネット）
 	cachedCandleRepo := candles.NewCachingRepository(rdb, candles.DefaultCacheTTL, candleRepo, "candles")
 
 	// JWTジェネレータ・ブラックリスト（ログアウト時の即時失効用）

--- a/docs/features/candles.md
+++ b/docs/features/candles.md
@@ -44,7 +44,7 @@ sequenceDiagram
             Repository->>DB: SELECT * FROM candles WHERE symbol_code=? AND interval=? ORDER BY time DESC LIMIT ?
             DB-->>Repository: Rows
             Repository-->>Cache: []Candle
-            Cache->>Redis: SET candles:AAPL:1day (TTL)
+            Cache->>Redis: SET NX candles:AAPL:1day (TTL)
             Cache-->>Usecase: []Candle
         end
     else Redis Unavailable
@@ -516,7 +516,7 @@ go test ./internal/feature/candles/... -v -race -cover
 | 設定 | 値 | 説明 |
 |------|-----|------|
 | キー形式 | `candles:{symbol}:{interval}` | symbol+interval単位でキャッシュ（全データ最大5000件を保存） |
-| 本番TTL | 7日 | `candles.DefaultCacheTTL`。ingest連続失敗時のセーフティネット、通常は日次ingestで上書き |
+| 本番TTL | 24時間 | `candles.DefaultCacheTTL`。DEL失敗時や競合による汚染時に古いキャッシュが残り続けないためのセーフティネット |
 | デフォルトTTL | 5分 | コンストラクタにttl=0を渡した場合のフォールバック |
 | 名前空間 | `candles` | 分離のためのキープレフィックス |
 
@@ -525,13 +525,15 @@ go test ./internal/feature/candles/... -v -race -cover
 1. **読み取りパス（Find）**
    - Redisのキャッシュデータを確認
    - ヒット時: デシリアライズしたデータを返却
-   - ミス時: PostgreSQLにクエリ、結果をキャッシュして返却
+   - ミス時: PostgreSQLにクエリし、`SET NX`（キーが存在しない場合のみ書き込み、TTL 24h）でキャッシュしてから返却
    - Redisエラー時: キャッシュをバイパスし、PostgreSQLに直接クエリ
 
 2. **書き込みパス（UpsertBatch）**
    - まずPostgreSQLに書き込み
-   - 影響を受ける symbol+interval のキャッシュキーを削除（`DEL candles:{symbol}:{interval}`）
-   - 削除後、最新データで再生成（ウォームアップ、ベストエフォート）
+   - 影響を受ける symbol+interval のキャッシュキーを削除するのみ（`DEL candles:{symbol}:{interval}`、ウォームアップなし）
+   - 再構築は行わず、次回Findのcache-miss経路に委ねる（ingestバッチとAPIサーバーは別インスタンスで動作するため、
+     UpsertBatch直後にウォームアップすると、他インスタンスのFindが読んだ古いDBデータで上書きされる競合が
+     起こり得る。「書くのは読み手だけ、消すのは書き手だけ」の原則により、この競合を回避している）
 
 ### グレースフルデグレード
 

--- a/internal/app/batch/candles.go
+++ b/internal/app/batch/candles.go
@@ -34,10 +34,10 @@ func runCandleIngest(cfg *config.Config) int {
 	ingestSymbolRepo := di.NewIngestSymbolAdapter(symbolRepo)
 	rateLimiter := clientratelimit.NewRateLimiter(rateLimitPerMinute, time.Minute)
 
-	// Redis接続（ベストエフォート: 接続失敗時はキャッシュウォームアップなしで続行）
+	// Redis接続（ベストエフォート: 接続失敗時はキャッシュ削除なしで続行）
 	var rdb *redisv9.Client
 	if tmp, err := infraredis.NewRedisClient(cfg.Redis.Host, cfg.Redis.Port, cfg.Redis.Password); err != nil {
-		slog.Warn("Redis unavailable, cache warm-up disabled", "error", err)
+		slog.Warn("Redis unavailable, cache invalidation disabled", "error", err)
 	} else {
 		rdb = tmp
 		defer func() {
@@ -47,7 +47,8 @@ func runCandleIngest(cfg *config.Config) int {
 		}()
 	}
 
-	// TTLはingest連続失敗時のセーフティネット、通常は UpsertBatch で日次上書き
+	// UpsertBatchは対象キーのキャッシュをDELするのみで、再構築は次回Findのcache-miss時に行われる。
+	// TTLはDEL失敗時や競合による汚染時に古いキャッシュが残り続けないためのセーフティネット。
 	cachedCandleRepo := candles.NewCachingRepository(rdb, candles.DefaultCacheTTL, candleRepo, "candles")
 
 	uc := candles.NewIngestUsecase(marketRepo, cachedCandleRepo, ingestSymbolRepo, rateLimiter)

--- a/internal/feature/candles/caching_repository.go
+++ b/internal/feature/candles/caching_repository.go
@@ -10,10 +10,11 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-// DefaultCacheTTL はingestの連続失敗時に古いデータが残り続けないためのセーフティネットTTL。
-// 通常運用ではingestのUpsertBatchによりキャッシュが日次で上書きされるため、
-// この値はフォールバックとしてのみ機能する。
-const DefaultCacheTTL = 7 * 24 * time.Hour
+// DefaultCacheTTL はキャッシュが汚染された場合やDEL失敗時に、古いデータが
+// 残り続けないためのセーフティネットTTL。通常運用ではingestのUpsertBatchが
+// 対象キーをDELし、次回Find時のcache-miss経路でキャッシュが再構築されるため、
+// このTTLはあくまでフォールバックとしてのみ機能する。
+const DefaultCacheTTL = 24 * time.Hour
 
 // readWriteRepository はCachingRepositoryが内部で必要とする読み書きインターフェースです。
 type readWriteRepository interface {
@@ -47,7 +48,14 @@ func NewCachingRepository(rdb *redis.Client, ttl time.Duration, inner readWriteR
 	}
 }
 
-// UpsertBatch はローソク足データを挿入または更新し、キャッシュを最新データで更新します。
+// UpsertBatch はローソク足データを挿入または更新し、対象キーのキャッシュを削除します。
+// ここでは削除のみを行い、キャッシュの再構築は行いません（ウォームアップの廃止）。
+//
+// ingestバッチとAPIサーバーは別インスタンスで動作するため、UpsertBatch完了直後に
+// inner.Findでウォームアップすると、他インスタンス上のFindが本コミット前の古いDBデータを
+// 読み取り、その古いデータでキャッシュをSETし直してウォームアップ結果を上書きしてしまう
+// 競合が起こり得る（「書くのは読み手だけ、消すのは書き手だけ」の原則）。
+// 再構築は次回Findのcache-miss経路に一本化し、書き込みはSetNXでベストエフォートに行う。
 func (c *CachingRepository) UpsertBatch(ctx context.Context, candles []Candle) error {
 	// まず基盤リポジトリにUpsert
 	if err := c.inner.UpsertBatch(ctx, candles); err != nil {
@@ -68,18 +76,10 @@ func (c *CachingRepository) UpsertBatch(ctx context.Context, candles []Candle) e
 		seen[symbolInterval{cd.SymbolCode, cd.Interval}] = struct{}{}
 	}
 
-	// 各 symbol+interval のキャッシュを削除し、最新データで再生成（ウォームアップ）
+	// 各 symbol+interval のキャッシュを削除するのみ（再構築は次回Findに委ねる）
 	for si := range seen {
 		key := c.cacheKey(si.symbol, si.interval)
 		_ = c.rdb.Del(ctx, key).Err() // ベストエフォート
-
-		data, err := c.inner.Find(ctx, si.symbol, si.interval, MaxOutputSize)
-		if err != nil {
-			continue // ベストエフォート: エラー時はウォームアップをスキップ
-		}
-		if b, err := json.Marshal(data); err == nil {
-			_ = c.rdb.Set(ctx, key, b, c.ttl).Err() // ベストエフォート
-		}
 	}
 	return nil
 }
@@ -111,8 +111,11 @@ func (c *CachingRepository) Find(ctx context.Context, symbol, interval string, o
 	}
 
 	// 3) キャッシュに保存（ベストエフォート）
+	// SetNX（SET key value EX <ttl> NX）を使い、キーが存在しない場合のみ書き込む。
+	// ingestのDELの直後に他インスタンスが新データで既にキャッシュを再構築している
+	// ケースで、本経路が読んだ（DEL前の）古いDBデータで上書きしてしまうのを防ぐ。
 	if b, err := json.Marshal(all); err == nil {
-		_ = c.rdb.Set(ctx, key, b, c.ttl).Err()
+		_ = c.rdb.SetNX(ctx, key, b, c.ttl).Err()
 	}
 
 	return sliceCandles(all, outputsize), nil

--- a/internal/feature/candles/caching_repository_test.go
+++ b/internal/feature/candles/caching_repository_test.go
@@ -196,8 +196,8 @@ func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 
 	// Cache miss
 	mock.ExpectGet("candles:AAPL:1day").RedisNil()
-	// Set cache after fetching from inner (全データで保存)
-	mock.ExpectSet("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal("OK")
+	// SetNXでキャッシュに保存（全データで保存）
+	mock.ExpectSetNX("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal(true)
 
 	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
@@ -266,8 +266,46 @@ func TestCachingCandleRepository_Find_CorruptedCache(t *testing.T) {
 	mock.ExpectGet("candles:AAPL:1day").SetVal("invalid json")
 	// Delete corrupted cache
 	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
-	// Set new cache after fetching from inner
-	mock.ExpectSet("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal("OK")
+	// SetNXで新しいキャッシュを保存
+	mock.ExpectSetNX("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal(true)
+
+	inner := &mockReadWriteRepository{
+		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
+			return expectedCandles, nil
+		},
+	}
+
+	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
+	candles, err := repo.Find(context.Background(), "AAPL", "1day", 100)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(candles) != 1 {
+		t.Errorf("expected 1 candle, got %d", len(candles))
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestCachingCandleRepository_Find_CacheMiss_SetNXLosesRace はcache-miss後のSetNXが
+// false（他インスタンスが既に新データを書き込み済み）を返しても、Findはエラーにならず
+// inner.Findから取得したデータをそのまま返すことを検証します。
+func TestCachingCandleRepository_Find_CacheMiss_SetNXLosesRace(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	expectedCandles := []Candle{
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+	}
+	expectedJSON, _ := json.Marshal(expectedCandles)
+
+	// Cache miss
+	mock.ExpectGet("candles:AAPL:1day").RedisNil()
+	// SetNXが false を返す（他インスタンスが先に書き込み済み = キーが既に存在）
+	mock.ExpectSetNX("candles:AAPL:1day", expectedJSON, 5*time.Minute).SetVal(false)
 
 	inner := &mockReadWriteRepository{
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
@@ -353,54 +391,14 @@ func TestCachingCandleRepository_UpsertBatch_EmptyCandles(t *testing.T) {
 	}
 }
 
-// TestCachingCandleRepository_UpsertBatch_CacheWarmUp はUpsertBatch後にキャッシュが削除され最新データで再生成されることを検証します。
-func TestCachingCandleRepository_UpsertBatch_CacheWarmUp(t *testing.T) {
+// TestCachingCandleRepository_UpsertBatch_InvalidatesCache はUpsertBatch後に
+// 対象キーのキャッシュが削除されるのみで、ウォームアップ（inner.Findの呼び出し）が
+// 行われないことを検証します（案A′: 再構築は次回Findのcache-miss経路に一本化）。
+func TestCachingCandleRepository_UpsertBatch_InvalidatesCache(t *testing.T) {
 	t.Parallel()
 
 	rdb, mock := redismock.NewClientMock()
 	defer func() { _ = rdb.Close() }()
-
-	warmCandles := []Candle{
-		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
-	}
-	warmJSON, _ := json.Marshal(warmCandles)
-
-	inner := &mockReadWriteRepository{
-		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
-			return nil
-		},
-		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
-			return warmCandles, nil
-		},
-	}
-
-	// 既存キャッシュを削除してから最新データで再生成
-	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
-	mock.ExpectSet("candles:AAPL:1day", warmJSON, 5*time.Minute).SetVal("OK")
-
-	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
-	err := repo.UpsertBatch(context.Background(), []Candle{
-		{SymbolCode: "AAPL", Interval: "1day"},
-	})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if err := mock.ExpectationsWereMet(); err != nil {
-		t.Errorf("unfulfilled mock expectations: %v", err)
-	}
-}
-
-// TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp は同一symbol+intervalのウォームアップが重複せず1回のみ実行されることを検証します。
-func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
-	t.Parallel()
-
-	rdb, mock := redismock.NewClientMock()
-	defer func() { _ = rdb.Close() }()
-
-	warmCandles := []Candle{
-		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0},
-	}
-	warmJSON, _ := json.Marshal(warmCandles)
 
 	findCallCount := 0
 	inner := &mockReadWriteRepository{
@@ -409,13 +407,45 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
 		},
 		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 			findCallCount++
-			return warmCandles, nil
+			return nil, nil
 		},
 	}
 
-	// AAPL:1day が3件あっても DEL と SET は1回ずつのみ
+	// 既存キャッシュを削除するのみ（SETは発行されない）
 	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
-	mock.ExpectSet("candles:AAPL:1day", warmJSON, 5*time.Minute).SetVal("OK")
+
+	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
+	err := repo.UpsertBatch(context.Background(), []Candle{
+		{SymbolCode: "AAPL", Interval: "1day"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if findCallCount != 0 {
+		t.Errorf("expected inner.Find not to be called (no warm-up), got %d calls", findCallCount)
+	}
+	// ExpectDel以外（Set等）が発行されていないことを担保
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestCachingCandleRepository_UpsertBatch_DeduplicatesDel は同一symbol+intervalの
+// キャッシュキーに対するDELが重複せず1回のみ実行されることを検証します。
+func TestCachingCandleRepository_UpsertBatch_DeduplicatesDel(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	inner := &mockReadWriteRepository{
+		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
+			return nil
+		},
+	}
+
+	// AAPL:1day が3件あっても DEL は1回のみ
+	mock.ExpectDel("candles:AAPL:1day").SetVal(1)
 
 	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
 	err := repo.UpsertBatch(context.Background(), []Candle{
@@ -425,9 +455,6 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesWarmUp(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if findCallCount != 1 {
-		t.Errorf("expected inner.Find to be called once, got %d", findCallCount)
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unfulfilled mock expectations: %v", err)


### PR DESCRIPTION
## 概要

Closes #265

ingestバッチとAPIサーバーが別インスタンス（別Cloud Runサービス）で動作する構成において、`CachingRepository.UpsertBatch` のキャッシュウォームアップ（DEL→Find→SET）とAPI側のcache-aside `Set` が競合し、コミット前の古いDBデータで新しいキャッシュが上書きされると最大7日間（`DefaultCacheTTL`）古いローソク足が返り続ける問題を修正します。

## 対応方針

「キャッシュを書くのは読み手だけ、消すのは書き手だけ」に役割を分離する設計に変更しました。

1. **ウォームアップ廃止**: `UpsertBatch` は対象 symbol×interval キーの `DEL` のみ行い、再構築は次回 `Find` のcache-miss経路に一本化。DELはDBコミット後のため、再構築は必ずコミット済みの最新データを読みます
2. **SetNX化**: `Find` のcache-miss時の書き込みを `SetNX`（`SET key value EX 86400 NX`）に変更。ingestのDEL後に他インスタンスが再構築した新データを、古いDB読み取り結果で上書きする経路を遮断します
3. **TTL短縮**: `DefaultCacheTTL` を7日→24時間に短縮。DEL直後に古いSetNXが先着する理論上の残存窓が発生しても、翌日のingestのDELまたはTTLで最大24時間で自然回復します

### 検討した代替案

- **バージョンチェック付きSet（CAS）**: 競合を理論上完全排除できるがLuaスクリプト等で実装・テストが重く、日次バッチの株価データには過剰と判断
- **singleflight**: 同一プロセス内でしか効かず、別インスタンス間の本競合を解決できないため不採用

## 変更内容

- `internal/feature/candles/caching_repository.go`: 上記1〜3の実装＋設計意図のコメント
- `internal/feature/candles/caching_repository_test.go`: ウォームアップ検証テストをDELのみの検証に書き換え、`ExpectSet`→`ExpectSetNX` 更新、SetNXがfalse（他インスタンスが先に書き込み済み）でも正常動作する回帰テストを追加
- `internal/app/batch/candles.go` / `cmd/api/main.go`: コメント・ログメッセージを新設計に更新
- `docs/features/candles.md`: キャッシュ設定表・キャッシュ動作・シーケンス図を更新

## 検証

- `go build ./...` ✅
- `go test ./... -race`（testcontainers含む全パッケージ）✅
- `golangci-lint run --timeout=5m` — 0 issues ✅
- `go tool go-arch-lint check` — OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)