### PR TITLE
fix: candles/logodetectionハンドラーのエラー分類を統一（バリデーションエラーを400/413で返す）

### DIFF
--- a/internal/feature/candles/candleshttp/handler.go
+++ b/internal/feature/candles/candleshttp/handler.go
@@ -2,6 +2,7 @@ package candleshttp
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"regexp"
@@ -65,16 +66,22 @@ func (h *Handler) GetCandlesHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	candles, err := h.uc.GetCandles(r.Context(), code, interval, outputsize)
+	result, err := h.uc.GetCandles(r.Context(), code, interval, outputsize)
 	if err != nil {
+		// リポジトリ/キャッシュ層がラップして ErrInvalidOutputSize を返す可能性があるため、
+		// 事前バリデーション（上記 outputsize チェック）と挙動を揃える防御的な分岐。
+		if errors.Is(err, candles.ErrInvalidOutputSize) {
+			httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: candles.ErrInvalidOutputSize.Error()})
+			return
+		}
 		slog.Error("failed to get candles", "error", err, "code", code)
 		httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{Error: "internal server error"})
 		return
 	}
 
 	// データをフォーマット
-	out := make([]api.CandleResponse, 0, len(candles))
-	for _, x := range candles {
+	out := make([]api.CandleResponse, 0, len(result))
+	for _, x := range result {
 		out = append(out, api.CandleResponse{
 			Time:   x.Time.UTC().Format("2006-01-02"),
 			Open:   x.Open,

--- a/internal/feature/candles/candleshttp/handler_test.go
+++ b/internal/feature/candles/candleshttp/handler_test.go
@@ -3,6 +3,7 @@ package candleshttp_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -70,6 +71,15 @@ func TestCandlesHandler_GetCandlesHandler(t *testing.T) {
 			},
 			expectedStatus: http.StatusInternalServerError,
 			expectedBody:   `{"error":"internal server error"}`,
+		},
+		{
+			name: "error: usecase returns wrapped ErrInvalidOutputSize",
+			url:  "/candles/7203.T?outputsize=200",
+			mockGetCandles: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+				return nil, fmt.Errorf("failed to fetch candles: %w", candles.ErrInvalidOutputSize)
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"outputsize must be between 1 and 5000"}`,
 		},
 		{
 			name:           "error: invalid outputsize string returns 400",

--- a/internal/feature/logodetection/errors.go
+++ b/internal/feature/logodetection/errors.go
@@ -1,0 +1,23 @@
+package logodetection
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrEmptyImage は画像データが空の場合のエラーです。
+	ErrEmptyImage = errors.New("image data is empty")
+
+	// ErrImageTooLarge は画像データが MaxImageSize を超える場合のエラーです。
+	ErrImageTooLarge = fmt.Errorf("image size exceeds maximum of %d bytes", MaxImageSize)
+
+	// ErrEmptyCompanyName は企業名が空の場合のエラーです。
+	ErrEmptyCompanyName = errors.New("company name is required")
+
+	// ErrCompanyNameTooLong は企業名が MaxCompanyNameLength を超える場合のエラーです。
+	ErrCompanyNameTooLong = fmt.Errorf("company name exceeds maximum length of %d characters", MaxCompanyNameLength)
+
+	// ErrInvalidCompanyName は企業名に許可されていない文字が含まれる場合のエラーです。
+	ErrInvalidCompanyName = errors.New("company name contains invalid characters")
+)

--- a/internal/feature/logodetection/logodetectionhttp/handler.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler.go
@@ -81,8 +81,17 @@ func (h *Handler) DetectLogos(w http.ResponseWriter, r *http.Request) {
 
 	logos, err := h.uc.DetectLogos(r.Context(), imageData)
 	if err != nil {
-		slog.Error("ロゴ検出に失敗", "error", err)
-		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "logo detection failed"})
+		switch {
+		case errors.Is(err, logodetection.ErrEmptyImage):
+			slog.Warn("ロゴ検出のバリデーションエラー", "error", err, "remote_addr", httpx.ClientIP(r))
+			httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: err.Error()})
+		case errors.Is(err, logodetection.ErrImageTooLarge):
+			slog.Warn("画像ファイルサイズ超過", "error", err, "remote_addr", httpx.ClientIP(r))
+			httpx.WriteJSON(w, http.StatusRequestEntityTooLarge, api.ErrorResponse{Error: err.Error()})
+		default:
+			slog.Error("ロゴ検出に失敗", "error", err)
+			httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "logo detection failed"})
+		}
 		return
 	}
 
@@ -110,8 +119,16 @@ func (h *Handler) AnalyzeCompany(w http.ResponseWriter, r *http.Request) {
 
 	analysis, err := h.uc.AnalyzeCompany(r.Context(), req.CompanyName)
 	if err != nil {
-		slog.Error("企業分析に失敗", "error", err, "company", req.CompanyName)
-		httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "company analysis failed"})
+		switch {
+		case errors.Is(err, logodetection.ErrEmptyCompanyName),
+			errors.Is(err, logodetection.ErrCompanyNameTooLong),
+			errors.Is(err, logodetection.ErrInvalidCompanyName):
+			slog.Warn("企業分析のバリデーションエラー", "error", err, "remote_addr", httpx.ClientIP(r))
+			httpx.WriteJSON(w, http.StatusBadRequest, api.ErrorResponse{Error: err.Error()})
+		default:
+			slog.Error("企業分析に失敗", "error", err, "company", req.CompanyName)
+			httpx.WriteJSON(w, http.StatusBadGateway, api.ErrorResponse{Error: "company analysis failed"})
+		}
 		return
 	}
 

--- a/internal/feature/logodetection/logodetectionhttp/handler_test.go
+++ b/internal/feature/logodetection/logodetectionhttp/handler_test.go
@@ -100,6 +100,30 @@ func TestLogoDetectionHandler_DetectLogos(t *testing.T) {
 			expectedStatus: http.StatusBadGateway,
 			expectedBody:   `{"error":"logo detection failed"}`,
 		},
+		{
+			name: "error: usecase returns empty image error",
+			setupRequest: func(t *testing.T) *http.Request {
+				req, _ := createMultipartRequest(t, "image", "test.jpg", []byte("fake-image"))
+				return req
+			},
+			mockFunc: func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error) {
+				return nil, logodetection.ErrEmptyImage
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"image data is empty"}`,
+		},
+		{
+			name: "error: usecase returns image too large error",
+			setupRequest: func(t *testing.T) *http.Request {
+				req, _ := createMultipartRequest(t, "image", "test.jpg", []byte("fake-image"))
+				return req
+			},
+			mockFunc: func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error) {
+				return nil, logodetection.ErrImageTooLarge
+			},
+			expectedStatus: http.StatusRequestEntityTooLarge,
+			expectedBody:   `{"error":"image size exceeds maximum of 10485760 bytes"}`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -159,6 +183,33 @@ func TestLogoDetectionHandler_AnalyzeCompany(t *testing.T) {
 			},
 			expectedStatus: http.StatusBadGateway,
 			expectedBody:   `{"error":"company analysis failed"}`,
+		},
+		{
+			name:        "error: usecase returns empty company name error",
+			requestBody: `{"company_name":"テスト企業"}`,
+			mockFunc: func(ctx context.Context, companyName string) (*logodetection.CompanyAnalysis, error) {
+				return nil, logodetection.ErrEmptyCompanyName
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"company name is required"}`,
+		},
+		{
+			name:        "error: usecase returns company name too long error",
+			requestBody: `{"company_name":"テスト企業"}`,
+			mockFunc: func(ctx context.Context, companyName string) (*logodetection.CompanyAnalysis, error) {
+				return nil, logodetection.ErrCompanyNameTooLong
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"company name exceeds maximum length of 100 characters"}`,
+		},
+		{
+			name:        "error: usecase returns invalid company name error",
+			requestBody: `{"company_name":"テスト企業"}`,
+			mockFunc: func(ctx context.Context, companyName string) (*logodetection.CompanyAnalysis, error) {
+				return nil, logodetection.ErrInvalidCompanyName
+			},
+			expectedStatus: http.StatusBadRequest,
+			expectedBody:   `{"error":"company name contains invalid characters"}`,
 		},
 	}
 

--- a/internal/feature/logodetection/usecase.go
+++ b/internal/feature/logodetection/usecase.go
@@ -55,10 +55,10 @@ func NewUsecase(ld LogoDetector, ca CompanyAnalyzer) *usecase {
 // DetectLogos は画像データからロゴを検出します。
 func (u *usecase) DetectLogos(ctx context.Context, imageData []byte) ([]DetectedLogo, error) {
 	if len(imageData) == 0 {
-		return nil, fmt.Errorf("image data is empty")
+		return nil, ErrEmptyImage
 	}
 	if len(imageData) > MaxImageSize {
-		return nil, fmt.Errorf("image size exceeds maximum of %d bytes", MaxImageSize)
+		return nil, ErrImageTooLarge
 	}
 	return u.logoDetector.DetectLogos(ctx, imageData)
 }
@@ -66,13 +66,13 @@ func (u *usecase) DetectLogos(ctx context.Context, imageData []byte) ([]Detected
 // AnalyzeCompany は企業名から分析サマリーを生成します。
 func (u *usecase) AnalyzeCompany(ctx context.Context, companyName string) (*CompanyAnalysis, error) {
 	if companyName == "" {
-		return nil, fmt.Errorf("company name is required")
+		return nil, ErrEmptyCompanyName
 	}
 	if utf8.RuneCountInString(companyName) > MaxCompanyNameLength {
-		return nil, fmt.Errorf("company name exceeds maximum length of %d characters", MaxCompanyNameLength)
+		return nil, ErrCompanyNameTooLong
 	}
 	if !validCompanyName.MatchString(companyName) {
-		return nil, fmt.Errorf("company name contains invalid characters")
+		return nil, ErrInvalidCompanyName
 	}
 	prompt := fmt.Sprintf(AnalysisPromptTemplate, companyName)
 	summary, err := u.companyAnalyzer.Analyze(ctx, prompt)

--- a/internal/feature/logodetection/usecase_test.go
+++ b/internal/feature/logodetection/usecase_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/logodetection"
@@ -53,6 +54,7 @@ func TestLogoDetectionUsecase_DetectLogos(t *testing.T) {
 		mockFunc      func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error)
 		expectedLogos []logodetection.DetectedLogo
 		expectedErr   string
+		expectedIs    error
 	}{
 		{
 			name:      "success: logos detected",
@@ -63,14 +65,14 @@ func TestLogoDetectionUsecase_DetectLogos(t *testing.T) {
 			expectedLogos: expectedLogos,
 		},
 		{
-			name:        "error: empty image data",
-			imageData:   []byte{},
-			expectedErr: "image data is empty",
+			name:       "error: empty image data",
+			imageData:  []byte{},
+			expectedIs: logodetection.ErrEmptyImage,
 		},
 		{
-			name:        "error: image too large",
-			imageData:   make([]byte, logodetection.MaxImageSize+1),
-			expectedErr: "image size exceeds maximum",
+			name:       "error: image too large",
+			imageData:  make([]byte, logodetection.MaxImageSize+1),
+			expectedIs: logodetection.ErrImageTooLarge,
 		},
 		{
 			name:      "error: api returns error",
@@ -90,6 +92,13 @@ func TestLogoDetectionUsecase_DetectLogos(t *testing.T) {
 			uc := logodetection.NewUsecase(detector, analyzer)
 
 			logos, err := uc.DetectLogos(ctx, tc.imageData)
+
+			if tc.expectedIs != nil {
+				if !errors.Is(err, tc.expectedIs) {
+					t.Fatalf("expected error to be %v, got %v", tc.expectedIs, err)
+				}
+				return
+			}
 
 			if tc.expectedErr != "" {
 				if err == nil {
@@ -120,6 +129,7 @@ func TestLogoDetectionUsecase_AnalyzeCompany(t *testing.T) {
 		mockFunc        func(ctx context.Context, prompt string) (string, error)
 		expectedSummary string
 		expectedErr     string
+		expectedIs      error
 	}{
 		{
 			name:        "success: analysis generated",
@@ -132,7 +142,17 @@ func TestLogoDetectionUsecase_AnalyzeCompany(t *testing.T) {
 		{
 			name:        "error: empty company name",
 			companyName: "",
-			expectedErr: "company name is required",
+			expectedIs:  logodetection.ErrEmptyCompanyName,
+		},
+		{
+			name:        "error: company name too long",
+			companyName: strings.Repeat("あ", logodetection.MaxCompanyNameLength+1),
+			expectedIs:  logodetection.ErrCompanyNameTooLong,
+		},
+		{
+			name:        "error: company name contains invalid characters",
+			companyName: "任天堂<script>",
+			expectedIs:  logodetection.ErrInvalidCompanyName,
 		},
 		{
 			name:        "error: api returns error",
@@ -151,6 +171,13 @@ func TestLogoDetectionUsecase_AnalyzeCompany(t *testing.T) {
 			uc := logodetection.NewUsecase(detector, analyzer)
 
 			result, err := uc.AnalyzeCompany(ctx, tc.companyName)
+
+			if tc.expectedIs != nil {
+				if !errors.Is(err, tc.expectedIs) {
+					t.Fatalf("expected error to be %v, got %v", tc.expectedIs, err)
+				}
+				return
+			}
 
 			if tc.expectedErr != "" {
 				if err == nil {


### PR DESCRIPTION
## 概要

Closes #267

candles/logodetection の HTTP ハンドラーは usecase から返るあらゆるエラーを無条件に 500/502 にマッピングしており、バリデーション起因のエラー（空画像・企業名不正・outputsize 範囲外）が本来の 400 ではなく 500/502 として返っていました。watchlist/auth で確立済みの「センチネルエラー + `errors.Is`」パターン（`watchlisthttp/handler.go` 参照）を踏襲し、実装を OpenAPI 仕様に整合させます。

## 変更内容

### logodetection
- `errors.go` を新設し、5つのセンチネルエラーを定義（メッセージ文字列は従来の `fmt.Errorf` と完全一致）
  - `ErrEmptyImage` / `ErrImageTooLarge` / `ErrEmptyCompanyName` / `ErrCompanyNameTooLong` / `ErrInvalidCompanyName`
- `usecase.go` の匿名 `fmt.Errorf` をセンチネル返却に置換（外部アダプタエラーのラップは従来どおり）
- `DetectLogos` ハンドラー: 空画像→**400**、サイズ超過→**413**（HTTP層の既存413チェック・OpenAPI定義と整合）、その他→502
- `AnalyzeCompany` ハンドラー: 企業名の未指定/文字数超過/不正文字→**400**、その他→502
- ログレベルはクライアント起因を `Warn`、サーバ側を `Error` に分離（既存慣例に一致）

### candles
- ハンドラーに `errors.Is(err, candles.ErrInvalidOutputSize)` → **400** の防御的分岐を追加（リポジトリ/キャッシュ層がラップして返すケースに対応）
- ローカル変数 `candles` がパッケージ識別子をシャドウしていたため `result` に改名

### OpenAPI
- 変更なし。仕様は既に 400/413 を定義済みで、本修正は実装を仕様に合わせるものです（`/v1/logo/analyze` はバリデーションエラーが仕様未定義の502で返っていた状態を解消）

## エラーマッピング（修正後）

| エラー | 修正前 | 修正後 |
|---|---|---|
| 空画像（usecase検証） | 502 | **400** |
| 画像サイズ超過（usecase検証） | 502 | **413** |
| 企業名 未指定/超過/不正文字 | 502 | **400** |
| outputsize 範囲外（リポジトリ層由来） | 500 | **400** |
| vision/gemini/DB 障害 | 502/500 | 502/500（変更なし） |

## テスト

- `logodetection/usecase_test.go`: バリデーション系の検証を部分一致から `errors.Is` によるセンチネル同一性検証へ変更。企業名の文字数超過・不正文字ケースを追加
- `logodetectionhttp/handler_test.go`: 400/413 のケースを5件追加（既存の502ケースは維持）
- `candleshttp/handler_test.go`: ラップされた `ErrInvalidOutputSize` が 400 になるケースを追加（既存の500ケースは維持）

## 検証結果

- `go build ./...` ✅
- `go test ./... -race -count=1` 全パッケージ PASS ✅
- `golangci-lint run --timeout=5m` 0 issues ✅
- `go tool go-arch-lint check` OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)