### PR TITLE
CIカバレッジしきい値ゲートと並行アクセステストを追加

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -147,7 +147,17 @@ jobs:
       - name: Run tests
         env:
           TEST_DB_DSN: postgres://appuser:apppass@localhost:5432/postgres?sslmode=disable
-        run: go test ./... -v -race -cover
+        run: go test ./... -v -race -coverprofile=coverage.out
+
+      - name: Check coverage threshold
+        env:
+          COVERAGE_THRESHOLD: "63.0"  # 実測65.1%の約2pt下。カバレッジ向上時に引き上げる
+        run: |
+          set -euo pipefail
+          total="$(go tool cover -func=coverage.out | awk '/^total:/ {sub(/%/,"",$3); print $3}')"
+          echo "total coverage: ${total}% (threshold: ${COVERAGE_THRESHOLD}%)"
+          awk -v t="${total}" -v th="${COVERAGE_THRESHOLD}" 'BEGIN { exit !(t+0 >= th+0) }' \
+            || { echo "::error::coverage ${total}% is below threshold ${COVERAGE_THRESHOLD}%"; exit 1; }
 
   # スキーマドキュメント（docs/schema/）がエンティティ変更と同期しているか検証
   schema-doc-check:

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.5
 
 require (
 	cloud.google.com/go/vision/v2 v2.15.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/getkin/kin-openapi v0.142.0
 	github.com/go-chi/chi/v5 v5.3.1
 	github.com/go-chi/cors v1.2.2
@@ -163,6 +164,7 @@ require (
 	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b // indirect
 	github.com/ydb-platform/ydb-go-sdk/v3 v3.141.1 // indirect
 	github.com/yuin/goldmark v1.5.3 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
 	go.opencensus.io v0.24.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/alecthomas/chroma/v2 v2.5.0 h1:CQCdj1BiBV17sD4Bd32b/Bzuiq/EqoNTrnIhyQ
 github.com/alecthomas/chroma/v2 v2.5.0/go.mod h1:yrkMI9807G1ROx13fhe1v6PN2DDeaR73L3d+1nmYQtw=
 github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
 github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
@@ -516,6 +518,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.5.3 h1:3HUJmBFbQW9fhQOzMgseU134xfi6hU+mjWywx5Ty+/M=
 github.com/yuin/goldmark v1.5.3/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/zeebo/xxh3 v1.1.0 h1:s7DLGDK45Dyfg7++yxI0khrfwq9661w9EN78eP/UZVs=

--- a/internal/feature/candles/caching_repository_concurrent_test.go
+++ b/internal/feature/candles/caching_repository_concurrent_test.go
@@ -1,0 +1,195 @@
+package candles
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+// versionedInnerRepository はmockReadWriteRepositoryをラップし、「現在のバージョン」を
+// sync.Mutexで保護しつつ保持するテスト用インナーリポジトリです。
+// 各バージョンのCandleはすべて同じCloseの値を持たせることで、Find結果が
+// 単一バージョンの完全なスナップショットになっているかを検証できるようにします。
+type versionedInnerRepository struct {
+	mu      sync.Mutex
+	current []Candle
+	*mockReadWriteRepository
+}
+
+// newVersionedInnerRepository はversion=0の初期データを持つversionedInnerRepositoryを生成します。
+func newVersionedInnerRepository(symbol, interval string, size int) *versionedInnerRepository {
+	v := &versionedInnerRepository{}
+	v.setVersion(symbol, interval, size, 0)
+	v.mockReadWriteRepository = &mockReadWriteRepository{
+		findFn: func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error) {
+			return sliceCandles(v.snapshot(), outputsize), nil
+		},
+		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
+			v.mu.Lock()
+			defer v.mu.Unlock()
+			v.current = candles
+			return nil
+		},
+	}
+	return v
+}
+
+// setVersion は current を version 番号をCloseに埋め込んだ candles で置き換えます。
+func (v *versionedInnerRepository) setVersion(symbol, interval string, size int, version int) {
+	candles := make([]Candle, size)
+	for i := range candles {
+		candles[i] = Candle{
+			SymbolCode: symbol,
+			Interval:   interval,
+			Time:       time.Now().Add(-time.Duration(i) * 24 * time.Hour),
+			Close:      float64(version), // バージョン番号をCloseに埋め込み、スナップショットの一貫性検証に使う
+		}
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.current = candles
+}
+
+// snapshot は現在の current のコピーを返します（呼び出し元が結果を変更しても
+// current 自体に影響を与えないようにするため）。
+func (v *versionedInnerRepository) snapshot() []Candle {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	out := make([]Candle, len(v.current))
+	copy(out, v.current)
+	return out
+}
+
+// TestCachingRepository_ConcurrentFindAndUpsert はFindとUpsertBatchを並行実行しても
+// レースコンディション（-race）が検出されず、各Find結果が単一バージョンの完全な
+// スナップショットになっていることを検証します。
+// SetNX/Del方式の設計上、実行中の一時的な古いキャッシュ読み取り（stale read）は
+// 許容範囲であるため、ここでは「読み取り結果の内部一貫性」と「全goroutine終了後の
+// 最終的な整合性（Del→cache miss→再構築）」のみを検証します。
+func TestCachingRepository_ConcurrentFindAndUpsert(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	const (
+		symbol           = "AAPL"
+		interval         = "1day"
+		candleCount      = 5
+		findGoroutines   = 10
+		findIterations   = 20
+		upsertGoroutines = 2
+		upsertIterations = 20
+	)
+
+	inner := newVersionedInnerRepository(symbol, interval, candleCount)
+	repo := NewCachingRepository(rdb, DefaultCacheTTL, inner, "candles-concurrent-test")
+
+	ctx := context.Background()
+
+	var (
+		wg    sync.WaitGroup
+		errMu sync.Mutex
+		errs  []error
+
+		versionMu  sync.Mutex
+		versionSeq int
+	)
+	nextVersion := func() int {
+		versionMu.Lock()
+		defer versionMu.Unlock()
+		versionSeq++
+		return versionSeq
+	}
+	recordErr := func(err error) {
+		if err == nil {
+			return
+		}
+		errMu.Lock()
+		defer errMu.Unlock()
+		errs = append(errs, err)
+	}
+
+	// Find側: 同一symbol/interval/outputsizeで並行に読み取る
+	for i := 0; i < findGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < findIterations; j++ {
+				candles, err := repo.Find(ctx, symbol, interval, candleCount)
+				if err != nil {
+					recordErr(fmt.Errorf("Find: %w", err))
+					continue
+				}
+				// スナップショットの一貫性: 件数とCloseの値が揃っているか検証
+				if len(candles) != candleCount {
+					recordErr(fmt.Errorf("Find returned %d candles, want %d", len(candles), candleCount))
+					continue
+				}
+				want := candles[0].Close
+				for _, c := range candles {
+					if c.Close != want {
+						recordErr(fmt.Errorf("Find result mixed versions: got Close values %v", closesOf(candles)))
+						break
+					}
+				}
+			}
+		}()
+	}
+
+	// Upsert側: バージョンを更新しながら並行に書き込む
+	for i := 0; i < upsertGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < upsertIterations; j++ {
+				inner.setVersion(symbol, interval, candleCount, nextVersion())
+				if err := repo.UpsertBatch(ctx, inner.snapshot()); err != nil {
+					recordErr(fmt.Errorf("UpsertBatch: %w", err))
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	if len(errs) != 0 {
+		t.Fatalf("expected no errors during concurrent Find/UpsertBatch, got %d errors, first: %v", len(errs), errs[0])
+	}
+
+	// 最終確認: sentinelバージョンでUpsertBatchした後、Findがその内容を反映していること
+	// （Del→cache miss→再構築の経路が正しく機能していることを検証）
+	const sentinelVersion = -1
+	inner.setVersion(symbol, interval, candleCount, sentinelVersion)
+	if err := repo.UpsertBatch(ctx, inner.snapshot()); err != nil {
+		t.Fatalf("final UpsertBatch failed: %v", err)
+	}
+
+	final, err := repo.Find(ctx, symbol, interval, candleCount)
+	if err != nil {
+		t.Fatalf("final Find failed: %v", err)
+	}
+	if len(final) != candleCount {
+		t.Fatalf("expected %d candles in final snapshot, got %d", candleCount, len(final))
+	}
+	for _, c := range final {
+		if c.Close != float64(sentinelVersion) {
+			t.Fatalf("expected final snapshot to reflect sentinel version %d, got Close=%v", sentinelVersion, c.Close)
+		}
+	}
+}
+
+// closesOf はエラーメッセージ用にCandleスライスからCloseの値だけを抽出します。
+func closesOf(candles []Candle) []float64 {
+	out := make([]float64, len(candles))
+	for i, c := range candles {
+		out[i] = c.Close
+	}
+	return out
+}

--- a/internal/feature/watchlist/repository_concurrent_test.go
+++ b/internal/feature/watchlist/repository_concurrent_test.go
@@ -1,0 +1,176 @@
+package watchlist
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// sortPermutations は3銘柄コードの全並び替え（3! = 6通り）です。
+// 並行実行するgoroutine数（8）がこれより多い場合は循環して再利用します。
+var sortPermutations = [][]string{
+	{"AAPL", "GOOGL", "MSFT"},
+	{"AAPL", "MSFT", "GOOGL"},
+	{"GOOGL", "AAPL", "MSFT"},
+	{"GOOGL", "MSFT", "AAPL"},
+	{"MSFT", "AAPL", "GOOGL"},
+	{"MSFT", "GOOGL", "AAPL"},
+}
+
+// entriesFromPerm はコードの並びから、usecase.ReorderSymbolsと同じ規約（0始まりの連番）で
+// SortKeyを割り当てたUserSymbolのスライスを生成します。
+func entriesFromPerm(userID int64, codes []string) []UserSymbol {
+	entries := make([]UserSymbol, len(codes))
+	for i, code := range codes {
+		entries[i] = UserSymbol{UserID: userID, SymbolCode: code, SortKey: i}
+	}
+	return entries
+}
+
+// TestWatchlistRepository_UpdateSortKeys_Concurrent は同一ユーザーに対して
+// UpdateSortKeysを並行に呼び出しても、LockWatchlistByUserによる行ロック（取得順ロック）で
+// デッドロックやユニーク制約違反、件数不一致エラーなく直列化されることを検証します。
+func TestWatchlistRepository_UpdateSortKeys_Concurrent(t *testing.T) {
+	t.Parallel()
+	db, ids := setupTestDB(t)
+	repo := NewRepository(db)
+	ctx := context.Background()
+
+	// u1・u2 両方に同じ初期状態（AAPL, GOOGL, MSFT の順）を投入する。
+	// u2 は並行更新の対象外とし、最後に「無関係のユーザーには影響しない」ことを検証する。
+	for _, uid := range []int64{ids.u1, ids.u2} {
+		require.NoError(t, repo.Add(ctx, UserSymbol{UserID: uid, SymbolCode: "AAPL", SortKey: 0}))
+		require.NoError(t, repo.Add(ctx, UserSymbol{UserID: uid, SymbolCode: "GOOGL", SortKey: 1}))
+		require.NoError(t, repo.Add(ctx, UserSymbol{UserID: uid, SymbolCode: "MSFT", SortKey: 2}))
+	}
+
+	const goroutines = 8
+
+	var wg sync.WaitGroup
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			perm := sortPermutations[idx%len(sortPermutations)]
+			errs[idx] = repo.UpdateSortKeys(ctx, ids.u1, entriesFromPerm(ids.u1, perm))
+		}(i)
+	}
+	wg.Wait()
+
+	// ロックにより直列化されるため、いずれの呼び出しも失敗しないはず。
+	for i, err := range errs {
+		assert.NoErrorf(t, err, "goroutine %d の UpdateSortKeys が失敗した", i)
+	}
+
+	// u1: 最終状態は投入した並び替えのいずれかと一致し、sort_keyは0,1,2の連番になっているはず。
+	final, err := repo.ListByUser(ctx, ids.u1)
+	require.NoError(t, err)
+	require.Len(t, final, 3)
+
+	gotCodes := []string{final[0].SymbolCode, final[1].SymbolCode, final[2].SymbolCode}
+	assert.Contains(t, sortPermutations, gotCodes, "最終的な並びは投入したいずれかの並び替えと一致するはず")
+	for i, us := range final {
+		assert.Equal(t, i, us.SortKey, "ListByUserはsort_key昇順のため、順序位置=sort_keyになるはず")
+	}
+
+	// u2: 並行更新の対象外のため、初期状態のまま変化していないはず。
+	u2List, err := repo.ListByUser(ctx, ids.u2)
+	require.NoError(t, err)
+	require.Len(t, u2List, 3)
+	assert.Equal(t, "AAPL", u2List[0].SymbolCode)
+	assert.Equal(t, 0, u2List[0].SortKey)
+	assert.Equal(t, "GOOGL", u2List[1].SymbolCode)
+	assert.Equal(t, 1, u2List[1].SortKey)
+	assert.Equal(t, "MSFT", u2List[2].SymbolCode)
+	assert.Equal(t, 2, u2List[2].SortKey)
+}
+
+// alwaysExistsSymbolChecker はSymbolExistsCheckerの常にtrueを返すテスト用スタブです。
+// このテストではReorderSymbols/RemoveSymbolのみを検証対象とし、いずれも
+// SymbolExistsCheckerを使わないため、呼び出されるかどうかは問いません。
+type alwaysExistsSymbolChecker struct{}
+
+func (alwaysExistsSymbolChecker) Exists(ctx context.Context, code string) (bool, error) {
+	return true, nil
+}
+
+// TestWatchlistUsecase_ReorderSymbols_ConcurrentRemove は ReorderSymbols の連続呼び出しと
+// Remove を並行実行した際、usecase/repositoryが返すエラーがドメインエラー
+// （ErrReorderCodesMismatch / ErrNotInWatchlist）の範囲に収まり、生のPGエラー
+// （unique violation等）が漏れ出さないことを検証します。
+//
+// ReorderSymbolsはListByUserで取得した現在の一覧とentriesの個数・コードを比較するため、
+// Remove（MSFT削除）が割り込むと「現在の一覧（2件）」と「投入したentries（3件）」の
+// 個数不一致によりErrReorderCodesMismatchを返す（usecase層のバリデーションで弾かれる）。
+// これに加え、usecaseのListByUser呼び出し後・repository.UpdateSortKeysのロック取得前に
+// Removeが割り込んだ場合は、repository層のLockWatchlistByUserによる件数チェックでも
+// 同じErrReorderCodesMismatchが返る。
+func TestWatchlistUsecase_ReorderSymbols_ConcurrentRemove(t *testing.T) {
+	t.Parallel()
+	db, ids := setupTestDB(t)
+	repo := NewRepository(db)
+	uc := NewUsecase(repo, alwaysExistsSymbolChecker{})
+	ctx := context.Background()
+
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "AAPL", SortKey: 0}))
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "GOOGL", SortKey: 1}))
+	require.NoError(t, repo.Add(ctx, UserSymbol{UserID: ids.u1, SymbolCode: "MSFT", SortKey: 2}))
+
+	const reorderIterations = 20
+
+	var (
+		wg      sync.WaitGroup
+		errMu   sync.Mutex
+		allErrs []error
+	)
+	recordErr := func(err error) {
+		errMu.Lock()
+		defer errMu.Unlock()
+		allErrs = append(allErrs, err)
+	}
+
+	// ReorderSymbolsを繰り返し呼ぶgoroutine。
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < reorderIterations; i++ {
+			perm := sortPermutations[i%len(sortPermutations)]
+			recordErr(uc.ReorderSymbols(ctx, ids.u1, perm))
+		}
+	}()
+
+	// MSFTを1回だけ削除するgoroutine。
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		recordErr(uc.RemoveSymbol(ctx, ids.u1, "MSFT"))
+	}()
+
+	wg.Wait()
+
+	for i, err := range allErrs {
+		if err == nil {
+			continue
+		}
+		assert.Truef(t,
+			errors.Is(err, ErrReorderCodesMismatch) || errors.Is(err, ErrNotInWatchlist),
+			"呼び出し%dで想定外のエラー: %v（ErrReorderCodesMismatchかErrNotInWatchlistのみ許容）", i, err)
+	}
+
+	// 最終状態: MSFTが存在せず、sort_keyに重複がないこと（連番であることまでは要求しない）。
+	final, err := repo.ListByUser(ctx, ids.u1)
+	require.NoError(t, err)
+
+	seenSortKeys := map[int]struct{}{}
+	for _, us := range final {
+		assert.NotEqual(t, "MSFT", us.SymbolCode, "MSFTは削除済みのため残っていないはず")
+		_, dup := seenSortKeys[us.SortKey]
+		assert.Falsef(t, dup, "sort_key %d が重複している", us.SortKey)
+		seenSortKeys[us.SortKey] = struct{}{}
+	}
+}

--- a/internal/transport/httpratelimit/limiter_concurrent_test.go
+++ b/internal/transport/httpratelimit/limiter_concurrent_test.go
@@ -1,0 +1,73 @@
+package httpratelimit
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLimiter_Allow_Concurrent は同一キーに対して limit を超える数の Allow を並行呼び出しし、
+// Luaスクリプト（ZCARD→ZADDの原子的実行）により許可数がちょうど limit 件に収まることを検証します。
+// member 値は "<nowNano>:<8バイト乱数の16進数>" で構成されるため、同一ナノ秒に複数goroutineが
+// 実行してもZADDのメンバーが衝突する（＝重複としてカウントされない）可能性は実質的にゼロであり、
+// 許可数の厳密な一致（ちょうどlimit件）をアサートしてよい。
+func TestLimiter_Allow_Concurrent(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	const (
+		limit      = 10
+		window     = time.Minute
+		key        = "rl:test:concurrent"
+		goroutines = 50
+	)
+
+	limiter := NewLimiter(rdb)
+
+	var (
+		wg              sync.WaitGroup
+		allowedCount    atomic.Int64
+		deniedCount     atomic.Int64
+		svcUnavailable  atomic.Int64
+		badRetryAfterMu sync.Mutex
+		badRetryAfters  []time.Duration
+	)
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			result := limiter.Allow(context.Background(), key, limit, window, FailClosed)
+			if result.ServiceUnavailable {
+				svcUnavailable.Add(1)
+				return
+			}
+			if result.Allowed {
+				allowedCount.Add(1)
+				return
+			}
+			deniedCount.Add(1)
+			if result.RetryAfter != window {
+				badRetryAfterMu.Lock()
+				badRetryAfters = append(badRetryAfters, result.RetryAfter)
+				badRetryAfterMu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Zero(t, svcUnavailable.Load(), "ServiceUnavailableが発生してはならない（miniredisは常に到達可能）")
+	assert.Equal(t, int64(limit), allowedCount.Load(), "許可数はちょうどlimit件になるべき")
+	assert.Equal(t, int64(goroutines-limit), deniedCount.Load(), "拒否数はgoroutines-limit件になるべき")
+	assert.Empty(t, badRetryAfters, "拒否された全リクエストのRetryAfterはwindowと一致すべき")
+}


### PR DESCRIPTION
## 概要

Closes #273

CIにカバレッジしきい値ゲートを追加し、未検証だった3コンポーネントに `go func`/`sync.WaitGroup` による本物の並行アクセステストを追加します。

## 変更内容

### 1. CIカバレッジしきい値ゲート（`.github/workflows/ci.yaml`）
- テストステップを `-cover` から `-coverprofile=coverage.out` に変更
- `go tool cover -func` の総カバレッジをしきい値 **63.0%** と比較するステップを追加（未満ならCI失敗）
- しきい値は実測値 **65.1%** の約2pt下に設定（`-race` 実行や環境差による揺らぎを吸収。カバレッジ向上時に引き上げる想定）

### 2. 並行アクセステスト（3ファイル新規）

| 対象 | テスト | 検証内容 |
|---|---|---|
| `candles.CachingRepository` | `TestCachingRepository_ConcurrentFindAndUpsert` | Find×10本/UpsertBatch×2本の並行実行で、各Find結果が単一バージョンの完全なスナップショットであること・収束後にDel→cache miss→再構築が機能すること |
| `watchlist.Repository.UpdateSortKeys` | `TestWatchlistRepository_UpdateSortKeys_Concurrent` | 8 goroutineの同時並び替えが行ロック（`LockWatchlistByUser`）で直列化され、デッドロック・UNIQUE違反なく最終状態がいずれかの順列と一致すること |
| `watchlist.Usecase.ReorderSymbols` | `TestWatchlistUsecase_ReorderSymbols_ConcurrentRemove` | Reorder連打とRemoveのTOCTOU競合時にドメインエラー（`ErrReorderCodesMismatch`/`ErrNotInWatchlist`）のみ返り、生のPGエラーが漏れないこと |
| `httpratelimit.Limiter` | `TestLimiter_Allow_Concurrent` | 50 goroutine同時 `Allow`（limit=10）でLuaスクリプトの原子性によりちょうど10件のみ許可されること |

### 3. テスト用依存の追加
- `github.com/alicebob/miniredis/v2` を追加（redismockは並行呼び出しの期待値を表現できないため）
- pure Go・Docker不要で、CIへのRedisサービス追加なしに実クライアント経由の並行検証が可能

## 検証

- `go build ./...` ✅
- 新規並行テスト4件すべて `-race` でパス（複数回実行でフレークなし）✅
- 全テストスイート `-race` でパス、総カバレッジ 65.1%（しきい値 63.0% を上回る）✅
- しきい値チェックのシェルスニペットを合格/不合格の両ケースでローカル検証 ✅
- `golangci-lint run` 0 issues ✅
- `go tool go-arch-lint check` OK ✅

## 補足

- issueが参照する `architecture-review.md` はリポジトリに存在しないため（audit skillの外部生成物）、本PRでは対応対象外です
- CachingRepositoryのSetNX/Del設計上、実行中の一時的なstale readは許容範囲のため、テストでは「読み取り結果の内部一貫性」と「収束後の整合性」のみを検証しています

🤖 Generated with [Claude Code](https://claude.com/claude-code)