### PR TITLE
chore: go mod tidy でVisionテストの直接依存を反映

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,10 @@ require (
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
+	google.golang.org/api v0.287.1
 	google.golang.org/genai v1.64.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7
+	google.golang.org/grpc v1.82.0
 )
 
 require (
@@ -191,11 +194,8 @@ require (
 	golang.org/x/tools v0.47.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gonum.org/v1/plot v0.12.0 // indirect
-	google.golang.org/api v0.287.1 // indirect
 	google.golang.org/genproto v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260630182238-925bb5da69e7 // indirect
-	google.golang.org/grpc v1.82.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
## 概要

`internal/feature/logodetection/vision/client_test.go`（フェイクサーバーを用いた Vision クライアントのユニットテスト）が以下のパッケージを直接 import しているため、`go mod tidy` によって `// indirect` から直接依存の require ブロックへ昇格させました。

- `google.golang.org/api`（`api/option`）
- `google.golang.org/grpc`（`grpc`, `grpc/codes`, `grpc/credentials/insecure`）
- `google.golang.org/genproto/googleapis/rpc`（`rpc/status`）

`go.mod` のみの変更で、`go.sum` に差分はありません。`go mod tidy` を再実行しても同一の `go.mod` になる安定した状態です。

## 検証

- `go mod tidy` 冪等（再実行しても差分なし）✅
- `go.sum` 変更なし ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)