### PR TITLE
fix: outputsizeの範囲バリデーションをキャッシュ有無で統一（#268）

### DIFF
--- a/internal/feature/candles/caching_repository.go
+++ b/internal/feature/candles/caching_repository.go
@@ -87,6 +87,13 @@ func (c *CachingRepository) UpsertBatch(ctx context.Context, candles []Candle) e
 // Find はローソク足データを取得します。まずキャッシュを確認し、なければデータベースにフォールバックします。
 // キャッシュには全データ（最大MaxOutputSize件）を保存し、outputsize件にスライスして返します。
 func (c *CachingRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
+	// outputsize は本来 handler で 1〜MaxOutputSize の範囲に検証済みだが、
+	// cache-hit 経路と dbRepository.Find の挙動を一致させるため、
+	// リポジトリ自身の不変条件としても防御的に検証する。
+	if outputsize <= 0 || outputsize > MaxOutputSize {
+		return nil, fmt.Errorf("find candles: %w", ErrInvalidOutputSize)
+	}
+
 	// Redisが未設定の場合はキャッシュをバイパス
 	if c.rdb == nil {
 		return c.inner.Find(ctx, symbol, interval, outputsize)
@@ -119,8 +126,10 @@ func (c *CachingRepository) Find(ctx context.Context, symbol, interval string, o
 }
 
 // sliceCandles は全ローソク足データから先頭 outputsize 件を返します。
+// outputsize は呼び出し元の Find で 1〜MaxOutputSize であることが検証済みのため、
+// ここでは outputsize が件数以上の場合に全件返すことのみを扱います。
 func sliceCandles(all []Candle, outputsize int) []Candle {
-	if outputsize <= 0 || outputsize >= len(all) {
+	if outputsize >= len(all) {
 		return all
 	}
 	return all[:outputsize]

--- a/internal/feature/candles/caching_repository_test.go
+++ b/internal/feature/candles/caching_repository_test.go
@@ -182,6 +182,61 @@ func TestCachingCandleRepository_Find_CacheHit_Slices(t *testing.T) {
 	}
 }
 
+// TestCachingCandleRepository_Find_InvalidOutputSize は outputsize が範囲外（0以下・MaxOutputSize超）の場合に
+// キャッシュヒット状態であっても ErrInvalidOutputSize を返し、inner.Find を呼ばないことを検証します
+// （cache-hit経路とdbRepository.Find経路で挙動を一致させるための防御的バリデーション）。
+func TestCachingCandleRepository_Find_InvalidOutputSize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		outputsize int
+	}{
+		{name: "zero", outputsize: 0},
+		{name: "negative", outputsize: -1},
+		{name: "exceeds max", outputsize: MaxOutputSize + 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rdb, mock := redismock.NewClientMock()
+			defer func() { _ = rdb.Close() }()
+
+			cachedCandles := []Candle{
+				{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+			}
+			cachedJSON, _ := json.Marshal(cachedCandles)
+
+			// キャッシュにヒットする状態をセットアップするが、outputsize検証は
+			// キャッシュ参照より前に行われるため Redis へのアクセスは発生しない。
+			mock.ExpectGet("candles:AAPL:1day").SetVal(string(cachedJSON))
+
+			innerCalled := false
+			inner := &mockReadWriteRepository{
+				findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
+					innerCalled = true
+					return nil, nil
+				},
+			}
+
+			repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
+			candles, err := repo.Find(context.Background(), "AAPL", "1day", tt.outputsize)
+
+			if !errors.Is(err, ErrInvalidOutputSize) {
+				t.Errorf("expected ErrInvalidOutputSize, got %v", err)
+			}
+			if candles != nil {
+				t.Errorf("expected nil candles, got %v", candles)
+			}
+			if innerCalled {
+				t.Error("inner repository should not be called for invalid outputsize")
+			}
+		})
+	}
+}
+
 // TestCachingCandleRepository_Find_CacheMiss はキャッシュミス時にDBから全データを取得し、キャッシュに保存してoutputsize件を返すことを検証します。
 func TestCachingCandleRepository_Find_CacheMiss(t *testing.T) {
 	t.Parallel()

--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -58,6 +58,12 @@ func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: "outputsize must be an integer"})
 		return
 	}
+	// 範囲外の outputsize はキャッシュ有無で挙動が分かれてしまう（cache-hit は全件返し、
+	// DB直読みは500になる）ため、ここで一律に拒否しリポジトリ層まで到達させない。
+	if outputsize < 1 || outputsize > candles.MaxOutputSize {
+		httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: candles.ErrInvalidOutputSize.Error()})
+		return
+	}
 
 	candles, err := h.uc.GetCandles(r.Context(), code, interval, outputsize)
 	if err != nil {

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -106,6 +106,47 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 			expectedBody:   `{"error":"invalid symbol code"}`,
 		},
+		{
+			name:           "error: outputsize zero returns 400",
+			url:            "/candles/7203.T?outputsize=0",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"outputsize must be between 1 and 5000"}`,
+		},
+		{
+			name:           "error: negative outputsize returns 400",
+			url:            "/candles/7203.T?outputsize=-1",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"outputsize must be between 1 and 5000"}`,
+		},
+		{
+			name:           "error: outputsize exceeding max returns 400",
+			url:            "/candles/7203.T?outputsize=5001",
+			mockGetCandles: nil,
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"outputsize must be between 1 and 5000"}`,
+		},
+		{
+			name: "success: outputsize lower boundary (1)",
+			url:  "/candles/7203.T?outputsize=1",
+			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+				assert.Equal(t, 1, outputsize)
+				return []candles.Candle{}, nil
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `[]`,
+		},
+		{
+			name: "success: outputsize upper boundary (5000)",
+			url:  "/candles/7203.T?outputsize=5000",
+			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+				assert.Equal(t, 5000, outputsize)
+				return []candles.Candle{}, nil
+			},
+			expectedStatus: http.StatusOK,
+			expectedBody:   `[]`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/feature/candles/usecase.go
+++ b/internal/feature/candles/usecase.go
@@ -40,9 +40,12 @@ func NewUsecase(candle Repository) *usecase {
 }
 
 // GetCandles は指定された銘柄と時間間隔のローソク足データを取得します。
-// interval / outputsize の妥当性は OpenAPI バリデーションミドルウェアと handler が
-// 検証済みのため、ここでは丸めやデフォルト化は行わず受け取った値をそのまま使います。
-// （リポジトリ層は outputsize が 1〜MaxOutputSize の範囲外であることを不変条件違反として別途防御的に検証します）
+// interval / outputsize の範囲チェックは OpenAPI バリデーションミドルウェアと handler
+// （candleshttp.Handler.GetCandlesHandler）が担うため、ここでは丸めやデフォルト化は行わず
+// 受け取った値をそのまま使います。
+// （リポジトリ層（dbRepository / CachingRepository）は outputsize が 1〜MaxOutputSize の
+// 範囲外であることを不変条件違反として別途防御的に検証し、cache-hit/DB直読みで挙動が
+// 一致するようにしています）
 func (cu *usecase) GetCandles(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
 	cs, err := cu.candle.Find(ctx, symbol, interval, outputsize)
 	if err != nil {


### PR DESCRIPTION
## 概要
`GET /v1/candles/{code}` の `outputsize` が範囲外（0以下・5000超）の場合に、キャッシュの有無で 200（全件返却）と 500 が入れ替わる不整合を解消します。ハンドラーで範囲バリデーションを一元化し、どの経路でも一律 400 を返すようにしました。

## 変更内容
- `candleshttp/handler.go`: `strconv.Atoi` 成功後に 1〜`MaxOutputSize` の範囲チェックを追加し、範囲外は 400（`outputsize must be between 1 and 5000`）を返す
- `caching_repository.go`: `Find` の冒頭に `dbRepository.Find` と同一の防御的検証を追加し、cache-hit 経路でも `ErrInvalidOutputSize` を返すよう統一
- `caching_repository.go`: `sliceCandles` から `outputsize <= 0` で全件返す分岐を削除（検証後は到達不能）
- `usecase.go`: バリデーション責務のコメントを実態に合わせて更新

## 関連issue
- closes #268

## テスト
- `handler_test.go`: `outputsize=0 / -1 / 5001` → 400、境界値 `1 / 5000` → 200 のケースを追加
- `caching_repository_test.go`: cache-hit 状態でも範囲外なら `ErrInvalidOutputSize` を返し `inner.Find` を呼ばないことを検証
- `go test ./... -race`（testcontainers 使用）全パッケージ合格、`golangci-lint run`・`go tool go-arch-lint check` 合格

## レビューポイント
- 範囲外 `outputsize` はこれまで cache-hit 時に 200 で全件返っていましたが、OpenAPI 仕様（`minimum: 1, maximum: 5000`、範囲外は 400）に合わせて 400 に統一しています。仕様どおりのクライアントには影響ありません
- リポジトリ層の `ErrInvalidOutputSize` は「ハンドラー検証を通過したのに範囲外」という不変条件違反のため、500 のままとしています（汎用エラーマッピング層は導入しない方針）

🤖 Generated with [Claude Code](https://claude.com/claude-code)