### PR TITLE
test: セキュリティクリティカルな箇所のテストを追加（OAuthプロバイダー・stateストア・Recover・ルーター・Gemini/Vision）

### DIFF
--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -1,0 +1,245 @@
+package router_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/app/router"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/auth/authhttp"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/candles"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/candles/candleshttp"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/logodetection"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/logodetection/logodetectionhttp"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/symbollist"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/symbollist/symbollisthttp"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/watchlist"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/watchlist/watchlisthttp"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
+)
+
+const testJWTSecret = "test-jwt-secret-for-router-tests"
+
+// --- スタブ usecase 実装（ミドルウェアチェーンの検証のみが目的のため、戻り値はゼロ値でよい） ---
+
+type stubAuthUsecase struct{}
+
+func (stubAuthUsecase) Signup(_ context.Context, _, _ string) (int64, error) { return 0, nil }
+func (stubAuthUsecase) Login(_ context.Context, _, _ string) (string, error) { return "", nil }
+
+type stubOAuthUsecase struct{}
+
+func (stubOAuthUsecase) BeginAuth(_ context.Context, _ string) (string, string, error) {
+	return "", "", nil
+}
+func (stubOAuthUsecase) HandleCallback(_ context.Context, _, _, _ string) (string, error) {
+	return "", nil
+}
+
+type stubCandlesUsecase struct{}
+
+func (stubCandlesUsecase) GetCandles(_ context.Context, _, _ string, _ int) ([]candles.Candle, error) {
+	return nil, nil
+}
+
+type stubSymbolUsecase struct{}
+
+func (stubSymbolUsecase) ListActiveSymbols(_ context.Context) ([]symbollist.Symbol, error) {
+	return nil, nil
+}
+
+type stubLogoUsecase struct{}
+
+func (stubLogoUsecase) DetectLogos(_ context.Context, _ []byte) ([]logodetection.DetectedLogo, error) {
+	return nil, nil
+}
+func (stubLogoUsecase) AnalyzeCompany(_ context.Context, _ string) (*logodetection.CompanyAnalysis, error) {
+	return nil, nil
+}
+
+type stubWatchlistUsecase struct{}
+
+func (stubWatchlistUsecase) ListUserSymbols(_ context.Context, _ int64) ([]watchlist.UserSymbol, error) {
+	return nil, nil
+}
+func (stubWatchlistUsecase) AddSymbol(_ context.Context, _ int64, _ string) error { return nil }
+func (stubWatchlistUsecase) RemoveSymbol(_ context.Context, _ int64, _ string) error {
+	return nil
+}
+func (stubWatchlistUsecase) ReorderSymbols(_ context.Context, _ int64, _ []string) error {
+	return nil
+}
+
+// newTestRouter は各テストごとに独立した miniredis インスタンスを使って router.NewRouter を構築します。
+// 公開ルートは httpratelimit.FailClosed のため実 Limiter（miniredis 接続）が必要であり、
+// OpenAPIValidator は nil だと router.go 側で panic するため no-op を明示的に渡す。
+func newTestRouter(t *testing.T, oauth *authhttp.OAuthHandler) http.Handler {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	limiter := httpratelimit.NewLimiter(rdb)
+
+	noopValidator := func(next http.Handler) http.Handler { return next }
+
+	h := router.Handlers{
+		Auth:      authhttp.NewHandler(stubAuthUsecase{}, limiter, false, testJWTSecret, nil),
+		OAuth:     oauth,
+		Candles:   candleshttp.NewHandler(stubCandlesUsecase{}),
+		Symbol:    symbollisthttp.NewHandler(stubSymbolUsecase{}),
+		Logo:      logodetectionhttp.NewHandler(stubLogoUsecase{}),
+		Watchlist: watchlisthttp.NewHandler(stubWatchlistUsecase{}),
+	}
+	cfg := router.Config{
+		Limiter:          limiter,
+		OpenAPIValidator: noopValidator,
+		AllowedOrigins:   []string{"http://localhost:3000"},
+		JWTSecret:        testJWTSecret,
+	}
+	return router.NewRouter(h, cfg)
+}
+
+// validToken は保護ルートを通過できる有効な JWT を生成します。
+func validToken(t *testing.T) string {
+	t.Helper()
+	tok, err := jwt.NewGenerator(testJWTSecret, time.Hour).GenerateToken(1, "user@example.com")
+	require.NoError(t, err)
+	return tok
+}
+
+// TestNewRouter_ProtectedRoutes は保護ルート（JWT必須）がトークン有無・有効性に応じて
+// 期待どおりのステータスを返すことを検証します。
+func TestNewRouter_ProtectedRoutes(t *testing.T) {
+	t.Parallel()
+
+	oauthHandler := authhttp.NewOAuthHandler(stubOAuthUsecase{}, false, "http://localhost:3000")
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"GET candles", http.MethodGet, "/v1/candles/AAPL"},
+		{"GET symbols", http.MethodGet, "/v1/symbols"},
+		{"POST logo detect", http.MethodPost, "/v1/logo/detect"},
+		{"POST logo analyze", http.MethodPost, "/v1/logo/analyze"},
+		{"GET watchlist", http.MethodGet, "/v1/watchlist"},
+		{"POST watchlist", http.MethodPost, "/v1/watchlist"},
+		{"DELETE watchlist item", http.MethodDelete, "/v1/watchlist/AAPL"},
+		{"PUT watchlist order", http.MethodPut, "/v1/watchlist/order"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := newTestRouter(t, oauthHandler)
+
+			t.Run("error: no token returns 401", func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequest(tt.method, tt.path, nil)
+				rec := httptest.NewRecorder()
+				r.ServeHTTP(rec, req)
+				assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			})
+
+			t.Run("error: garbage bearer token returns 401", func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequest(tt.method, tt.path, nil)
+				req.Header.Set("Authorization", "Bearer invalid")
+				rec := httptest.NewRecorder()
+				r.ServeHTTP(rec, req)
+				assert.Equal(t, http.StatusUnauthorized, rec.Code)
+			})
+
+			t.Run("success: valid bearer token passes auth", func(t *testing.T) {
+				t.Parallel()
+				req := httptest.NewRequest(tt.method, tt.path, nil)
+				req.Header.Set("Authorization", "Bearer "+validToken(t))
+				rec := httptest.NewRecorder()
+				r.ServeHTTP(rec, req)
+				// スタブハンドラーは空ボディ等で 400/500 を返しうるが、401/403 でなければ
+				// 認証・CSRF チェックを通過したことの証明として十分（200 は要求しない）。
+				assert.NotEqual(t, http.StatusUnauthorized, rec.Code)
+				assert.NotEqual(t, http.StatusForbidden, rec.Code)
+			})
+		})
+	}
+}
+
+// TestNewRouter_PublicRoutes は認証不要ルートが 401/403 を返さないこと、
+// レートリミッターが正しく機能し 503（FailClosed）にならないことを検証します。
+func TestNewRouter_PublicRoutes(t *testing.T) {
+	t.Parallel()
+
+	oauthHandler := authhttp.NewOAuthHandler(stubOAuthUsecase{}, false, "http://localhost:3000")
+
+	t.Run("success: healthz returns exactly 200", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, oauthHandler)
+		req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusOK, rec.Code)
+	})
+
+	tests := []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"POST signup", http.MethodPost, "/v1/signup"},
+		{"POST login", http.MethodPost, "/v1/login"},
+		{"DELETE logout", http.MethodDelete, "/v1/logout"},
+		{"GET oauth begin", http.MethodGet, "/v1/auth/oauth/google"},
+		{"GET oauth callback", http.MethodGet, "/v1/auth/oauth/google/callback"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			r := newTestRouter(t, oauthHandler)
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, req)
+			assert.NotEqual(t, http.StatusUnauthorized, rec.Code)
+			assert.NotEqual(t, http.StatusForbidden, rec.Code)
+			assert.NotEqual(t, http.StatusServiceUnavailable, rec.Code)
+		})
+	}
+}
+
+// TestNewRouter_OAuthRoutesOptional は Handlers.OAuth が nil の場合に
+// OAuthルートが一切登録されないことを検証します。
+func TestNewRouter_OAuthRoutesOptional(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: OAuth nil disables oauth routes", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, nil)
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/oauth/google", nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+// TestNewRouter_UnknownRoute は未定義パスへのアクセスが 404 になることを検証します。
+func TestNewRouter_UnknownRoute(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, authhttp.NewOAuthHandler(stubOAuthUsecase{}, false, "http://localhost:3000"))
+	req := httptest.NewRequest(http.MethodGet, "/v1/nonexistent", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/internal/feature/auth/github_provider.go
+++ b/internal/feature/auth/github_provider.go
@@ -43,6 +43,11 @@ func (p *GitHubProvider) AuthorizationURL(state, _ string) string {
 // ExchangeCode はauthorization codeをユーザー情報に交換します。
 // GitHub APIの /user/emails で検証済みプライマリメールを、/user で数値IDを取得します。
 func (p *GitHubProvider) ExchangeCode(ctx context.Context, code, _ string) (*OAuthUserInfo, error) {
+	// oauth2ライブラリはcontextのoauth2.HTTPClientキー経由でHTTPクライアントを取得するため、
+	// ここで注入しないとp.hcのタイムアウトがトークン交換に適用されない。
+	if p.hc != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, p.hc)
+	}
 	tok, err := p.cfg.Exchange(ctx, code)
 	if err != nil {
 		return nil, fmt.Errorf("github: code exchange failed: %w", err)

--- a/internal/feature/auth/github_provider.go
+++ b/internal/feature/auth/github_provider.go
@@ -13,8 +13,10 @@ import (
 
 // GitHubProvider はOAuthProviderインターフェースのGitHub実装です。
 type GitHubProvider struct {
-	cfg *oauth2.Config
-	hc  *http.Client
+	cfg       *oauth2.Config
+	hc        *http.Client
+	emailsURL string
+	userURL   string
 }
 
 var _ OAuthProvider = (*GitHubProvider)(nil)
@@ -29,7 +31,9 @@ func NewGitHubProvider(clientID, clientSecret, redirectURL string, hc *http.Clie
 			Scopes:       []string{"user:email"},
 			Endpoint:     githuboauth.Endpoint,
 		},
-		hc: hc,
+		hc:        hc,
+		emailsURL: "https://api.github.com/user/emails",
+		userURL:   "https://api.github.com/user",
 	}
 }
 
@@ -68,7 +72,7 @@ func (p *GitHubProvider) ExchangeCode(ctx context.Context, code, _ string) (*OAu
 
 func (p *GitHubProvider) fetchPrimaryEmail(ctx context.Context, token string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"https://api.github.com/user/emails", nil)
+		p.emailsURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("github: failed to build emails request: %w", err)
 	}
@@ -108,7 +112,7 @@ func (p *GitHubProvider) fetchPrimaryEmail(ctx context.Context, token string) (s
 
 func (p *GitHubProvider) fetchUserID(ctx context.Context, token string) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"https://api.github.com/user", nil)
+		p.userURL, nil)
 	if err != nil {
 		return "", fmt.Errorf("github: failed to build user request: %w", err)
 	}

--- a/internal/feature/auth/github_provider_test.go
+++ b/internal/feature/auth/github_provider_test.go
@@ -1,0 +1,216 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// newTestGitHubProvider はhttptestサーバーに向けたGitHubProviderを生成するテスト用ヘルパーです。
+// トークンエンドポイント・emails/userエンドポイントをすべてmuxで差し替えます。
+func newTestGitHubProvider(t *testing.T, mux *http.ServeMux) *GitHubProvider {
+	t.Helper()
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	p := NewGitHubProvider("cid", "secret", "http://localhost/cb", srv.Client())
+	p.cfg.Endpoint = oauth2.Endpoint{
+		AuthURL:  srv.URL + "/auth",
+		TokenURL: srv.URL + "/token",
+	}
+	p.emailsURL = srv.URL + "/user/emails"
+	p.userURL = srv.URL + "/user"
+	return p
+}
+
+func TestGitHubProvider_AuthorizationURL(t *testing.T) {
+	t.Parallel()
+
+	p := newTestGitHubProvider(t, http.NewServeMux())
+
+	authURL := p.AuthorizationURL("test-state", "unused-challenge")
+
+	u, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	q := u.Query()
+	assert.Equal(t, "test-state", q.Get("state"))
+	assert.Equal(t, "user:email", q.Get("scope"))
+	// GitHub の OAuth App は PKCE をサポートしないため code_challenge は付与されない。
+	assert.False(t, q.Has("code_challenge"))
+}
+
+func TestGitHubProvider_ExchangeCode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: picks primary+verified email and returns numeric user ID", func(t *testing.T) {
+		t.Parallel()
+
+		var emailsAccept, emailsAPIVersion, userAccept, userAPIVersion string
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+			writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+		})
+		mux.HandleFunc("/user/emails", func(w http.ResponseWriter, r *http.Request) {
+			emailsAccept = r.Header.Get("Accept")
+			emailsAPIVersion = r.Header.Get("X-GitHub-Api-Version")
+			// primary+verified なエントリを先頭以外に配置し、選択ロジックを検証する。
+			writeJSON(w, http.StatusOK, `[
+				{"email":"other@example.com","primary":false,"verified":true},
+				{"email":"unverified@example.com","primary":true,"verified":false},
+				{"email":"gh@example.com","primary":true,"verified":true}
+			]`)
+		})
+		mux.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+			userAccept = r.Header.Get("Accept")
+			userAPIVersion = r.Header.Get("X-GitHub-Api-Version")
+			writeJSON(w, http.StatusOK, `{"id":12345}`)
+		})
+
+		p := newTestGitHubProvider(t, mux)
+
+		info, err := p.ExchangeCode(context.Background(), "auth-code", "")
+
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "12345", info.ProviderUID)
+		assert.Equal(t, "gh@example.com", info.Email)
+		assert.Equal(t, "application/vnd.github+json", emailsAccept)
+		assert.Equal(t, "2022-11-28", emailsAPIVersion)
+		assert.Equal(t, "application/vnd.github+json", userAccept)
+		assert.Equal(t, "2022-11-28", userAPIVersion)
+	})
+
+	tests := []struct {
+		name          string
+		tokenHandler  http.HandlerFunc
+		emailsHandler http.HandlerFunc
+		userHandler   http.HandlerFunc
+		wantErrSubstr string
+		wantErrIs     error
+	}{
+		{
+			name: "error: token endpoint returns 400",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `[]`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"id":1}`)
+			},
+			wantErrSubstr: "code exchange failed",
+		},
+		{
+			name: "error: emails API returns 500",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusInternalServerError, `{"error":"boom"}`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"id":1}`)
+			},
+			wantErrSubstr: "emails API returned 500",
+		},
+		{
+			name: "error: emails API returns invalid JSON",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `not-json`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"id":1}`)
+			},
+			wantErrSubstr: "failed to parse emails",
+		},
+		{
+			name: "error: no primary verified email",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `[{"email":"a@example.com","primary":false,"verified":true},{"email":"b@example.com","primary":true,"verified":false}]`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"id":1}`)
+			},
+			wantErrIs: ErrOAuthEmailUnavailable,
+		},
+		{
+			name: "error: user API returns 500",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `[{"email":"gh@example.com","primary":true,"verified":true}]`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusInternalServerError, `{"error":"boom"}`)
+			},
+			wantErrSubstr: "user API returned 500",
+		},
+		{
+			name: "error: user API returns invalid ID",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `[{"email":"gh@example.com","primary":true,"verified":true}]`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"id":0}`)
+			},
+			wantErrSubstr: "invalid ID",
+		},
+		{
+			name: "error: user API returns invalid JSON",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			emailsHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `[{"email":"gh@example.com","primary":true,"verified":true}]`)
+			},
+			userHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `not-json`)
+			},
+			wantErrSubstr: "failed to parse user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/token", tt.tokenHandler)
+			mux.HandleFunc("/user/emails", tt.emailsHandler)
+			mux.HandleFunc("/user", tt.userHandler)
+
+			p := newTestGitHubProvider(t, mux)
+
+			info, err := p.ExchangeCode(context.Background(), "auth-code", "")
+
+			require.Error(t, err)
+			assert.Nil(t, info)
+			if tt.wantErrSubstr != "" {
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+			}
+			if tt.wantErrIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrIs)
+			}
+		})
+	}
+}

--- a/internal/feature/auth/google_provider.go
+++ b/internal/feature/auth/google_provider.go
@@ -46,6 +46,11 @@ func (p *GoogleProvider) AuthorizationURL(state, codeChallenge string) string {
 // ExchangeCode はauthorization codeをユーザー情報に交換します。
 // Googleの /oauth2/v3/userinfo エンドポイントでメールアドレスを取得します。
 func (p *GoogleProvider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*OAuthUserInfo, error) {
+	// oauth2ライブラリはcontextのoauth2.HTTPClientキー経由でHTTPクライアントを取得するため、
+	// ここで注入しないとp.hcのタイムアウトがトークン交換に適用されない。
+	if p.hc != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, p.hc)
+	}
 	tok, err := p.cfg.Exchange(ctx, code,
 		oauth2.SetAuthURLParam("code_verifier", codeVerifier),
 	)

--- a/internal/feature/auth/google_provider.go
+++ b/internal/feature/auth/google_provider.go
@@ -13,8 +13,9 @@ import (
 
 // GoogleProvider はOAuthProviderインターフェースのGoogle実装です。
 type GoogleProvider struct {
-	cfg *oauth2.Config
-	hc  *http.Client
+	cfg         *oauth2.Config
+	hc          *http.Client
+	userinfoURL string
 }
 
 var _ OAuthProvider = (*GoogleProvider)(nil)
@@ -29,7 +30,8 @@ func NewGoogleProvider(clientID, clientSecret, redirectURL string, hc *http.Clie
 			Scopes:       []string{"openid", "email"},
 			Endpoint:     google.Endpoint,
 		},
-		hc: hc,
+		hc:          hc,
+		userinfoURL: "https://www.googleapis.com/oauth2/v3/userinfo",
 	}
 }
 
@@ -59,7 +61,7 @@ func (p *GoogleProvider) ExchangeCode(ctx context.Context, code, codeVerifier st
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet,
-		"https://www.googleapis.com/oauth2/v3/userinfo", nil)
+		p.userinfoURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("google: failed to build userinfo request: %w", err)
 	}

--- a/internal/feature/auth/google_provider_test.go
+++ b/internal/feature/auth/google_provider_test.go
@@ -1,0 +1,170 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// newTestGoogleProvider はhttptestサーバーに向けたGoogleProviderを生成するテスト用ヘルパーです。
+// トークンエンドポイント・userinfoエンドポイントをすべてmuxで差し替えます。
+func newTestGoogleProvider(t *testing.T, mux *http.ServeMux) *GoogleProvider {
+	t.Helper()
+
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	p := NewGoogleProvider("cid", "secret", "http://localhost/cb", srv.Client())
+	p.cfg.Endpoint = oauth2.Endpoint{
+		AuthURL:  srv.URL + "/auth",
+		TokenURL: srv.URL + "/token",
+	}
+	p.userinfoURL = srv.URL + "/userinfo"
+	return p
+}
+
+// writeJSON はテスト用ハンドラーからJSONレスポンスを返す簡易ヘルパーです。
+func writeJSON(w http.ResponseWriter, status int, body string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write([]byte(body))
+}
+
+func TestGoogleProvider_AuthorizationURL(t *testing.T) {
+	t.Parallel()
+
+	p := newTestGoogleProvider(t, http.NewServeMux())
+
+	authURL := p.AuthorizationURL("test-state", "test-challenge")
+
+	u, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	q := u.Query()
+	assert.Equal(t, "test-state", q.Get("state"))
+	assert.Equal(t, "test-challenge", q.Get("code_challenge"))
+	assert.Equal(t, "S256", q.Get("code_challenge_method"))
+	assert.Equal(t, "cid", q.Get("client_id"))
+}
+
+func TestGoogleProvider_ExchangeCode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: returns user info and forwards code/verifier/token correctly", func(t *testing.T) {
+		t.Parallel()
+
+		var gotCode, gotVerifier, gotAuthHeader string
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+			_ = r.ParseForm()
+			gotCode = r.FormValue("code")
+			gotVerifier = r.FormValue("code_verifier")
+			writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+		})
+		mux.HandleFunc("/userinfo", func(w http.ResponseWriter, r *http.Request) {
+			gotAuthHeader = r.Header.Get("Authorization")
+			writeJSON(w, http.StatusOK, `{"sub":"user-123","email":"user@example.com","email_verified":true}`)
+		})
+
+		p := newTestGoogleProvider(t, mux)
+
+		info, err := p.ExchangeCode(context.Background(), "auth-code", "verifier-abc")
+
+		require.NoError(t, err)
+		require.NotNil(t, info)
+		assert.Equal(t, "user-123", info.ProviderUID)
+		assert.Equal(t, "user@example.com", info.Email)
+		assert.Equal(t, "auth-code", gotCode)
+		assert.Equal(t, "verifier-abc", gotVerifier)
+		assert.Equal(t, "Bearer test-token", gotAuthHeader)
+	})
+
+	tests := []struct {
+		name            string
+		tokenHandler    http.HandlerFunc
+		userinfoHandler http.HandlerFunc
+		wantErrSubstr   string
+		wantErrIs       error
+	}{
+		{
+			name: "error: token endpoint returns 400",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusBadRequest, `{"error":"invalid_grant"}`)
+			},
+			userinfoHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{}`)
+			},
+			wantErrSubstr: "code exchange failed",
+		},
+		{
+			name: "error: userinfo endpoint returns 500",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			userinfoHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusInternalServerError, `{"error":"boom"}`)
+			},
+			wantErrSubstr: "userinfo API returned 500",
+		},
+		{
+			name: "error: userinfo returns invalid JSON",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			userinfoHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `not-json`)
+			},
+			wantErrSubstr: "failed to parse userinfo",
+		},
+		{
+			name: "error: email not verified",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			userinfoHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"sub":"s","email":"e@example.com","email_verified":false}`)
+			},
+			wantErrIs: ErrOAuthEmailUnavailable,
+		},
+		{
+			name: "error: email verified but empty",
+			tokenHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"access_token":"test-token","token_type":"Bearer"}`)
+			},
+			userinfoHandler: func(w http.ResponseWriter, r *http.Request) {
+				writeJSON(w, http.StatusOK, `{"sub":"s","email":"","email_verified":true}`)
+			},
+			wantErrIs: ErrOAuthEmailUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mux := http.NewServeMux()
+			mux.HandleFunc("/token", tt.tokenHandler)
+			mux.HandleFunc("/userinfo", tt.userinfoHandler)
+
+			p := newTestGoogleProvider(t, mux)
+
+			info, err := p.ExchangeCode(context.Background(), "auth-code", "verifier-abc")
+
+			require.Error(t, err)
+			assert.Nil(t, info)
+			if tt.wantErrSubstr != "" {
+				assert.ErrorContains(t, err, tt.wantErrSubstr)
+			}
+			if tt.wantErrIs != nil {
+				assert.ErrorIs(t, err, tt.wantErrIs)
+			}
+		})
+	}
+}

--- a/internal/feature/auth/oauth_state_store_test.go
+++ b/internal/feature/auth/oauth_state_store_test.go
@@ -1,0 +1,107 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestRedisOAuthStateStore はminiredisに接続したredisOAuthStateStoreを生成するテスト用ヘルパーです。
+// サブテストごとに独立したminiredisインスタンスを起動し、状態を分離します。
+func newTestRedisOAuthStateStore(t *testing.T) (*redisOAuthStateStore, *miniredis.Miniredis) {
+	t.Helper()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	return NewRedisOAuthStateStore(rdb), mr
+}
+
+func TestRedisOAuthStateStore_SaveState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: stores value under the state key with the given TTL", func(t *testing.T) {
+		t.Parallel()
+
+		store, mr := newTestRedisOAuthStateStore(t)
+
+		err := store.SaveState(context.Background(), "state-1", "verifier-1", 5*time.Minute)
+
+		require.NoError(t, err)
+		got, err := mr.Get("oauth:state:state-1")
+		require.NoError(t, err)
+		assert.Equal(t, "verifier-1", got)
+		assert.Equal(t, 5*time.Minute, mr.TTL("oauth:state:state-1"))
+	})
+
+	t.Run("error: redis is unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		store, mr := newTestRedisOAuthStateStore(t)
+		mr.Close()
+
+		err := store.SaveState(context.Background(), "state-1", "verifier-1", 5*time.Minute)
+
+		assert.Error(t, err)
+	})
+}
+
+func TestRedisOAuthStateStore_ConsumeState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success: returns and deletes the stored verifier", func(t *testing.T) {
+		t.Parallel()
+
+		store, _ := newTestRedisOAuthStateStore(t)
+		require.NoError(t, store.SaveState(context.Background(), "state-1", "verifier-1", 5*time.Minute))
+
+		got, err := store.ConsumeState(context.Background(), "state-1")
+		require.NoError(t, err)
+		assert.Equal(t, "verifier-1", got)
+
+		// 一度消費したstateはatomicに削除されているため、再度の取得はErrStateNotFoundとなる（リプレイ防止）。
+		_, err = store.ConsumeState(context.Background(), "state-1")
+		assert.ErrorIs(t, err, ErrStateNotFound)
+	})
+
+	t.Run("error: unknown state", func(t *testing.T) {
+		t.Parallel()
+
+		store, _ := newTestRedisOAuthStateStore(t)
+
+		_, err := store.ConsumeState(context.Background(), "unknown-state")
+
+		assert.ErrorIs(t, err, ErrStateNotFound)
+	})
+
+	t.Run("error: expired state", func(t *testing.T) {
+		t.Parallel()
+
+		store, mr := newTestRedisOAuthStateStore(t)
+		require.NoError(t, store.SaveState(context.Background(), "state-1", "verifier-1", 10*time.Minute))
+
+		mr.FastForward(11 * time.Minute)
+
+		_, err := store.ConsumeState(context.Background(), "state-1")
+		assert.ErrorIs(t, err, ErrStateNotFound)
+	})
+
+	t.Run("error: redis is unavailable", func(t *testing.T) {
+		t.Parallel()
+
+		store, mr := newTestRedisOAuthStateStore(t)
+		mr.Close()
+
+		_, err := store.ConsumeState(context.Background(), "state-1")
+
+		require.Error(t, err)
+		assert.ErrorContains(t, err, "state store error")
+		assert.NotErrorIs(t, err, ErrStateNotFound)
+	})
+}

--- a/internal/feature/logodetection/gemini/client_test.go
+++ b/internal/feature/logodetection/gemini/client_test.go
@@ -1,0 +1,102 @@
+package gemini
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genai"
+)
+
+// newTestGeminiAnalyzer は httptest サーバーに向いた GeminiAnalyzer を生成するヘルパーです。
+// genai SDK は BackendGeminiAPI では APIKey が必須のため、ADC を使わないダミーキーを設定します。
+// これにより本番コード（NewGeminiAnalyzer）を変更せずにテストダブルを注入できます。
+func newTestGeminiAnalyzer(t *testing.T, handler http.HandlerFunc) *GeminiAnalyzer {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client, err := genai.NewClient(context.Background(), &genai.ClientConfig{
+		Backend:    genai.BackendGeminiAPI,
+		APIKey:     "test-key",
+		HTTPClient: srv.Client(),
+		HTTPOptions: genai.HTTPOptions{
+			BaseURL: srv.URL,
+		},
+	})
+	require.NoError(t, err)
+
+	return &GeminiAnalyzer{client: client, model: DefaultModel}
+}
+
+// TestGeminiAnalyzer_Analyze は Analyze の正常系・異常系を検証します。
+//
+// resp == nil を扱うガード節は genai SDK 経由では到達不能（sendRequest がエラー時は必ず
+// err を返すため、resp が nil かつ err が nil のケースは発生しない）ためテスト対象外です。
+// また ADC（Application Default Credentials）を利用する NewGeminiAnalyzer は
+// 実クレデンシャルなしに検証できないため、意図的にテスト対象外としています。
+func TestGeminiAnalyzer_Analyze(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantText    string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name: "success: single candidate text",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Contains(t, r.URL.Path, "generateContent")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"分析結果"}]}}]}`))
+			},
+			wantText: "分析結果",
+		},
+		{
+			name: "success: multiple text parts are concatenated",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				assert.Contains(t, r.URL.Path, "generateContent")
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"candidates":[{"content":{"role":"model","parts":[{"text":"分析"},{"text":"結果"}]}}]}`))
+			},
+			wantText: "分析結果",
+		},
+		{
+			name: "error: server returns 500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_, _ = w.Write([]byte(`{"error":{"code":500,"message":"internal error","status":"INTERNAL"}}`))
+			},
+			wantErr:     true,
+			wantErrText: "gemini API request failed",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			g := newTestGeminiAnalyzer(t, tt.handler)
+
+			got, err := g.Analyze(context.Background(), "テストプロンプト")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrText)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantText, got)
+		})
+	}
+}

--- a/internal/feature/logodetection/vision/client_test.go
+++ b/internal/feature/logodetection/vision/client_test.go
@@ -1,0 +1,194 @@
+// コンストラクタ NewVisionLogoDetector は ADC（Application Default Credentials）を
+// 前提としており、実クレデンシャルなしに検証できないためテスト対象外です。
+// 本テストでは bufconn 上のフェイク gRPC サーバーに向けた VisionLogoDetector を
+// 構造体リテラルで直接組み立て、本番コードを変更せずに DetectLogos を検証します。
+package vision
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	gvision "cloud.google.com/go/vision/v2/apiv1"
+	visionpb "cloud.google.com/go/vision/v2/apiv1/visionpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/option"
+	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/logodetection"
+)
+
+// fakeImageAnnotator は visionpb.ImageAnnotatorServer のテスト用フェイク実装です。
+// BatchAnnotateImagesFunc に各テストケースの挙動を差し込みます。
+type fakeImageAnnotator struct {
+	visionpb.UnimplementedImageAnnotatorServer
+	BatchAnnotateImagesFunc  func(context.Context, *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error)
+	BatchAnnotateImagesCalls int
+}
+
+func (f *fakeImageAnnotator) BatchAnnotateImages(ctx context.Context, req *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error) {
+	f.BatchAnnotateImagesCalls++
+	return f.BatchAnnotateImagesFunc(ctx, req)
+}
+
+// newTestDetector は bufconn 上のフェイク gRPC サーバーに接続した VisionLogoDetector を生成します。
+func newTestDetector(t *testing.T, fake *fakeImageAnnotator) *VisionLogoDetector {
+	t.Helper()
+
+	const bufSize = 1024 * 1024
+	lis := bufconn.Listen(bufSize)
+
+	srv := grpc.NewServer()
+	visionpb.RegisterImageAnnotatorServer(srv, fake)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	conn, err := grpc.NewClient("passthrough:///bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	client, err := gvision.NewImageAnnotatorClient(context.Background(), option.WithGRPCConn(conn))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	return &VisionLogoDetector{client: client}
+}
+
+// TestVisionLogoDetector_DetectLogos は DetectLogos の正常系・異常系を検証します。
+func TestVisionLogoDetector_DetectLogos(t *testing.T) {
+	t.Parallel()
+
+	imageBytes := []byte("dummy-image-bytes")
+
+	t.Run("success: two logo annotations are mapped to DetectedLogo", func(t *testing.T) {
+		t.Parallel()
+
+		var gotReq *visionpb.BatchAnnotateImagesRequest
+		fake := &fakeImageAnnotator{
+			BatchAnnotateImagesFunc: func(_ context.Context, req *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error) {
+				gotReq = req
+				return &visionpb.BatchAnnotateImagesResponse{
+					Responses: []*visionpb.AnnotateImageResponse{
+						{
+							LogoAnnotations: []*visionpb.EntityAnnotation{
+								{Description: "Company A", Score: 0.95},
+								{Description: "Company B", Score: 0.80},
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		detector := newTestDetector(t, fake)
+
+		got, err := detector.DetectLogos(context.Background(), imageBytes)
+
+		require.NoError(t, err)
+		assert.Equal(t, []logodetection.DetectedLogo{
+			{Name: "Company A", Confidence: 0.95},
+			{Name: "Company B", Confidence: 0.80},
+		}, got)
+
+		require.Equal(t, 1, fake.BatchAnnotateImagesCalls)
+		require.Len(t, gotReq.Requests, 1)
+		assert.Equal(t, imageBytes, gotReq.Requests[0].Image.Content)
+		require.Len(t, gotReq.Requests[0].Features, 1)
+		assert.Equal(t, visionpb.Feature_LOGO_DETECTION, gotReq.Requests[0].Features[0].Type)
+	})
+
+	t.Run("success: zero annotations returns empty slice without error", func(t *testing.T) {
+		t.Parallel()
+
+		fake := &fakeImageAnnotator{
+			BatchAnnotateImagesFunc: func(_ context.Context, _ *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error) {
+				return &visionpb.BatchAnnotateImagesResponse{
+					Responses: []*visionpb.AnnotateImageResponse{
+						{LogoAnnotations: nil},
+					},
+				}, nil
+			},
+		}
+		detector := newTestDetector(t, fake)
+
+		got, err := detector.DetectLogos(context.Background(), imageBytes)
+
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("success: empty Responses slice returns nil without error", func(t *testing.T) {
+		t.Parallel()
+
+		fake := &fakeImageAnnotator{
+			BatchAnnotateImagesFunc: func(_ context.Context, _ *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error) {
+				return &visionpb.BatchAnnotateImagesResponse{Responses: nil}, nil
+			},
+		}
+		detector := newTestDetector(t, fake)
+
+		got, err := detector.DetectLogos(context.Background(), imageBytes)
+
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("error: Responses[0].Error is set", func(t *testing.T) {
+		t.Parallel()
+
+		fake := &fakeImageAnnotator{
+			BatchAnnotateImagesFunc: func(_ context.Context, _ *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error) {
+				return &visionpb.BatchAnnotateImagesResponse{
+					Responses: []*visionpb.AnnotateImageResponse{
+						{
+							Error: &rpcstatus.Status{
+								Code:    int32(codes.InvalidArgument),
+								Message: "bad image",
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		detector := newTestDetector(t, fake)
+
+		got, err := detector.DetectLogos(context.Background(), imageBytes)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "vision API error")
+		assert.Contains(t, err.Error(), "bad image")
+	})
+
+	t.Run("error: RPC failure returns wrapped error", func(t *testing.T) {
+		t.Parallel()
+
+		// codes.Internal はクライアント側の自動リトライ対象コード（DeadlineExceeded/Unavailable）に
+		// 含まれないため、決定的に1回で失敗させられる。
+		fake := &fakeImageAnnotator{
+			BatchAnnotateImagesFunc: func(_ context.Context, _ *visionpb.BatchAnnotateImagesRequest) (*visionpb.BatchAnnotateImagesResponse, error) {
+				return nil, status.Error(codes.Internal, "boom")
+			},
+		}
+		detector := newTestDetector(t, fake)
+
+		got, err := detector.DetectLogos(context.Background(), imageBytes)
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "vision API request failed")
+		assert.Equal(t, 1, fake.BatchAnnotateImagesCalls)
+	})
+}

--- a/internal/transport/middleware/recover_test.go
+++ b/internal/transport/middleware/recover_test.go
@@ -1,0 +1,113 @@
+package middleware
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
+)
+
+// TestRecover は Recover ミドルウェアが panic を 500 レスポンスへ変換すること、
+// panic が発生しない場合は後続ハンドラーの結果をそのまま透過させることを検証します。
+func TestRecover(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		next          http.HandlerFunc
+		wantPanicVal  any // non-nil の場合、ServeHTTP 呼び出し自体が panic することを期待する
+		wantStatus    int
+		wantErrBody   string
+		checkJSONBody bool
+	}{
+		{
+			name: "success: no panic passes status and body through unchanged",
+			next: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusTeapot)
+				_, _ = w.Write([]byte("hello"))
+			},
+			wantStatus:    http.StatusTeapot,
+			checkJSONBody: false,
+		},
+		{
+			name: "success: panic with string value returns 500 JSON error",
+			next: func(_ http.ResponseWriter, _ *http.Request) {
+				panic("something went wrong")
+			},
+			wantStatus:    http.StatusInternalServerError,
+			wantErrBody:   "internal server error",
+			checkJSONBody: true,
+		},
+		{
+			name: "success: panic with error value returns 500",
+			next: func(_ http.ResponseWriter, _ *http.Request) {
+				panic(errors.New("boom"))
+			},
+			wantStatus:    http.StatusInternalServerError,
+			wantErrBody:   "internal server error",
+			checkJSONBody: true,
+		},
+		{
+			name: "success: panic(nil) returns 500",
+			next: func(_ http.ResponseWriter, _ *http.Request) {
+				// Go 1.21+ では panic(nil) は recover() で *runtime.PanicNilError になる。
+				panic(nil) //nolint:govet // 意図的に panic(nil) の挙動を検証する
+			},
+			wantStatus:    http.StatusInternalServerError,
+			wantErrBody:   "internal server error",
+			checkJSONBody: true,
+		},
+		{
+			name: "success: panic(http.ErrAbortHandler) re-panics with the same value",
+			next: func(_ http.ResponseWriter, _ *http.Request) {
+				panic(http.ErrAbortHandler)
+			},
+			wantPanicVal: http.ErrAbortHandler,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var called bool
+			wrapped := Recover()(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				tt.next(w, r)
+			}))
+
+			req := httptest.NewRequest(http.MethodGet, "/some/path", nil)
+			rr := httptest.NewRecorder()
+
+			if tt.wantPanicVal != nil {
+				require.PanicsWithValue(t, tt.wantPanicVal, func() {
+					wrapped.ServeHTTP(rr, req)
+				})
+				assert.True(t, called, "next handler should have been invoked before panicking")
+				return
+			}
+
+			require.NotPanics(t, func() {
+				wrapped.ServeHTTP(rr, req)
+			})
+			assert.True(t, called, "next handler should have been invoked")
+			assert.Equal(t, tt.wantStatus, rr.Code)
+
+			if tt.checkJSONBody {
+				assert.Equal(t, "application/json; charset=utf-8", rr.Header().Get("Content-Type"))
+				var errResp api.ErrorResponse
+				require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &errResp))
+				assert.Equal(t, tt.wantErrBody, errResp.Error)
+				return
+			}
+
+			assert.Equal(t, "hello", rr.Body.String())
+		})
+	}
+}


### PR DESCRIPTION
## 概要

Closes #271

セキュリティクリティカルでありながらテストが存在しなかった以下の箇所に、`twelvedata/repository_test.go` と同水準の HTTP/フェイクサーバーベースのテストを追加します。あわせて、調査中に発見した OAuth トークン交換の潜在バグを修正します。

## 変更内容

### fix（潜在バグ修正）
- `google_provider.go` / `github_provider.go`: `oauth2` ライブラリは context の `oauth2.HTTPClient` キー経由で HTTP クライアントを取得するため、コンストラクタに注入した `*http.Client`（10秒タイムアウト）が**トークン交換に適用されていなかった**問題を修正。`ExchangeCode` 内で context に注入するように変更。

### refactor（テスト可能化・公開API不変）
- OAuth プロバイダーのハードコードされていた userinfo / emails / user URL を非公開フィールド化し、コンストラクタで本番デフォルトを設定。in-package テストから httptest サーバーに差し替え可能に。

### test（新規7ファイル・約1,150行）
| 対象 | 手法 | 主な検証内容 |
|---|---|---|
| Google/GitHub プロバイダー | `httptest.Server` | トークン交換・userinfo 取得の成功/失敗、PKCE パラメータ、GitHub API ヘッダー、primary+verified メール選択、`ErrOAuthEmailUnavailable` |
| OAuth state ストア | miniredis | `GetDel` によるワンタイム消費（リプレイ防止）、TTL 失効、Redis 断 |
| Recover ミドルウェア | `httptest.NewRecorder` | 500 変換・JSON ボディ・`panic(nil)`・`http.ErrAbortHandler` の同値再 panic |
| ルーター | ルート保護マトリクス | 保護8ルート×（トークンなし/不正/有効Bearer）、公開ルートの非401/403/503、OAuth ハンドラー nil 時の404 |
| Gemini クライアント | genai SDK の BaseURL 注入 | `Analyze` の成功・複数 parts 連結・500 エラー（**本番コード無改修**） |
| Vision クライアント | bufconn フェイク gRPC | リクエスト構築（画像バイト・`LOGO_DETECTION`）、レスポンス変換、APIエラー/RPC失敗（**本番コード無改修**） |

## 検証

- `go build ./...` / `go vet ./...`: クリーン
- `go test ./... -race`: 全40パッケージ成功（auth パッケージカバレッジ 77.7%）
- `golangci-lint run --timeout=5m`: 0 issues
- `go tool go-arch-lint check`: 警告なし（`_test.go` は除外対象のためテスト専用 import は影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)