### PR TITLE
fix: ウォッチリスト並び替えのTOCTOU競合と更新0件の見逃しを解消

### DIFF
--- a/internal/feature/watchlist/repository.go
+++ b/internal/feature/watchlist/repository.go
@@ -77,8 +77,12 @@ func (r *repository) Remove(ctx context.Context, userID int64, symbolCode string
 }
 
 // UpdateSortKeys はウォッチリストの sort_key をトランザクション内で一括更新します。
+// 冒頭でユーザーの全レコードを ORDER BY id で取得順にロックし、件数が entries と
+// 一致しなければ ErrReorderCodesMismatch を返します（ListByUser との TOCTOU 競合対策。
+// 取得順ロックにより並行 Reorder 同士のデッドロックも防ぎます）。
 // (user_id, sort_key) のユニーク制約が一時的に違反しないよう、まず全レコードを
-// 負値（-(i+1)）にシフトしてから最終値に更新します。
+// 負値（-(i+1)）にシフトしてから最終値に更新します。各更新の更新行数が1でない場合
+// （並行削除等で対象行が消えている場合）も ErrReorderCodesMismatch を返します。
 func (r *repository) UpdateSortKeys(ctx context.Context, userID int64, entries []UserSymbol) error {
 	tx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
@@ -92,24 +96,43 @@ func (r *repository) UpdateSortKeys(ctx context.Context, userID int64, entries [
 	}()
 	qtx := r.q.WithTx(tx)
 
+	// ユーザーの全レコードをロックし、entries と件数が一致するか検証する。
+	// これにより ListByUser（呼び出し元）から本トランザクション開始までの間の
+	// 並行変更を検出する。
+	locked, err := qtx.LockWatchlistByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if len(locked) != len(entries) {
+		return ErrReorderCodesMismatch
+	}
+
 	// Phase 1: 負値にシフト
 	for i, e := range entries {
-		if _, err := qtx.UpdateWatchlistSortKey(ctx, watchlistsqlc.UpdateWatchlistSortKeyParams{
+		rowsAffected, err := qtx.UpdateWatchlistSortKey(ctx, watchlistsqlc.UpdateWatchlistSortKeyParams{
 			UserID:     userID,
 			SymbolCode: e.SymbolCode,
 			SortKey:    int64(-(i + 1)),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
+		}
+		if rowsAffected != 1 {
+			return ErrReorderCodesMismatch
 		}
 	}
 	// Phase 2: 最終値に更新
 	for _, e := range entries {
-		if _, err := qtx.UpdateWatchlistSortKey(ctx, watchlistsqlc.UpdateWatchlistSortKeyParams{
+		rowsAffected, err := qtx.UpdateWatchlistSortKey(ctx, watchlistsqlc.UpdateWatchlistSortKeyParams{
 			UserID:     userID,
 			SymbolCode: e.SymbolCode,
 			SortKey:    int64(e.SortKey),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
+		}
+		if rowsAffected != 1 {
+			return ErrReorderCodesMismatch
 		}
 	}
 	if err := tx.Commit(); err != nil {

--- a/internal/feature/watchlist/repository_test.go
+++ b/internal/feature/watchlist/repository_test.go
@@ -186,6 +186,62 @@ func TestWatchlistRepository_UpdateSortKeys(t *testing.T) {
 	assert.Equal(t, "GOOGL", list[2].SymbolCode)
 }
 
+func TestWatchlistRepository_UpdateSortKeys_TargetRowMissing(t *testing.T) {
+	t.Parallel()
+	db, ids := setupTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "AAPL", SortKey: 0}))
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "GOOGL", SortKey: 1}))
+
+	// entries の件数（2件）は DB の件数（2件）と一致するが、GOOGL の代わりに
+	// 存在しない MSFT を指定することでロック件数チェックを素通りさせ、
+	// UpdateWatchlistSortKey の更新行数0件チェックを踏ませる。
+	err := repo.UpdateSortKeys(ctx, ids.u1, []UserSymbol{
+		{SymbolCode: "AAPL", SortKey: 0},
+		{SymbolCode: "MSFT", SortKey: 1},
+	})
+	assert.ErrorIs(t, err, ErrReorderCodesMismatch)
+
+	// ロールバックされ、既存行の sort_key が変更されていないことを確認する。
+	list, err := repo.ListByUser(ctx, ids.u1)
+	require.NoError(t, err)
+	require.Len(t, list, 2)
+	assert.Equal(t, "AAPL", list[0].SymbolCode)
+	assert.Equal(t, 0, list[0].SortKey)
+	assert.Equal(t, "GOOGL", list[1].SymbolCode)
+	assert.Equal(t, 1, list[1].SortKey)
+}
+
+func TestWatchlistRepository_UpdateSortKeys_CountMismatch(t *testing.T) {
+	t.Parallel()
+	db, ids := setupTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "AAPL", SortKey: 0}))
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "GOOGL", SortKey: 1}))
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "MSFT", SortKey: 2}))
+
+	// DB には3件あるが entries は2件のみ（並行削除等を想定した不一致ケース）。
+	err := repo.UpdateSortKeys(ctx, ids.u1, []UserSymbol{
+		{SymbolCode: "AAPL", SortKey: 0},
+		{SymbolCode: "GOOGL", SortKey: 1},
+	})
+	assert.ErrorIs(t, err, ErrReorderCodesMismatch)
+
+	list, err := repo.ListByUser(ctx, ids.u1)
+	require.NoError(t, err)
+	require.Len(t, list, 3)
+	assert.Equal(t, "AAPL", list[0].SymbolCode)
+	assert.Equal(t, 0, list[0].SortKey)
+	assert.Equal(t, "GOOGL", list[1].SymbolCode)
+	assert.Equal(t, 1, list[1].SortKey)
+	assert.Equal(t, "MSFT", list[2].SymbolCode)
+	assert.Equal(t, 2, list[2].SortKey)
+}
+
 func TestWatchlistRepository_ListByUser_Isolation(t *testing.T) {
 	t.Parallel()
 	db, ids := setupTestDB(t)

--- a/internal/feature/watchlist/sqlc/querier.go
+++ b/internal/feature/watchlist/sqlc/querier.go
@@ -12,6 +12,7 @@ type Querier interface {
 	DeleteWatchlist(ctx context.Context, arg DeleteWatchlistParams) (int64, error)
 	InsertWatchlist(ctx context.Context, arg InsertWatchlistParams) error
 	ListWatchlistByUser(ctx context.Context, userID int64) ([]Watchlist, error)
+	LockWatchlistByUser(ctx context.Context, userID int64) ([]int64, error)
 	MaxWatchlistSortKey(ctx context.Context, userID int64) (int64, error)
 	UpdateWatchlistSortKey(ctx context.Context, arg UpdateWatchlistSortKeyParams) (int64, error)
 }

--- a/internal/feature/watchlist/sqlc/queries.sql
+++ b/internal/feature/watchlist/sqlc/queries.sql
@@ -22,3 +22,10 @@ UPDATE watchlists
 SET sort_key = $3,
     updated_at = now()
 WHERE user_id = $1 AND symbol_code = $2;
+
+-- name: LockWatchlistByUser :many
+SELECT id
+FROM watchlists
+WHERE user_id = $1
+ORDER BY id
+FOR UPDATE;

--- a/internal/feature/watchlist/sqlc/queries.sql.go
+++ b/internal/feature/watchlist/sqlc/queries.sql.go
@@ -80,6 +80,37 @@ func (q *Queries) ListWatchlistByUser(ctx context.Context, userID int64) ([]Watc
 	return items, nil
 }
 
+const lockWatchlistByUser = `-- name: LockWatchlistByUser :many
+SELECT id
+FROM watchlists
+WHERE user_id = $1
+ORDER BY id
+FOR UPDATE
+`
+
+func (q *Queries) LockWatchlistByUser(ctx context.Context, userID int64) ([]int64, error) {
+	rows, err := q.db.QueryContext(ctx, lockWatchlistByUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const maxWatchlistSortKey = `-- name: MaxWatchlistSortKey :one
 SELECT COALESCE(MAX(sort_key), -1)::bigint AS max_key
 FROM watchlists

--- a/internal/feature/watchlist/usecase.go
+++ b/internal/feature/watchlist/usecase.go
@@ -21,6 +21,8 @@ type Repository interface {
 	Remove(ctx context.Context, userID int64, symbolCode string) error
 	// UpdateSortKeys は entries の SortKey でウォッチリストの並び順を一括更新します。
 	// 全更新は原子的に適用され、途中で失敗した場合はいずれの並び順も変更されません。
+	// トランザクション内でユーザーの全行をロックして件数を検証し、一致しない場合や
+	// 並行削除等で更新行数が0件になった場合は ErrReorderCodesMismatch を返します。
 	UpdateSortKeys(ctx context.Context, userID int64, entries []UserSymbol) error
 }
 


### PR DESCRIPTION
## 概要
ウォッチリスト並び替え（`ReorderSymbols`）で、usecase の検証と DB 更新が別トランザクションになっていることによる TOCTOU 競合と、`UpdateSortKeys` が更新行数を確認せず削除済みレコードでも成功を返す問題を解消します。

## 変更内容
- `LockWatchlistByUser` クエリ（`SELECT id ... ORDER BY id FOR UPDATE`）を追加し、`UpdateSortKeys` のトランザクション冒頭でユーザーの全行をロック
  - ロック件数が `entries` と不一致（並行追加・削除）の場合は `ErrReorderCodesMismatch` を返してロールバック
  - `ORDER BY id` の取得順ロックにより、並行 Reorder 同士のデッドロックを防止
- Phase 1（負値シフト）/ Phase 2（最終値更新）の各 `UpdateWatchlistSortKey` で更新行数をチェックし、0件（並行削除等）の場合も `ErrReorderCodesMismatch` を返してロールバック
- usecase 側の事前検証（コードの過不足・重複チェック）は入力バリデーションとして維持し、repository のトランザクション内チェックを競合時の最終防衛線とする構成

## 関連issue
- closes #269

## テスト
- `TestWatchlistRepository_UpdateSortKeys_TargetRowMissing`: 件数は一致するが存在しない銘柄を含む entries で更新行数0件チェックが働き、ロールバックされることを検証
- `TestWatchlistRepository_UpdateSortKeys_CountMismatch`: DB 3件 / entries 2件の不一致で `ErrReorderCodesMismatch` が返り、既存行が変更されないことを検証
- `go build ./...` / `go test ./... -race`（testcontainers + 実PostgreSQL）/ `golangci-lint run` / `go tool go-arch-lint check` すべてパス

## レビューポイント
- 競合検出時のエラーは既存の `ErrReorderCodesMismatch`（HTTP 400）を再利用しています。並行変更の意味合いとしては 409 Conflict も考えられますが、API 契約変更を避けるためスコープ外としました

🤖 Generated with [Claude Code](https://claude.com/claude-code)