### PR TITLE
fix: ロゴ検出/企業分析APIにユーザーID単位のレート制限を追加

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -544,6 +544,23 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: リクエスト過多（レートリミット超過）
+          headers:
+            Retry-After:
+              description: 再試行までの秒数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: サービス一時利用不可（レートリミット基盤障害時）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: サーバーエラー
           content:
@@ -590,6 +607,23 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "403":
           description: CSRFトークン不一致
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: リクエスト過多（レートリミット超過）
+          headers:
+            Retry-After:
+              description: 再試行までの秒数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: サービス一時利用不可（レートリミット基盤障害時）
           content:
             application/json:
               schema:

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -74,14 +74,14 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 		r.Group(func(r chi.Router) {
 			r.Use(cfg.OpenAPIValidator)
 
-			r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
+			r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.RateLimitConfig{
 				Prefix: "rl:signup:ip",
 				Limit:  5,
 				Window: 1 * time.Hour,
 				Policy: httpratelimit.FailClosed,
 			})).Post("/signup", h.Auth.Signup)
 
-			r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
+			r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.RateLimitConfig{
 				Prefix: "rl:login:ip",
 				Limit:  10,
 				Window: 1 * time.Minute,
@@ -95,7 +95,7 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 			if h.OAuth != nil {
 				r.Route("/auth/oauth", func(r chi.Router) {
 					r.Get("/{provider}", h.OAuth.BeginAuth)
-					r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.IPRateLimitConfig{
+					r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.RateLimitConfig{
 						Prefix: "rl:oauth:callback:ip",
 						Limit:  20,
 						Window: 1 * time.Minute,
@@ -115,8 +115,21 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 
 			r.Get("/candles/{code}", h.Candles.GetCandlesHandler)
 			r.Get("/symbols", h.Symbol.List)
-			r.Post("/logo/detect", h.Logo.DetectLogos)
-			r.Post("/logo/analyze", h.Logo.AnalyzeCompany)
+
+			// Vision/Gemini API は従量課金のため、ユーザー単位で1日あたりの呼び出し回数を制限する。
+			r.With(httpratelimit.ByUserID(cfg.Limiter, httpratelimit.RateLimitConfig{
+				Prefix: "rl:logo:detect:user",
+				Limit:  10,
+				Window: 24 * time.Hour,
+				Policy: httpratelimit.FailClosed,
+			})).Post("/logo/detect", h.Logo.DetectLogos)
+
+			r.With(httpratelimit.ByUserID(cfg.Limiter, httpratelimit.RateLimitConfig{
+				Prefix: "rl:logo:analyze:user",
+				Limit:  10,
+				Window: 24 * time.Hour,
+				Policy: httpratelimit.FailClosed,
+			})).Post("/logo/analyze", h.Logo.AnalyzeCompany)
 			r.Get("/watchlist", h.Watchlist.List)
 			r.Post("/watchlist", h.Watchlist.Add)
 			r.Delete("/watchlist/{code}", h.Watchlist.Remove)

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -108,10 +108,16 @@ func newTestRouter(t *testing.T, oauth *authhttp.OAuthHandler) http.Handler {
 	return router.NewRouter(h, cfg)
 }
 
-// validToken は保護ルートを通過できる有効な JWT を生成します。
+// validToken は保護ルートを通過できる有効な JWT（userID=1）を生成します。
 func validToken(t *testing.T) string {
 	t.Helper()
-	tok, err := jwt.NewGenerator(testJWTSecret, time.Hour).GenerateToken(1, "user@example.com")
+	return tokenForUser(t, 1)
+}
+
+// tokenForUser は指定した userID で保護ルートを通過できる有効な JWT を生成します。
+func tokenForUser(t *testing.T, userID int64) string {
+	t.Helper()
+	tok, err := jwt.NewGenerator(testJWTSecret, time.Hour).GenerateToken(userID, "user@example.com")
 	require.NoError(t, err)
 	return tok
 }
@@ -242,4 +248,58 @@ func TestNewRouter_UnknownRoute(t *testing.T) {
 	rec := httptest.NewRecorder()
 	r.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+// TestNewRouter_LogoRateLimit は /v1/logo/detect・/v1/logo/analyze がユーザーID単位で
+// 1日10回にレートリミットされること、エンドポイントごと・ユーザーごとに独立したバケットで
+// カウントされることを検証します。
+// 同一ルーターインスタンスへの逐次リクエストでカウント順序を検証するため、
+// リクエストを発行するサブテストは t.Parallel() を使わない。
+func TestNewRouter_LogoRateLimit(t *testing.T) {
+	t.Parallel()
+
+	r := newTestRouter(t, nil)
+
+	postLogoDetect := func(t *testing.T, token string) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/logo/detect", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	postLogoAnalyze := func(t *testing.T, token string) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/logo/analyze", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	tokenUser1 := tokenForUser(t, 1)
+
+	t.Run("success: 10回までは429にならない", func(t *testing.T) {
+		for i := 0; i < 10; i++ {
+			code := postLogoDetect(t, tokenUser1)
+			assert.NotEqual(t, http.StatusTooManyRequests, code, "リクエスト%d回目で429になってはいけない", i+1)
+		}
+	})
+
+	t.Run("error: 11回目は429になる", func(t *testing.T) {
+		code := postLogoDetect(t, tokenUser1)
+		assert.Equal(t, http.StatusTooManyRequests, code)
+	})
+
+	t.Run("success: 別ユーザーは独立したバケットで429にならない", func(t *testing.T) {
+		tokenUser2 := tokenForUser(t, 2)
+		code := postLogoDetect(t, tokenUser2)
+		assert.NotEqual(t, http.StatusTooManyRequests, code)
+	})
+
+	t.Run("success: エンドポイントごとに別バケットのため429にならない", func(t *testing.T) {
+		code := postLogoAnalyze(t, tokenUser1)
+		assert.NotEqual(t, http.StatusTooManyRequests, code)
+	})
 }

--- a/internal/transport/httpratelimit/middleware.go
+++ b/internal/transport/httpratelimit/middleware.go
@@ -9,10 +9,11 @@ import (
 
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/api"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
-// IPRateLimitConfig はIPベースのレートリミットの設定を保持します。
-type IPRateLimitConfig struct {
+// RateLimitConfig はレートリミットの設定を保持します（キー方式に依存しない共通設定）。
+type RateLimitConfig struct {
 	Prefix string        // Redisキーのプレフィックス（例: "rl:login:ip"）
 	Limit  int           // ウィンドウ内の最大リクエスト数
 	Window time.Duration // スライディングウィンドウの時間幅
@@ -22,8 +23,30 @@ type IPRateLimitConfig struct {
 	Policy Policy
 }
 
+// writeRateLimitResult は Allow() の結果に応じて 503/429 レスポンスを書き込む共通処理です。
+// ログ属性はキー方式ごとに異なるため、呼び出し側から logType と追加の slog 属性を受け取ります。
+// 許可された場合は何も書き込みません（呼び出し側が next.ServeHTTP を続行します）。
+func writeRateLimitResult(w http.ResponseWriter, result Result, logType string, logArgs ...any) {
+	if result.ServiceUnavailable {
+		slog.Error("rate limiter unavailable, rejecting request",
+			append([]any{"type", logType}, logArgs...)...,
+		)
+		httpx.WriteJSON(w, http.StatusServiceUnavailable, api.ErrorResponse{
+			Error: "service temporarily unavailable",
+		})
+		return
+	}
+	slog.Warn("rate limit exceeded",
+		append([]any{"type", logType}, logArgs...)...,
+	)
+	w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
+	httpx.WriteJSON(w, http.StatusTooManyRequests, api.ErrorResponse{
+		Error: "too many requests",
+	})
+}
+
 // ByIP はIPアドレスベースのレートリミットミドルウェアを返します。
-func ByIP(limiter *Limiter, cfg IPRateLimitConfig) func(http.Handler) http.Handler {
+func ByIP(limiter *Limiter, cfg RateLimitConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ip := httpx.ClientIP(r)
@@ -31,26 +54,36 @@ func ByIP(limiter *Limiter, cfg IPRateLimitConfig) func(http.Handler) http.Handl
 			result := limiter.Allow(r.Context(), key, cfg.Limit, cfg.Window, cfg.Policy)
 
 			if !result.Allowed {
-				if result.ServiceUnavailable {
-					slog.Error("rate limiter unavailable, rejecting request",
-						"type", "ip",
-						"ip", ip,
-						"prefix", cfg.Prefix,
-					)
-					httpx.WriteJSON(w, http.StatusServiceUnavailable, api.ErrorResponse{
-						Error: "service temporarily unavailable",
-					})
-					return
-				}
-				slog.Warn("rate limit exceeded",
-					"type", "ip",
-					"ip", ip,
+				writeRateLimitResult(w, result, "ip", "ip", ip, "prefix", cfg.Prefix)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// ByUserID は認証済みユーザーIDベースのレートリミットミドルウェアを返します。
+// jwt.AuthRequired より後段に配置する必要があります。
+func ByUserID(limiter *Limiter, cfg RateLimitConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID, ok := jwt.UserIDFromContext(r.Context())
+			if !ok {
+				slog.Error("rate limiter: user id not found in context (AuthRequired must run before ByUserID)",
+					"type", "user",
 					"prefix", cfg.Prefix,
 				)
-				w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
-				httpx.WriteJSON(w, http.StatusTooManyRequests, api.ErrorResponse{
-					Error: "too many requests",
+				httpx.WriteJSON(w, http.StatusInternalServerError, api.ErrorResponse{
+					Error: "internal server error",
 				})
+				return
+			}
+
+			key := fmt.Sprintf("%s:%d", cfg.Prefix, userID)
+			result := limiter.Allow(r.Context(), key, cfg.Limit, cfg.Window, cfg.Policy)
+
+			if !result.Allowed {
+				writeRateLimitResult(w, result, "user", "user_id", userID, "prefix", cfg.Prefix)
 				return
 			}
 			next.ServeHTTP(w, r)

--- a/internal/transport/httpratelimit/middleware_test.go
+++ b/internal/transport/httpratelimit/middleware_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/go-redis/redismock/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
 // okHandler はレートリミットを通過した場合に呼ばれる終端ハンドラーです。
@@ -37,7 +39,7 @@ func TestByIP_Allowed(t *testing.T) {
 	setupEvalMock(mock, "rl:test:ip:192.0.2.1", 1, 0) // allowed=1, count=0
 
 	limiter := NewLimiter(rdb)
-	cfg := IPRateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: window, Policy: FailOpen}
+	cfg := RateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: window, Policy: FailOpen}
 
 	called := false
 	h := ByIP(limiter, cfg)(okHandler(&called))
@@ -64,7 +66,7 @@ func TestByIP_RateLimited(t *testing.T) {
 	setupEvalMock(mock, "rl:test:ip:192.0.2.1", 0, 10) // allowed=0, count=10 (at limit)
 
 	limiter := NewLimiter(rdb)
-	cfg := IPRateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: window, Policy: FailOpen}
+	cfg := RateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: window, Policy: FailOpen}
 
 	handlerCalled := false
 	h := ByIP(limiter, cfg)(okHandler(&handlerCalled))
@@ -95,7 +97,7 @@ func TestByIP_NilRedis_Allowed(t *testing.T) {
 	t.Parallel()
 
 	limiter := NewLimiter(nil)
-	cfg := IPRateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: time.Minute, Policy: FailOpen}
+	cfg := RateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: time.Minute, Policy: FailOpen}
 
 	called := false
 	h := ByIP(limiter, cfg)(okHandler(&called))
@@ -115,7 +117,7 @@ func TestByIP_NilRedis_FailClosed_ServiceUnavailable(t *testing.T) {
 	t.Parallel()
 
 	limiter := NewLimiter(nil)
-	cfg := IPRateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: time.Minute, Policy: FailClosed}
+	cfg := RateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: time.Minute, Policy: FailClosed}
 
 	called := false
 	h := ByIP(limiter, cfg)(okHandler(&called))
@@ -135,7 +137,7 @@ func TestByIP_NilRedis_FailClosed_ServiceUnavailable(t *testing.T) {
 	assert.Equal(t, "service temporarily unavailable", body["error"])
 }
 
-// TestByIP_DefaultPolicy_FailClosed はIPRateLimitConfig.Policyを未指定（ゼロ値）のまま
+// TestByIP_DefaultPolicy_FailClosed はRateLimitConfig.Policyを未指定（ゼロ値）のまま
 // Redisクライアントがnilの場合に、secure by defaultの方針によりゼロ値がFailClosedとして
 // 扱われ、ハンドラーを呼ばずに503を返すことを検証します。Policyの指定漏れが安全側（拒否）に
 // 倒れることそのものが主眼です。
@@ -144,7 +146,7 @@ func TestByIP_DefaultPolicy_FailClosed(t *testing.T) {
 
 	limiter := NewLimiter(nil)
 	// Policyフィールドを意図的に指定しない（ゼロ値のまま）。
-	cfg := IPRateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: time.Minute}
+	cfg := RateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: time.Minute}
 
 	called := false
 	h := ByIP(limiter, cfg)(okHandler(&called))
@@ -176,7 +178,7 @@ func TestByIP_RedisError_FailClosed_ServiceUnavailable(t *testing.T) {
 	setupEvalErrorMock(mock, "rl:test:ip:192.0.2.1", fmt.Errorf("connection refused"))
 
 	limiter := NewLimiter(rdb)
-	cfg := IPRateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: window, Policy: FailClosed}
+	cfg := RateLimitConfig{Prefix: "rl:test:ip", Limit: 10, Window: window, Policy: FailClosed}
 
 	handlerCalled := false
 	h := ByIP(limiter, cfg)(okHandler(&handlerCalled))
@@ -196,4 +198,167 @@ func TestByIP_RedisError_FailClosed_ServiceUnavailable(t *testing.T) {
 	assert.Equal(t, "service temporarily unavailable", body["error"])
 
 	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// newUserRequest はcontextに認証済みユーザーIDを注入したリクエストを生成します。
+func newUserRequest(userID int64) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/test", nil)
+	if userID != 0 {
+		req = req.WithContext(jwt.WithUserID(req.Context(), userID))
+	}
+	return req
+}
+
+// TestByUserID_Allowed はレートリミット内のリクエストがハンドラーまで到達し200を返すことを検証します。
+func TestByUserID_Allowed(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	window := 24 * time.Hour
+	setupEvalMock(mock, "rl:test:user:1", 1, 0) // allowed=1, count=0
+
+	limiter := NewLimiter(rdb)
+	cfg := RateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: window, Policy: FailOpen}
+
+	called := false
+	h := ByUserID(limiter, cfg)(okHandler(&called))
+
+	req := newUserRequest(1)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called, "ハンドラーが呼ばれるべき")
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestByUserID_RateLimited はレートリミット超過時に429とRetry-Afterヘッダーが返され、
+// ハンドラーが呼ばれないことを検証します。
+func TestByUserID_RateLimited(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	window := 24 * time.Hour
+	setupEvalMock(mock, "rl:test:user:1", 0, 10) // allowed=0, count=10 (at limit)
+
+	limiter := NewLimiter(rdb)
+	cfg := RateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: window, Policy: FailOpen}
+
+	handlerCalled := false
+	h := ByUserID(limiter, cfg)(okHandler(&handlerCalled))
+
+	req := newUserRequest(1)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.False(t, handlerCalled, "ハンドラーは呼ばれるべきではない")
+	assert.Equal(t, "86400", w.Header().Get("Retry-After"))
+
+	var body map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "too many requests", body["error"])
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestByUserID_IndependentCountPerUser はユーザーごとにカウントが独立していることを検証します。
+// userID=1が超過状態でも、userID=2は別バケットとして通過することを確認します。
+func TestByUserID_IndependentCountPerUser(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	window := 24 * time.Hour
+	setupEvalMock(mock, "rl:test:user:1", 0, 10) // userID=1: 超過
+	setupEvalMock(mock, "rl:test:user:2", 1, 0)  // userID=2: 未使用
+
+	limiter := NewLimiter(rdb)
+	cfg := RateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: window, Policy: FailOpen}
+
+	h := ByUserID(limiter, cfg)(okHandler(nil))
+
+	w1 := httptest.NewRecorder()
+	h.ServeHTTP(w1, newUserRequest(1))
+	assert.Equal(t, http.StatusTooManyRequests, w1.Code)
+
+	w2 := httptest.NewRecorder()
+	h.ServeHTTP(w2, newUserRequest(2))
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}
+
+// TestByUserID_NoUserIDInContext はcontextにユーザーIDが無い場合（AuthRequiredより前段に
+// 配置された設定ミス等）に500を返すことを検証します。
+func TestByUserID_NoUserIDInContext(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewLimiter(nil)
+	cfg := RateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: time.Minute, Policy: FailOpen}
+
+	called := false
+	h := ByUserID(limiter, cfg)(okHandler(&called))
+
+	req := httptest.NewRequest(http.MethodPost, "/test", nil) // userIDを注入しない
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.False(t, called, "ハンドラーは呼ばれるべきではない")
+
+	var body map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "internal server error", body["error"])
+}
+
+// TestByUserID_NilRedis_FailClosed_ServiceUnavailable はRedisクライアントがnilかつ
+// Policy=FailClosedの場合、ハンドラーを呼ばずに503を返すことを検証します。
+func TestByUserID_NilRedis_FailClosed_ServiceUnavailable(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewLimiter(nil)
+	cfg := RateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: time.Minute, Policy: FailClosed}
+
+	called := false
+	h := ByUserID(limiter, cfg)(okHandler(&called))
+
+	req := newUserRequest(1)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.False(t, called, "ハンドラーは呼ばれるべきではない")
+	assert.Empty(t, w.Header().Get("Retry-After"), "Retry-Afterヘッダーは付与しない")
+
+	var body map[string]string
+	err := json.Unmarshal(w.Body.Bytes(), &body)
+	require.NoError(t, err)
+	assert.Equal(t, "service temporarily unavailable", body["error"])
+}
+
+// TestByUserID_NilRedis_FailOpen_Allowed はRedisクライアントがnilかつPolicy=FailOpenを
+// 明示指定した場合にミドルウェアがリクエストを通過させることを検証します。
+func TestByUserID_NilRedis_FailOpen_Allowed(t *testing.T) {
+	t.Parallel()
+
+	limiter := NewLimiter(nil)
+	cfg := RateLimitConfig{Prefix: "rl:test:user", Limit: 10, Window: time.Minute, Policy: FailOpen}
+
+	called := false
+	h := ByUserID(limiter, cfg)(okHandler(&called))
+
+	req := newUserRequest(1)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, called, "ハンドラーが呼ばれるべき")
 }


### PR DESCRIPTION
## 概要
`/v1/logo/detect`・`/v1/logo/analyze` はJWT認証済みだがレート制限がなく、Vision/Gemini API（従量課金）の呼び出しコストが青天井だった。認証済みユーザーIDをキーとするレート制限（10回/日/ユーザー/エンドポイント）を追加し、コスト上限を設ける。

## 変更内容
- `httpratelimit` に認証済みユーザーIDをキーとする `ByUserID` ミドルウェアを新規追加
  - `jwt.UserIDFromContext` でユーザーIDを取得（`jwt.AuthRequired` の後段に配置する前提。取得できない場合は設定ミスとして 500 を返す）
  - 超過時 429 + `Retry-After` / Redis 障害時は `FailClosed` により 503（既存 `ByIP` と同一挙動）
- `IPRateLimitConfig` をキー方式に依存しない `RateLimitConfig` にリネームし、429/503 レスポンス書き込みを `ByIP` と共通化
- `router.go` で `/logo/detect`・`/logo/analyze` に各 10回/24h・ユーザー単位・独立バケットで適用
- OpenAPI 仕様（`api/openapi.yaml`）に両エンドポイントの 429/503 レスポンスを追記（`go generate` の型生成に差分なし）

### issue 原案（ByIP）から変更した理由
デプロイ先の Cloud Run ではリクエストがプロキシ経由で届き、`httpx.ClientIP`（`RemoteAddr` 参照）では実クライアントIPが取れず「全ユーザー共有の1バケツ」になる可能性が高い。対象ルートは認証済みで userID が利用できるため、ユーザーID単位を採用した。既存 signup/login の ByIP に関する同問題は #309 に切り分け済み。

## 関連issue
- closes #262
- refs #309

## テスト
- `ByUserID` の単体テスト追加（通過 / 429 + Retry-After / ユーザーごとの独立カウント / context に userID なしで 500 / Redis 未接続時の FailClosed 503・FailOpen 通過）
- ルーターの回帰テスト `TestNewRouter_LogoRateLimit` 追加（miniredis 使用。10回目まで通過・11回目 429・別ユーザー独立・エンドポイント別バケット）
- `go build ./...` / 対象パッケージの `go test -race` / `golangci-lint run` / `go tool go-arch-lint check` すべて成功

## レビューポイント
- 制限値 10回/日・`FailClosed`（Redis 障害時は拒否）の妥当性
- クライアント側（フロントエンド）で 429 受信時のハンドリングが必要になる点

🤖 Generated with [Claude Code](https://claude.com/claude-code)