### PR TITLE
docs: tblsスキーマドキュメントをフレッシュDBで再生成するスクリプトを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,19 @@ GOOSE_DRIVER=postgres GOOSE_MIGRATION_DIR=db/migrations \
   go tool goose create <snake_case_name> sql
 ```
 
+### スキーマドキュメント再生成（tbls）
+`db/migrations/` を変更した際は**必ず** `./scripts/regen-schema-docs.sh` を実行して
+`docs/schema/`（ER図・テーブル定義書）を再生成し、同じ PR でコミットしてください。
+
+```bash
+./scripts/regen-schema-docs.sh
+```
+
+起動中の開発用DB（`stock-postgres`）に対して `tbls doc` を**直接実行しないでください**。
+使い回しDBでは制約（PRIMARY KEY / FOREIGN KEY）の表示順序が非決定になり、CIの
+`Schema Doc Drift` ジョブが失敗します。詳細な理由はスクリプト冒頭のコメントおよび
+ルート `README.md` の「ER 図・テーブル定義書の生成（tbls）」を参照してください。
+
 ### sqlc コード生成
 クエリ追加・変更時に再生成します。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,19 @@ GOOSE_DRIVER=postgres GOOSE_MIGRATION_DIR=db/migrations \
   go tool goose create <snake_case_name> sql
 ```
 
+### スキーマドキュメント再生成（tbls）
+`db/migrations/` を変更した際は**必ず** `./scripts/regen-schema-docs.sh` を実行して
+`docs/schema/`（ER図・テーブル定義書）を再生成し、同じ PR でコミットしてください。
+
+```bash
+./scripts/regen-schema-docs.sh
+```
+
+起動中の開発用DB（`stock-postgres`）に対して `tbls doc` を**直接実行しないでください**。
+使い回しDBでは制約（PRIMARY KEY / FOREIGN KEY）の表示順序が非決定になり、CIの
+`Schema Doc Drift` ジョブが失敗します。詳細な理由はスクリプト冒頭のコメントおよび
+ルート `README.md` の「ER 図・テーブル定義書の生成（tbls）」を参照してください。
+
 ### sqlc コード生成
 クエリ追加・変更時に再生成します。
 

--- a/README.md
+++ b/README.md
@@ -378,30 +378,28 @@ docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps logo
 スキーマは [tbls](https://github.com/k1LoW/tbls) で稼働中の PostgreSQL から自動生成されます。
 生成物は [docs/schema/](docs/schema/) 配下にコミットされており、GitHub 上で Mermaid ER 図としてレンダリングされます。
 
-`db/migrations/` 配下のスキーマを変更したときは以下の手順で再生成します。
+`db/migrations/` 配下のスキーマを変更したときは、以下の1コマンドで再生成します。
 
 ```bash
-# 1) backend を起動（依存する db / migrate / seed が順に立ち上がり、最新スキーマが適用される）
-#    フォアグラウンドで起動し続けるので、手順 2)・3) は別ターミナルで実行する
-docker compose -f docker/docker-compose.yml -p stock up backend
-
-# 2) ER 図・テーブル定義書を再生成（docs/schema/ を上書き）
-docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --rm tbls doc --config /work/docs/tbls.yml --force
-
-# 3) 差分が残っていないか確認（CI でも同じ内容をチェックしている）
-docker compose -f docker/docker-compose.yml -p stock --profile on-demand run --rm tbls diff --config /work/docs/tbls.yml
+./scripts/regen-schema-docs.sh
 ```
 
-`backend` は `.env` や GCP ADC 等の環境が必要です。認証情報を持たない環境では、手順 1) を以下の軽量バイナリ (`cmd/migrate`) に置き換えられます（引数なしで `up` が適用されます）。
+前提: Docker（`docker` コマンドが使えること）とホストの Go（`go run ./cmd/migrate` を実行するため）。
+`.env` や GCP ADC は不要です。
 
-```bash
-# 1') db だけ起動してローカルの cmd/migrate でスキーマを反映（GCP 認証不要）
-docker compose -f docker/docker-compose.yml -p stock up -d db
-DB_HOST=localhost DB_PORT=5432 DB_USER=appuser DB_PASSWORD=apppass DB_NAME=app \
-  go run ./cmd/migrate
-```
+このスクリプトは使い捨てのPostgreSQLコンテナ（`postgres:18`）を一時起動し、
+そこにマイグレーションを一括適用してから `tbls doc --force` → `tbls diff` を実行し、
+最後に一時コンテナ・ネットワークを削除します。稼働中の開発用DB（`stock-postgres`）や
+そのボリュームには一切触れません。
 
-CI の `Schema Doc Drift` ジョブでスキーマと `docs/schema/` の乖離を検出するため、スキーマを変更した PR では必ず再生成してコミットしてください。
+**なぜフレッシュDBが必要か**: tblsは制約（PRIMARY KEY / FOREIGN KEY）をインデックスのOID順で
+取得するため、up/downを繰り返した使い回しの開発用DBではOIDの配置が異なり、論理的に同一の
+スキーマでも制約の表示順序が変わってしまいます。その状態で生成すると、毎回フレッシュなDBで
+検証している CI の `Schema Doc Drift` ジョブと意図せず食い違って失敗します。
+
+スクリプト実行後は `git diff` で `docs/schema/` の差分を確認し、意図した変更であれば
+そのままコミットしてください。CI の `Schema Doc Drift` ジョブでスキーマと `docs/schema/` の
+乖離を検出するため、スキーマを変更した PR では必ず再生成してコミットしてください。
 
 ### 補足
 

--- a/db/README.md
+++ b/db/README.md
@@ -66,6 +66,10 @@ go tool goose down
 4. ローカル PostgreSQL で `go tool goose up` → `go tool goose down` → `go tool goose up` を試し、可逆性を確認
 5. PR に含める
 
+`db/migrations/` を変更したら、`./scripts/regen-schema-docs.sh` で `docs/schema/`
+（ER図・テーブル定義書）を再生成し、同じ PR でコミットしてください。手順の詳細は
+ルート [README.md](../README.md) の「ER 図・テーブル定義書の生成（tbls）」を参照してください。
+
 ## 本番・ステージング環境での適用
 
 `docker/Dockerfile.migrate` でビルドした `migrate` バイナリを Cloud Run Job などで起動し、

--- a/scripts/regen-schema-docs.sh
+++ b/scripts/regen-schema-docs.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# docs/schema/ (tbls生成のER図・テーブル定義書) を再生成するスクリプト。
+#
+# なぜ使い回しの開発用DB（stock-postgres）ではなく毎回まっさらなDBを使うのか:
+# tblsのPostgreSQLドライバは制約（PRIMARY KEY / FOREIGN KEY）を
+# `ORDER BY cons.conindid, cons.conname` で取得しており、第1キー conindid は
+# 制約を支えるインデックスのOID＝DBの作成履歴に依存する物理的な値。
+# CIは毎回フレッシュなDBにマイグレーションを一括適用するのに対し、
+# up/down を繰り返した使い回しDBはOIDの配置が異なるため、論理的に同一の
+# スキーマでも制約の表示順序が食い違い、CIの Schema Doc Drift が
+# 意図せず失敗する。これを避けるため、本スクリプトは使い捨てのPostgreSQL
+# コンテナに対してマイグレーションを一括適用してから tbls を実行する。
+# 開発用の stock-postgres / stock_postgres_data ボリュームには一切触れない。
+set -euo pipefail
+
+# tblsのバージョンは以下3箇所を揃えること:
+#   .github/workflows/ci.yaml（schema-doc-check ジョブの k1LoW/setup-tbls）
+#   docker/docker-compose.yml（tbls サービスの ghcr.io/k1low/tbls イメージタグ）
+#   本スクリプト
+TBLS_VERSION="v1.94.4"
+
+# CIの postgres サービスコンテナ・docker-compose.yml の db サービスと揃える
+POSTGRES_IMAGE="postgres:18"
+
+# 衝突しにくい固定名（開発用の stock-postgres / stock-backend とは別名にする）
+CONTAINER_NAME="stock-tbls-regen-db"
+NETWORK_NAME="stock-tbls-regen-net"
+
+# 開発用DB（5432番）と衝突しないポート。環境変数で上書き可能。
+HOST_PORT="${REGEN_DB_PORT:-55432}"
+
+DB_USER="appuser"
+DB_PASSWORD="apppass"
+DB_NAME="app"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+cleanup() {
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker network rm "$NETWORK_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# 前回異常終了時の残骸が残っていれば先に掃除する
+cleanup
+
+echo "==> 一時ネットワーク ${NETWORK_NAME} を作成"
+docker network create "$NETWORK_NAME" >/dev/null
+
+echo "==> 使い捨てPostgreSQLコンテナ ${CONTAINER_NAME} を起動（${POSTGRES_IMAGE}, 127.0.0.1:${HOST_PORT}）"
+docker run -d \
+  --name "$CONTAINER_NAME" \
+  --network "$NETWORK_NAME" \
+  -e "POSTGRES_DB=${DB_NAME}" \
+  -e "POSTGRES_USER=${DB_USER}" \
+  -e "POSTGRES_PASSWORD=${DB_PASSWORD}" \
+  -p "127.0.0.1:${HOST_PORT}:5432" \
+  "$POSTGRES_IMAGE" >/dev/null
+
+echo "==> PostgreSQLの起動待ち"
+READY=""
+for _ in $(seq 1 30); do
+  if docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; then
+    READY="1"
+    break
+  fi
+  sleep 1
+done
+if [ -z "$READY" ]; then
+  echo "エラー: PostgreSQLが30秒以内に起動しませんでした" >&2
+  exit 1
+fi
+
+echo "==> マイグレーション適用（go run ./cmd/migrate up）"
+DB_HOST=127.0.0.1 \
+DB_PORT="$HOST_PORT" \
+DB_USER="$DB_USER" \
+DB_PASSWORD="$DB_PASSWORD" \
+DB_NAME="$DB_NAME" \
+  go run ./cmd/migrate up
+
+TBLS_DSN="postgres://${DB_USER}:${DB_PASSWORD}@${CONTAINER_NAME}:5432/${DB_NAME}?sslmode=disable"
+
+echo "==> tbls doc --force で docs/schema/ を再生成"
+docker run --rm \
+  --network "$NETWORK_NAME" \
+  -v "$REPO_ROOT":/work \
+  -w /work \
+  -e "TBLS_DSN=${TBLS_DSN}" \
+  "ghcr.io/k1low/tbls:${TBLS_VERSION}" \
+  doc --config /work/docs/tbls.yml --force
+
+echo "==> tbls diff で乖離ゼロを確認（CIと同じ検証）"
+docker run --rm \
+  --network "$NETWORK_NAME" \
+  -v "$REPO_ROOT":/work \
+  -w /work \
+  -e "TBLS_DSN=${TBLS_DSN}" \
+  "ghcr.io/k1low/tbls:${TBLS_VERSION}" \
+  diff --config /work/docs/tbls.yml
+
+echo "==> 完了: docs/schema/ を再生成しました。git diff で差分を確認してコミットしてください。"


### PR DESCRIPTION
## 概要

Closes #283

tblsで `docs/schema/` を再生成する際、生成元DBの状態によって `candles` / `watchlists` の制約（PRIMARY KEY / FOREIGN KEY）の表示順序が変わり、CIの `Schema Doc Drift` ジョブが不安定になる問題への対応です。

## 原因

tblsのPostgreSQLドライバは制約を `ORDER BY cons.conindid, cons.conname` で取得しており、第1キーの `conindid`（制約を支えるインデックスのOID）が**DBの作成履歴に依存**します。CIは毎回フレッシュなDBにマイグレーションを一括適用するのに対し、up/downを繰り返した使い回しのローカルDB（`stock-postgres`）はOID配置が異なるため、論理的に同一のスキーマでも表示順序が食い違います。

## 対応方針

Issueの解決策候補のうち「フレッシュなDBに対して再生成する運用ルール化」を採用しました。tblsの `format.sort: true` はカラムがDDL定義順でなくなる（アルファベット順になる）ため見送り、ドキュメントの見た目は現状維持としています。

## 変更内容

- **`scripts/regen-schema-docs.sh`（新規）**: 使い捨てのPostgreSQLコンテナ（`postgres:18`・127.0.0.1:55432・ボリュームなし）を一時起動し、マイグレーション一括適用 → `tbls doc --force` → `tbls diff` を実行して自動クリーンアップするスクリプト。**開発用の `stock-postgres` とそのデータには一切触れません**
- **`README.md`**: 再生成手順をスクリプト1コマンドに置き換え、フレッシュDBが必要な理由を明記
- **`db/README.md`**: マイグレーション変更時は同じPRで `docs/schema/` を再生成・コミットするルールを追記
- **`CLAUDE.md` / `AGENTS.md`**: コーディングエージェント（Claude Code / Codex）向けに、`db/migrations/` 変更時のスクリプト実行と、稼働中の開発用DBへの直接 `tbls doc` 禁止を明記

## 検証

- スクリプトを実行し、マイグレーション適用 → 生成 → `tbls diff` 乖離ゼロまで正常終了することを確認
- 実行後の `git status` で `docs/schema/` に**差分ゼロ**（フレッシュDB生成結果がコミット済みドキュメントと完全一致 = CIと同条件で再現できることの証明）
- 一時コンテナ・ネットワークの残骸なし、開発用 `stock-postgres` コンテナ・`stock_postgres_data` ボリュームが無傷であることを確認
- `bash -n` による構文チェックOK

## レビュー時の補足

- tblsのバージョン `v1.94.4` は CI（`.github/workflows/ci.yaml`）・`docker/docker-compose.yml`・本スクリプトの3箇所で揃える運用です（スクリプト内にコメントで明記）
- ホストの Go と Docker が前提です（`.env` や GCP ADC は不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)