### PR TITLE
fix: サインアップ後フックをリクエストcontextのキャンセルから独立させる

### DIFF
--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -88,8 +88,11 @@ func (h *Handler) Signup(w http.ResponseWriter, r *http.Request) {
 	}
 	// 後処理フック呼び出し（例: ウォッチリスト初期化）
 	// フック失敗はユーザー作成自体には影響しないため非致命的とし、ログのみ記録する。
+	// ユーザー作成コミット後の後処理はクライアント切断（リクエストcontextのキャンセル）に
+	// 影響されてはならないため、キャンセルだけを切り離したcontextで実行する（valueは引き継ぐ）。
+	hookCtx := context.WithoutCancel(r.Context())
 	for _, hook := range h.postHooks {
-		if err := hook.OnUserCreated(r.Context(), userID); err != nil {
+		if err := hook.OnUserCreated(hookCtx, userID); err != nil {
 			slog.Error("post-signup hook failed", "error", err, "userID", userID)
 		}
 	}

--- a/internal/feature/auth/authhttp/handler_test.go
+++ b/internal/feature/auth/authhttp/handler_test.go
@@ -193,6 +193,39 @@ func TestAuthHandler_Signup_HookFailureIsNonFatal(t *testing.T) {
 	assert.True(t, hook.called, "後処理フックが呼ばれること")
 }
 
+// TestAuthHandler_Signup_HookRunsWithoutCancelOnClientDisconnect はリクエストcontextが
+// クライアント切断等で既にキャンセルされていても、後処理フック（ウォッチリスト初期化等）が
+// キャンセルの影響を受けずに実行されることを検証します（issue #272）。
+func TestAuthHandler_Signup_HookRunsWithoutCancelOnClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	mockUC := &mockUsecase{
+		SignupFunc: func(ctx context.Context, email, password string) (int64, error) { return 1, nil },
+	}
+	hook := &mockPostHook{
+		OnUserCreatedFunc: func(ctx context.Context, userID int64) error {
+			assert.NoError(t, ctx.Err(), "フックのcontextはリクエストcontextのキャンセルに影響されないこと")
+			return nil
+		},
+	}
+	h := authhttp.NewHandler(mockUC, nil, false, "", nil, hook)
+
+	bodyBytes, err := json.Marshal(H{"email": "test@example.com", "password": "password12345"})
+	require.NoError(t, err)
+
+	// クライアント切断を模擬するため、ハンドラー呼び出し前にリクエストcontextをキャンセルする。
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req := httptest.NewRequest(http.MethodPost, "/signup", bytes.NewBuffer(bodyBytes)).WithContext(ctx)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	h.Signup(w, req)
+
+	assertJSONResponse(t, w, http.StatusCreated, H{"message": "ok"})
+	assert.True(t, hook.called, "後処理フックが呼ばれること")
+}
+
 // TestAuthHandler_Login_RateLimited はメールベースのレートリミット超過時に429が返されることを検証します。
 func TestAuthHandler_Login_RateLimited(t *testing.T) {
 	t.Parallel()

--- a/internal/feature/auth/oauth.go
+++ b/internal/feature/auth/oauth.go
@@ -165,8 +165,11 @@ func (uc *oauthUsecase) findOrCreateUser(ctx context.Context, providerName strin
 
 	// 新規作成後フック呼び出し（例: ウォッチリスト初期化）
 	// フック失敗はユーザー作成自体には影響しないため非致命的とし、ログのみ記録する。
+	// ユーザー作成コミット後の後処理はクライアント切断（リクエストcontextのキャンセル）に
+	// 影響されてはならないため、キャンセルだけを切り離したcontextで実行する（valueは引き継ぐ）。
+	hookCtx := context.WithoutCancel(ctx)
 	for _, hook := range uc.hooks {
-		if err := hook.OnUserCreated(ctx, newUser.ID); err != nil {
+		if err := hook.OnUserCreated(hookCtx, newUser.ID); err != nil {
 			slog.Error("post-create hook failed", "user_id", newUser.ID, "error", err)
 		}
 	}

--- a/internal/feature/auth/oauth_test.go
+++ b/internal/feature/auth/oauth_test.go
@@ -56,6 +56,20 @@ func (m *mockOAuthUserCreator) CreateUserWithOAuthAccount(ctx context.Context, u
 	return m.CreateUserWithOAuthAccountFunc(ctx, user, account)
 }
 
+// mockPostHook は UserCreatedHook インターフェースのモック実装です。
+type mockPostHook struct {
+	OnUserCreatedFunc func(ctx context.Context, userID int64) error
+	called            bool
+}
+
+func (m *mockPostHook) OnUserCreated(ctx context.Context, userID int64) error {
+	m.called = true
+	if m.OnUserCreatedFunc != nil {
+		return m.OnUserCreatedFunc(ctx, userID)
+	}
+	return nil
+}
+
 // TestOAuthUsecase_HandleCallback_FindOrCreateUser は、OAuthAccount の有無と
 // 同メール既存ユーザーの有無に応じたログイン・拒否・新規作成の分岐を検証します。
 // 同メールの既存ユーザーへの自動リンクはアカウント乗っ取りリスクがあるため、
@@ -197,5 +211,73 @@ func TestOAuthUsecase_HandleCallback_FindOrCreateUser(t *testing.T) {
 				t.Errorf("FindByEmail called with %q, want %q", lookupEmail, tt.wantLookupEmail)
 			}
 		})
+	}
+}
+
+// TestOAuthUsecase_HandleCallback_HookRunsWithoutCancelOnClientDisconnect は、
+// 新規ユーザー作成後に呼び出される後処理フック（ウォッチリスト初期化等）が、
+// 呼び出し元contextが既にキャンセルされていてもキャンセルの影響を受けずに
+// 実行されることを検証します（issue #272）。
+func TestOAuthUsecase_HandleCallback_HookRunsWithoutCancelOnClientDisconnect(t *testing.T) {
+	t.Parallel()
+
+	const providerName = "google"
+
+	users := &mockUserRepository{
+		FindByEmailFunc: func(ctx context.Context, email string) (*auth.User, error) {
+			return nil, auth.ErrUserNotFound
+		},
+	}
+	oauthAccts := &mockOAuthAccountRepository{
+		FindByProviderFunc: func(ctx context.Context, provider, providerUID string) (*auth.OAuthAccount, error) {
+			return nil, auth.ErrUserNotFound
+		},
+		CreateFunc: func(ctx context.Context, account *auth.OAuthAccount) error { return nil },
+	}
+	creator := &mockOAuthUserCreator{
+		CreateUserWithOAuthAccountFunc: func(ctx context.Context, user *auth.User, account *auth.OAuthAccount) error {
+			user.ID = 7
+			return nil
+		},
+	}
+	stateStore := &mockOAuthStateStore{
+		ConsumeStateFunc: func(ctx context.Context, state string) (string, error) {
+			return "code-verifier", nil
+		},
+	}
+	provider := &mockOAuthProvider{
+		ExchangeCodeFunc: func(ctx context.Context, code, codeVerifier string) (*auth.OAuthUserInfo, error) {
+			return &auth.OAuthUserInfo{ProviderUID: "google-uid-1", Email: "user@example.com"}, nil
+		},
+	}
+	hook := &mockPostHook{
+		OnUserCreatedFunc: func(ctx context.Context, userID int64) error {
+			if ctx.Err() != nil {
+				t.Errorf("フックのcontextはリクエストcontextのキャンセルに影響されないこと: ctx.Err() = %v", ctx.Err())
+			}
+			return nil
+		},
+	}
+
+	uc := auth.NewOAuthUsecase(
+		users, oauthAccts, creator, stateStore,
+		&mockJWTGenerator{},
+		map[string]auth.OAuthProvider{providerName: provider},
+		hook,
+	)
+
+	// クライアント切断を模擬するため、HandleCallback呼び出し前にcontextをキャンセルする。
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	token, err := uc.HandleCallback(ctx, providerName, "code", "state")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token == "" {
+		t.Error("token is empty")
+	}
+	if !hook.called {
+		t.Error("後処理フックが呼ばれること")
 	}
 }


### PR DESCRIPTION
## 概要
ユーザー作成成功後の非致命的な後処理フック（ウォッチリスト初期化）が `r.Context()` で実行されており、クライアントが応答前に切断するとフックがキャンセルされ、ユーザーは作成済みなのにウォッチリスト初期化だけ失われる可能性がありました。

`context.WithoutCancel`（Go 1.21+）でキャンセルだけを切り離したcontextを派生させ、フックをクライアント切断の影響から独立させました。値（trace情報等）は引き継がれます。

## 変更内容
- `internal/feature/auth/authhttp/handler.go`: Signupの後処理フック呼び出しを `context.WithoutCancel(r.Context())` で実行
- `internal/feature/auth/oauth.go`: OAuth新規ユーザー作成後のフック呼び出しにも同一の欠陥があったため、同様に `context.WithoutCancel(ctx)` で実行（issueと同一欠陥クラスのためスコープ内として対応）
- テスト追加: キャンセル済みcontextでも両パスのフックが実行され、フックに渡るcontextが `ctx.Err() == nil` であることを検証

## 検証
- `go build ./...` ✅
- `go test ./internal/feature/auth/... -race` ✅（新規テスト2件含む）
- `golangci-lint run` ✅ 0 issues
- `go tool go-arch-lint check` ✅ No warnings

## 関連issue
closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)