### PR TITLE
refactor: ファイル内の関数をトップダウン順に整列

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,20 @@ vertical slice として、各フィーチャーは**HTTP 読み取り**と**バ
 
 **注意**: Goの慣例に従い、**リポジトリインターフェースは利用者側のファイル**（`usecase.go` / `<name>http/handler.go`）で定義します。別途 domain/repository ディレクトリには配置しません。
 
+### ファイル内の関数の並び順（トップダウン整列）
+
+同一ファイル内の関数は、Go の慣例（新聞記事的なトップダウン）に従い、**呼ぶ側を先に・呼ばれる側を後に**、
+**公開（大文字始まり）を先に・非公開ヘルパー（小文字始まり）を後に**並べます。読み手が上から下へ
+読み進めれば理解できる順序にし、非公開ヘルパーを探して上へ戻らせないようにします。
+
+- 型定義・コンストラクタ（`New*`）→ 公開API（エントリポイント）→ それらが使う非公開ヘルパー、の順
+- 例: `internal/feature/auth/authhttp/handler.go` は
+  `NewHandler` → `Signup` → `Login` → `Logout` → `setAuthCookie`（ヘルパーは末尾）
+- 例: `internal/feature/candles/ingest.go` は
+  `NewIngestUsecase` → `IngestAll`（公開エントリ）→ `ingestOne` → `dedupCandles`
+- 例外: 複数の公開関数から共有される小さなキー生成ヘルパー等（`stateKey` / `blacklistKey` 等）は、
+  コンストラクタ直後に置く定石を許容します
+
 ### 依存関係ルール（go-arch-lint で強制）
 
 `.go-arch-lint.yml` で**デフォルト拒否**の宣言式に強制します（`go tool go-arch-lint check`）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,20 @@ vertical slice として、各フィーチャーは**HTTP 読み取り**と**バ
 
 **注意**: Goの慣例に従い、**リポジトリインターフェースは利用者側のファイル**（`usecase.go` / `<name>http/handler.go`）で定義します。別途 domain/repository ディレクトリには配置しません。
 
+### ファイル内の関数の並び順（トップダウン整列）
+
+同一ファイル内の関数は、Go の慣例（新聞記事的なトップダウン）に従い、**呼ぶ側を先に・呼ばれる側を後に**、
+**公開（大文字始まり）を先に・非公開ヘルパー（小文字始まり）を後に**並べます。読み手が上から下へ
+読み進めれば理解できる順序にし、非公開ヘルパーを探して上へ戻らせないようにします。
+
+- 型定義・コンストラクタ（`New*`）→ 公開API（エントリポイント）→ それらが使う非公開ヘルパー、の順
+- 例: `internal/feature/auth/authhttp/handler.go` は
+  `NewHandler` → `Signup` → `Login` → `Logout` → `setAuthCookie`（ヘルパーは末尾）
+- 例: `internal/feature/candles/ingest.go` は
+  `NewIngestUsecase` → `IngestAll`（公開エントリ）→ `ingestOne` → `dedupCandles`
+- 例外: 複数の公開関数から共有される小さなキー生成ヘルパー等（`stateKey` / `blacklistKey` 等）は、
+  コンストラクタ直後に置く定石を許容します
+
 ### 依存関係ルール（go-arch-lint で強制）
 
 `.go-arch-lint.yml` で**デフォルト拒否**の宣言式に強制します（`go tool go-arch-lint check`）。

--- a/internal/app/batch/batch.go
+++ b/internal/app/batch/batch.go
@@ -19,17 +19,6 @@ var jobs = map[string]func(*config.Config) int{
 	"logo":    runLogoIngest,   // ロゴURL取り込み
 }
 
-// supportedJobs は対応している job_id を辞書順で連結した文字列を返す（エラーメッセージ用）。
-// map のイテレーション順は非決定的なので、ソートして出力を安定させる。
-func supportedJobs() string {
-	keys := make([]string, 0, len(jobs))
-	for k := range jobs {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return strings.Join(keys, ", ")
-}
-
 // Run は job_id（コマンド引数）に応じてバッチを実行し、終了コードを返す。
 // candles: 株価取り込み、logo: ロゴURL取り込み。
 // 環境変数から読み込んだ設定は cfg として注入される。
@@ -45,4 +34,15 @@ func Run(cfg *config.Config, args []string) int {
 		return 2
 	}
 	return job(cfg)
+}
+
+// supportedJobs は対応している job_id を辞書順で連結した文字列を返す（エラーメッセージ用）。
+// map のイテレーション順は非決定的なので、ソートして出力を安定させる。
+func supportedJobs() string {
+	keys := make([]string, 0, len(jobs))
+	for k := range jobs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
 }

--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -17,21 +17,6 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
 
-// setAuthCookie は SameSite=Lax の認証関連 Cookie をレスポンスへ設定します。
-// auth_token / csrf_token の設定・削除に共通利用します。
-// maxAge は秒数（削除時は -1）です。
-func setAuthCookie(w http.ResponseWriter, name, value string, maxAge int, secure, httpOnly bool) {
-	http.SetCookie(w, &http.Cookie{
-		Name:     name,
-		Value:    value,
-		Path:     "/",
-		MaxAge:   maxAge,
-		Secure:   secure,
-		HttpOnly: httpOnly,
-		SameSite: http.SameSiteLaxMode,
-	})
-}
-
 // Usecase は認証操作のユースケースを定義します。
 // Goの慣例に従い、インターフェースはプロバイダー（usecase）ではなくコンシューマー（handler）が定義します。
 type Usecase interface {
@@ -177,4 +162,19 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 	setAuthCookie(w, "csrf_token", "", -1, h.secureCookie, false)
 
 	httpx.WriteJSON(w, http.StatusOK, api.MessageResponse{Message: "ok"})
+}
+
+// setAuthCookie は SameSite=Lax の認証関連 Cookie をレスポンスへ設定します。
+// auth_token / csrf_token の設定・削除に共通利用します。
+// maxAge は秒数（削除時は -1）です。
+func setAuthCookie(w http.ResponseWriter, name, value string, maxAge int, secure, httpOnly bool) {
+	http.SetCookie(w, &http.Cookie{
+		Name:     name,
+		Value:    value,
+		Path:     "/",
+		MaxAge:   maxAge,
+		Secure:   secure,
+		HttpOnly: httpOnly,
+		SameSite: http.SameSiteLaxMode,
+	})
 }

--- a/internal/feature/auth/usecase.go
+++ b/internal/feature/auth/usecase.go
@@ -128,17 +128,6 @@ func (u *usecase) pepperPassword(password string) string {
 	return hex.EncodeToString(mac.Sum(nil))
 }
 
-// validatePassword はパスワードがセキュリティ要件を満たしているかチェックします。
-func validatePassword(password string) error {
-	if len(password) < minPasswordLength {
-		return fmt.Errorf("password must be at least %d characters long", minPasswordLength)
-	}
-	if len(password) > maxPasswordLength {
-		return fmt.Errorf("password must be at most %d characters long", maxPasswordLength)
-	}
-	return nil
-}
-
 // Signup はハッシュ化されたパスワードで新規ユーザーを登録します。
 // 成功時に作成されたユーザーのIDを返します。
 func (u *usecase) Signup(ctx context.Context, email, password string) (int64, error) {
@@ -204,4 +193,15 @@ func (u *usecase) Login(ctx context.Context, email, password string) (string, er
 	}
 
 	return token, nil
+}
+
+// validatePassword はパスワードがセキュリティ要件を満たしているかチェックします。
+func validatePassword(password string) error {
+	if len(password) < minPasswordLength {
+		return fmt.Errorf("password must be at least %d characters long", minPasswordLength)
+	}
+	if len(password) > maxPasswordLength {
+		return fmt.Errorf("password must be at most %d characters long", maxPasswordLength)
+	}
+	return nil
 }

--- a/internal/feature/candles/ingest.go
+++ b/internal/feature/candles/ingest.go
@@ -77,6 +77,40 @@ func NewIngestUsecase(market MarketRepository, candle WriteRepository, symbol Sy
 	return &IngestUsecase{market: market, candle: candle, symbol: symbol, rateLimiter: rateLimiter}
 }
 
+// IngestAll はアクティブな全銘柄の時系列データを取得し、
+// 日足・週足・月足をデータベースに永続化します。
+// APIレート制限を遵守し、必要に応じてリクエスト間で待機します。
+//
+// 銘柄単位の失敗は IngestResult に集約され処理は継続します。
+// 致命的エラー（symbol 一覧取得失敗、ctx キャンセル、rateLimiter 失敗）は
+// それまでの部分集計と共に error を返します。
+func (iu *IngestUsecase) IngestAll(ctx context.Context) (IngestResult, error) {
+	symbols, err := iu.symbol.ListActiveSymbols(ctx)
+	if err != nil {
+		return IngestResult{}, err
+	}
+
+	result := IngestResult{Total: len(symbols)}
+	for _, s := range symbols {
+		// WaitIfNeeded は limit 未到達なら cancelled ctx でも nil を返すため、
+		// ループごとに明示的に ctx をチェックして早期離脱する。
+		if err := ctx.Err(); err != nil {
+			return result, err
+		}
+		if err := iu.rateLimiter.WaitIfNeeded(ctx); err != nil {
+			return result, err
+		}
+		if err := iu.ingestOne(ctx, s, ingestOutputSize); err != nil {
+			// 1銘柄のエラーで処理を停止せず、エラーをログに記録して続行
+			slog.Error("failed to ingest data", "symbol", s.Code, "error", err)
+			result.Failed++
+			continue
+		}
+		result.Succeeded++
+	}
+	return result, nil
+}
+
 // ingestOne は指定された銘柄の日足データを外部リポジトリから取得し、
 // 週足・月足を集計して3種まとめてデータベースにバッチ挿入（または更新）します。
 // sym.Timezone は IANA タイムゾーン文字列で、外部 API レスポンスの解釈および
@@ -135,38 +169,4 @@ func dedupCandles(candles []Candle) []Candle {
 		}
 	}
 	return out
-}
-
-// IngestAll はアクティブな全銘柄の時系列データを取得し、
-// 日足・週足・月足をデータベースに永続化します。
-// APIレート制限を遵守し、必要に応じてリクエスト間で待機します。
-//
-// 銘柄単位の失敗は IngestResult に集約され処理は継続します。
-// 致命的エラー（symbol 一覧取得失敗、ctx キャンセル、rateLimiter 失敗）は
-// それまでの部分集計と共に error を返します。
-func (iu *IngestUsecase) IngestAll(ctx context.Context) (IngestResult, error) {
-	symbols, err := iu.symbol.ListActiveSymbols(ctx)
-	if err != nil {
-		return IngestResult{}, err
-	}
-
-	result := IngestResult{Total: len(symbols)}
-	for _, s := range symbols {
-		// WaitIfNeeded は limit 未到達なら cancelled ctx でも nil を返すため、
-		// ループごとに明示的に ctx をチェックして早期離脱する。
-		if err := ctx.Err(); err != nil {
-			return result, err
-		}
-		if err := iu.rateLimiter.WaitIfNeeded(ctx); err != nil {
-			return result, err
-		}
-		if err := iu.ingestOne(ctx, s, ingestOutputSize); err != nil {
-			// 1銘柄のエラーで処理を停止せず、エラーをログに記録して続行
-			slog.Error("failed to ingest data", "symbol", s.Code, "error", err)
-			result.Failed++
-			continue
-		}
-		result.Succeeded++
-	}
-	return result, nil
 }

--- a/internal/infra/db/config.go
+++ b/internal/infra/db/config.go
@@ -81,19 +81,6 @@ func (c Config) Validate() error {
 	return nil
 }
 
-// quotePGValue は libpq の key=value 形式で安全に値を埋め込めるようエスケープします。
-// 値に空白・'='・シングルクオート・バックスラッシュが含まれる場合、または空値の場合は
-// シングルクオートで囲み、内部の '\' と '\” をエスケープします。
-// 参考: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-KEYWORD-VALUE
-func quotePGValue(v string) string {
-	if v == "" || strings.ContainsAny(v, " \t\n\r='\\") {
-		escaped := strings.ReplaceAll(v, `\`, `\\`)
-		escaped = strings.ReplaceAll(escaped, `'`, `\'`)
-		return "'" + escaped + "'"
-	}
-	return v
-}
-
 // BuildDSN は設定からPostgreSQL DSN文字列を構築します。
 // InstanceNameが設定されている場合はCloud SQL Unixソケット接続を作成します。
 // それ以外の場合はHostとPortを使用してTCP接続を作成します。
@@ -118,4 +105,17 @@ func BuildDSN(cfg Config) string {
 		quotePGValue(string(cfg.Password)),
 		quotePGValue(cfg.Name),
 		quotePGValue(sslMode))
+}
+
+// quotePGValue は libpq の key=value 形式で安全に値を埋め込めるようエスケープします。
+// 値に空白・'='・シングルクオート・バックスラッシュが含まれる場合、または空値の場合は
+// シングルクオートで囲み、内部の '\' と '\” をエスケープします。
+// 参考: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-KEYWORD-VALUE
+func quotePGValue(v string) string {
+	if v == "" || strings.ContainsAny(v, " \t\n\r='\\") {
+		escaped := strings.ReplaceAll(v, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `'`, `\'`)
+		return "'" + escaped + "'"
+	}
+	return v
 }

--- a/internal/transport/httpratelimit/middleware.go
+++ b/internal/transport/httpratelimit/middleware.go
@@ -23,28 +23,6 @@ type RateLimitConfig struct {
 	Policy Policy
 }
 
-// writeRateLimitResult は Allow() の結果に応じて 503/429 レスポンスを書き込む共通処理です。
-// ログ属性はキー方式ごとに異なるため、呼び出し側から logType と追加の slog 属性を受け取ります。
-// 許可された場合は何も書き込みません（呼び出し側が next.ServeHTTP を続行します）。
-func writeRateLimitResult(w http.ResponseWriter, result Result, logType string, logArgs ...any) {
-	if result.ServiceUnavailable {
-		slog.Error("rate limiter unavailable, rejecting request",
-			append([]any{"type", logType}, logArgs...)...,
-		)
-		httpx.WriteJSON(w, http.StatusServiceUnavailable, api.ErrorResponse{
-			Error: "service temporarily unavailable",
-		})
-		return
-	}
-	slog.Warn("rate limit exceeded",
-		append([]any{"type", logType}, logArgs...)...,
-	)
-	w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
-	httpx.WriteJSON(w, http.StatusTooManyRequests, api.ErrorResponse{
-		Error: "too many requests",
-	})
-}
-
 // ByIP はIPアドレスベースのレートリミットミドルウェアを返します。
 func ByIP(limiter *Limiter, cfg RateLimitConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -89,4 +67,26 @@ func ByUserID(limiter *Limiter, cfg RateLimitConfig) func(http.Handler) http.Han
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// writeRateLimitResult は Allow() の結果に応じて 503/429 レスポンスを書き込む共通処理です。
+// ログ属性はキー方式ごとに異なるため、呼び出し側から logType と追加の slog 属性を受け取ります。
+// 許可された場合は何も書き込みません（呼び出し側が next.ServeHTTP を続行します）。
+func writeRateLimitResult(w http.ResponseWriter, result Result, logType string, logArgs ...any) {
+	if result.ServiceUnavailable {
+		slog.Error("rate limiter unavailable, rejecting request",
+			append([]any{"type", logType}, logArgs...)...,
+		)
+		httpx.WriteJSON(w, http.StatusServiceUnavailable, api.ErrorResponse{
+			Error: "service temporarily unavailable",
+		})
+		return
+	}
+	slog.Warn("rate limit exceeded",
+		append([]any{"type", logType}, logArgs...)...,
+	)
+	w.Header().Set("Retry-After", strconv.Itoa(int(result.RetryAfter.Seconds())))
+	httpx.WriteJSON(w, http.StatusTooManyRequests, api.ErrorResponse{
+		Error: "too many requests",
+	})
 }

--- a/internal/transport/jwt/middleware.go
+++ b/internal/transport/jwt/middleware.go
@@ -29,16 +29,6 @@ func ExtractToken(r *http.Request) (tokenStr, authSource string) {
 	return "", ""
 }
 
-// parseToken はJWT署名を検証し、HMACアルゴリズムで署名されたトークンのみを受理します。
-func parseToken(secret, tokenStr string) (*gojwt.Token, error) {
-	return gojwt.Parse(tokenStr, func(t *gojwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*gojwt.SigningMethodHMAC); !ok {
-			return nil, gojwt.ErrSignatureInvalid
-		}
-		return []byte(secret), nil
-	})
-}
-
 // AuthRequired はJWTトークンを検証し、認証済みユーザーのみにアクセスを制限するミドルウェアを返します。
 // 認証はCookie（auth_token）を優先し、存在しない場合はAuthorizationヘッダーにフォールバックします。
 // 署名シークレットは起動時に注入されます（環境変数の読み込みは internal/app/config に集約）。
@@ -95,6 +85,16 @@ func AuthRequired(secret string, blacklist *Blacklist) func(http.Handler) http.H
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// parseToken はJWT署名を検証し、HMACアルゴリズムで署名されたトークンのみを受理します。
+func parseToken(secret, tokenStr string) (*gojwt.Token, error) {
+	return gojwt.Parse(tokenStr, func(t *gojwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*gojwt.SigningMethodHMAC); !ok {
+			return nil, gojwt.ErrSignatureInvalid
+		}
+		return []byte(secret), nil
+	})
 }
 
 // parseSubject はJWT subjectをユーザーIDへ変換します。


### PR DESCRIPTION
## 概要

同一ファイル内の関数の並び順を Go の慣例（新聞記事的なトップダウン: **呼ぶ側を先に・呼ばれる側を後に**、**公開APIを先に・非公開ヘルパーを後に**）に沿って整列しました。非公開ヘルパーが呼び出し元の公開関数より前に定義されており、読み手が下から上へ戻って読む必要があった箇所を解消します。

**ロジックは一切変更せず、関数ブロックの位置のみ移動しています。**（純粋な移動: +116 / −116 行）

## 変更内容

| ファイル | 移動した関数 |
|---|---|
| `transport/httpratelimit/middleware.go` | `writeRateLimitResult` を末尾へ |
| `feature/auth/authhttp/handler.go` | `setAuthCookie` を末尾へ |
| `feature/candles/ingest.go` | 公開 `IngestAll` を `NewIngestUsecase` 直後へ |
| `infra/db/config.go` | `quotePGValue` を `BuildDSN` の後ろへ |
| `app/batch/batch.go` | `supportedJobs` を `Run` の後ろへ |
| `transport/jwt/middleware.go` | `parseToken` を `AuthRequired` の後ろへ |
| `feature/auth/usecase.go` | `validatePassword` を `Login` の後ろへ（`pepperPassword` は据え置き） |

あわせて `CLAUDE.md` / `AGENTS.md` にこの並び順ルールを明文化しました。

### 対象外
`oauth_state_store.go` / `jwt/blacklist.go` は「キー生成ヘルパーをコンストラクタ直後に置く」定石イディオムのため据え置いています（ドキュメントにも例外として記載）。

## 検証

- `go build ./...` ✅
- `gofmt -l` / `go vet` ✅ 差分なし
- 対象パッケージのテスト（auth / candles / infra/db / batch / jwt）✅ 全て `ok`
- `golangci-lint run` ✅ `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)