### PR TITLE
fix: IPレート制限のCloud Run対応（X-Forwarded-For解決）とOAuth BeginAuthへの制限追加

### DIFF
--- a/.github/workflows/cd-api.yaml
+++ b/.github/workflows/cd-api.yaml
@@ -61,7 +61,7 @@ jobs:
                     --region "${{ env.REGION }}" \
                     --platform managed \
                     --allow-unauthenticated \
-                    --set-env-vars=GIN_MODE=release \
+                    --set-env-vars=GIN_MODE=release,TRUSTED_PROXY_HOPS=1 \
                     --service-account "${{ env.RUNTIME_SERVICE_ACCOUNT }}" \
                     --add-cloudsql-instances "${{ secrets.INSTANCE_CONNECTION_NAME_FOR_DEPLOY }}" \
                     --vpc-connector run-connector \

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -164,6 +164,7 @@ func run() int {
 			JWTSecret:        cfg.Server.JWTSecret,
 			Blacklist:        jwtBlacklist,
 			SecureCookie:     cfg.Server.SecureCookie,
+			TrustedProxyHops: cfg.Server.TrustedProxyHops,
 		},
 	)
 

--- a/docker/example.env
+++ b/docker/example.env
@@ -28,6 +28,14 @@ RUN_MIGRATIONS=true
 # CORS（許可するオリジン、カンマ区切りで複数指定可。未設定時は http://localhost:3000）
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
+# 信頼するリバースプロキシの段数（任意。0 以上の整数。未設定時は 0）
+# X-Forwarded-For ヘッダーのうち、右から何番目のエントリを実クライアントIPとして
+# 信頼するかを指定する（httpratelimit.ByIP のバケット分割に使用）。
+# 0: XFF を一切信頼せず RemoteAddr のみ使用（ローカル直アクセス向け）
+# 1: Cloud Run 直公開（Google Front End が唯一の信頼できるプロキシ）
+# 2: 前段に外部ロードバランサーを追加した場合
+# TRUSTED_PROXY_HOPS=0
+
 # JWT
 # 32 バイト以上必須（未満だと起動時に fail-fast し終了コード 2）。
 # 生成例: openssl rand -base64 48

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -71,6 +71,9 @@ type ServerConfig struct {
 	SecureCookie   bool
 	CORSOrigins    []string
 	GCPProjectID   string // GOOGLE_CLOUD_PROJECT。未設定可（トレース相関に使用）
+	// TrustedProxyHops は X-Forwarded-For を信頼するリバースプロキシの段数。
+	// middleware.RealIP に渡す。0（デフォルト）なら XFF を一切信頼しない。
+	TrustedProxyHops int
 }
 
 // BatchConfig はバッチ実行のタイムアウト・失敗率しきい値です。
@@ -207,12 +210,15 @@ func readServer(warn *[]string) (ServerConfig, error) {
 		corsOrigins = []string{defaultCORSOrigin}
 	}
 
+	trustedProxyHops := readNonNegativeInt("TRUSTED_PROXY_HOPS", warn)
+
 	return ServerConfig{
-		JWTSecret:      jwtSecret,
-		PasswordPepper: passwordPepper,
-		SecureCookie:   secureCookie,
-		CORSOrigins:    corsOrigins,
-		GCPProjectID:   os.Getenv("GOOGLE_CLOUD_PROJECT"),
+		JWTSecret:        jwtSecret,
+		PasswordPepper:   passwordPepper,
+		SecureCookie:     secureCookie,
+		CORSOrigins:      corsOrigins,
+		GCPProjectID:     os.Getenv("GOOGLE_CLOUD_PROJECT"),
+		TrustedProxyHops: trustedProxyHops,
 	}, nil
 }
 
@@ -300,6 +306,23 @@ func readInt(key string, warn *[]string) int {
 	n, err := strconv.Atoi(v)
 	if err != nil || n <= 0 {
 		*warn = append(*warn, fmt.Sprintf("invalid int for %s=%q, using default", key, v))
+		return 0
+	}
+	return n
+}
+
+// readNonNegativeInt は env の 0 以上の整数を読み取ります。未設定なら 0 を返します
+// （警告なし。TRUSTED_PROXY_HOPS 等、0 が正当なデフォルト値である項目向け）。
+// readInt は n<=0 を不正値として扱うため、0 を許容する本ヘルパーを別途用意しています。
+// 不正値（非整数・負数）の場合は警告を蓄積して 0 を返します。
+func readNonNegativeInt(key string, warn *[]string) int {
+	v := os.Getenv(key)
+	if v == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		*warn = append(*warn, fmt.Sprintf("invalid non-negative int for %s=%q, using default 0", key, v))
 		return 0
 	}
 	return n

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -43,6 +43,44 @@ func TestReadInt(t *testing.T) {
 	}
 }
 
+// TestReadNonNegativeInt は readNonNegativeInt の未設定（0）・0・正常値・不正値
+// （警告蓄積して 0）の各ケースを検証します。
+func TestReadNonNegativeInt(t *testing.T) {
+	const key = "TEST_READ_NON_NEGATIVE_INT"
+
+	tests := []struct {
+		name     string
+		set      bool
+		value    string
+		want     int
+		wantWarn bool
+	}{
+		{name: "未設定なら 0", set: false, want: 0, wantWarn: false},
+		{name: "0 は正常値", set: true, value: "0", want: 0, wantWarn: false},
+		{name: "正の整数は正常値", set: true, value: "2", want: 2, wantWarn: false},
+		{name: "非整数は警告して 0", set: true, value: "abc", want: 0, wantWarn: true},
+		{name: "負数は警告して 0", set: true, value: "-1", want: 0, wantWarn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.set {
+				t.Setenv(key, tt.value)
+			} else {
+				t.Setenv(key, "")
+			}
+			var warn []string
+			got := readNonNegativeInt(key, &warn)
+			if got != tt.want {
+				t.Errorf("readNonNegativeInt = %d, want %d", got, tt.want)
+			}
+			if (len(warn) > 0) != tt.wantWarn {
+				t.Errorf("warn = %v, wantWarn %v", warn, tt.wantWarn)
+			}
+		})
+	}
+}
+
 // TestReadDuration は readDuration の未設定（0）・正常・不正値（警告蓄積して 0）の各ケースを検証します。
 func TestReadDuration(t *testing.T) {
 	const key = "TEST_READ_DURATION"

--- a/internal/app/config/load_test.go
+++ b/internal/app/config/load_test.go
@@ -26,6 +26,7 @@ func clearServerEnv(t *testing.T) {
 		"GITHUB_CLIENT_SECRET",
 		"GITHUB_REDIRECT_URL",
 		"OAUTH_FRONTEND_REDIRECT_URL",
+		"TRUSTED_PROXY_HOPS",
 	} {
 		t.Setenv(k, "")
 	}
@@ -125,6 +126,56 @@ func TestLoadAPI(t *testing.T) {
 		}
 		if cfg.Server.SecureCookie {
 			t.Error("secureCookie should fall back to false")
+		}
+	})
+
+	t.Run("TRUSTED_PROXY_HOPS 未設定は0", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
+
+		cfg, err := LoadAPI()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Server.TrustedProxyHops != 0 {
+			t.Errorf("TrustedProxyHops = %d, want 0", cfg.Server.TrustedProxyHops)
+		}
+		if len(cfg.Warnings) != 0 {
+			t.Errorf("expected no warnings, got %v", cfg.Warnings)
+		}
+	})
+
+	t.Run("TRUSTED_PROXY_HOPS 正常値を読み込む", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
+		t.Setenv("TRUSTED_PROXY_HOPS", "1")
+
+		cfg, err := LoadAPI()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Server.TrustedProxyHops != 1 {
+			t.Errorf("TrustedProxyHops = %d, want 1", cfg.Server.TrustedProxyHops)
+		}
+	})
+
+	t.Run("TRUSTED_PROXY_HOPS 不正値はWarningsに記録し0にフォールバック", func(t *testing.T) {
+		clearServerEnv(t)
+		t.Setenv(jwt.EnvKeyJWTSecret, validSecret)
+		t.Setenv(auth.EnvKeyPasswordPepper, validSecret)
+		t.Setenv("TRUSTED_PROXY_HOPS", "-1")
+
+		cfg, err := LoadAPI()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Server.TrustedProxyHops != 0 {
+			t.Errorf("TrustedProxyHops = %d, want 0", cfg.Server.TrustedProxyHops)
+		}
+		if len(cfg.Warnings) == 0 {
+			t.Error("expected a warning for invalid TRUSTED_PROXY_HOPS")
 		}
 	})
 }

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -41,6 +41,9 @@ type Config struct {
 	Blacklist *jwt.Blacklist
 	// SecureCookie が true（本番・TLS終端）のとき HSTS ヘッダーを有効化する。
 	SecureCookie bool
+	// TrustedProxyHops は httpmw.RealIP に渡す、X-Forwarded-For を信頼するプロキシ段数。
+	// 0（デフォルト）なら XFF を信頼せず RemoteAddr のみを使用する。
+	TrustedProxyHops int
 }
 
 // NewRouter はすべてのアプリケーションルートを設定したHTTPハンドラー（chiルーター）を生成します。
@@ -48,6 +51,11 @@ type Config struct {
 // h.OAuth が nil の場合はOAuthルートを登録しません。
 func NewRouter(h Handlers, cfg Config) http.Handler {
 	r := chi.NewRouter()
+
+	// RealIP を最初に置き、X-Forwarded-For から解決したクライアントIPを
+	// 以降のミドルウェア（AccessLog のログ出力・レートリミッターのキー生成）が
+	// httpx.ClientIP 経由で参照できるようにする。
+	r.Use(httpmw.RealIP(cfg.TrustedProxyHops))
 
 	// AccessLog を外側、Recover を内側に置くことで、panic を 500 に変換した結果も
 	// アクセスログに記録される。

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -102,7 +102,12 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 			// OAuthルート（環境変数が設定されている場合のみ登録）
 			if h.OAuth != nil {
 				r.Route("/auth/oauth", func(r chi.Router) {
-					r.Get("/{provider}", h.OAuth.BeginAuth)
+					r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.RateLimitConfig{
+						Prefix: "rl:oauth:begin:ip",
+						Limit:  20,
+						Window: 1 * time.Minute,
+						Policy: httpratelimit.FailClosed,
+					})).Get("/{provider}", h.OAuth.BeginAuth)
 					r.With(httpratelimit.ByIP(cfg.Limiter, httpratelimit.RateLimitConfig{
 						Prefix: "rl:oauth:callback:ip",
 						Limit:  20,

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -81,8 +81,14 @@ func (stubWatchlistUsecase) ReorderSymbols(_ context.Context, _ int64, _ []strin
 // newTestRouter は各テストごとに独立した miniredis インスタンスを使って router.NewRouter を構築します。
 // 公開ルートは httpratelimit.FailClosed のため実 Limiter（miniredis 接続）が必要であり、
 // OpenAPIValidator は nil だと router.go 側で panic するため no-op を明示的に渡す。
-func newTestRouter(t *testing.T, oauth *authhttp.OAuthHandler) http.Handler {
+// trustedHops は省略可（省略時は 0 = X-Forwarded-For を信頼しない）。
+func newTestRouter(t *testing.T, oauth *authhttp.OAuthHandler, trustedHops ...int) http.Handler {
 	t.Helper()
+
+	hops := 0
+	if len(trustedHops) > 0 {
+		hops = trustedHops[0]
+	}
 
 	mr := miniredis.RunT(t)
 	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
@@ -104,6 +110,7 @@ func newTestRouter(t *testing.T, oauth *authhttp.OAuthHandler) http.Handler {
 		OpenAPIValidator: noopValidator,
 		AllowedOrigins:   []string{"http://localhost:3000"},
 		JWTSecret:        testJWTSecret,
+		TrustedProxyHops: hops,
 	}
 	return router.NewRouter(h, cfg)
 }
@@ -301,5 +308,50 @@ func TestNewRouter_LogoRateLimit(t *testing.T) {
 	t.Run("success: エンドポイントごとに別バケットのため429にならない", func(t *testing.T) {
 		code := postLogoAnalyze(t, tokenUser1)
 		assert.NotEqual(t, http.StatusTooManyRequests, code)
+	})
+}
+
+// TestNewRouter_TrustedProxyHops は TrustedProxyHops の設定に応じて
+// httpmw.RealIP が X-Forwarded-For を解決し、レートリミッターのバケット分割
+// （httpx.ClientIP 経由のキー生成）に反映されることを検証します。
+func TestNewRouter_TrustedProxyHops(t *testing.T) {
+	t.Parallel()
+
+	postSignup := func(t *testing.T, r http.Handler, xff string) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/signup", nil)
+		if xff != "" {
+			req.Header.Set("X-Forwarded-For", xff)
+		}
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	t.Run("hops=0はXFFを無視しRemoteAddr単位で共有バケットになる", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, nil, 0)
+
+		for i := 0; i < 5; i++ {
+			code := postSignup(t, r, "203.0.113.1")
+			assert.NotEqual(t, http.StatusTooManyRequests, code)
+		}
+		// 別のXFF値でも RemoteAddr は同一（httptest既定値）のため同じバケットで429になる。
+		code := postSignup(t, r, "203.0.113.2")
+		assert.Equal(t, http.StatusTooManyRequests, code)
+	})
+
+	t.Run("hops=1はXFF末尾のIPごとに独立したバケットになる", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, nil, 1)
+
+		for i := 0; i < 5; i++ {
+			code := postSignup(t, r, "203.0.113.1")
+			assert.NotEqual(t, http.StatusTooManyRequests, code)
+		}
+		// 上限に達しているため同一IPはさらに429になる。
+		assert.Equal(t, http.StatusTooManyRequests, postSignup(t, r, "203.0.113.1"))
+		// 別のクライアントIPは独立したバケットのため429にならない。
+		assert.NotEqual(t, http.StatusTooManyRequests, postSignup(t, r, "203.0.113.2"))
 	})
 }

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -311,6 +311,37 @@ func TestNewRouter_LogoRateLimit(t *testing.T) {
 	})
 }
 
+// TestNewRouter_OAuthBeginAuthRateLimit は issue #270 対応: /v1/auth/oauth/{provider}
+// （BeginAuth）が Callback と同じ IP 単位 20回/分でレートリミットされることを検証します。
+// 同一ルーターインスタンスへの逐次リクエストでカウント順序を検証するため、
+// リクエストを発行するサブテストは t.Parallel() を使わない。
+func TestNewRouter_OAuthBeginAuthRateLimit(t *testing.T) {
+	t.Parallel()
+
+	oauthHandler := authhttp.NewOAuthHandler(stubOAuthUsecase{}, false, "http://localhost:3000")
+	r := newTestRouter(t, oauthHandler)
+
+	getBeginAuth := func(t *testing.T) int {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodGet, "/v1/auth/oauth/google", nil)
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		return rec.Code
+	}
+
+	t.Run("success: 20回までは429にならない", func(t *testing.T) {
+		for i := 0; i < 20; i++ {
+			code := getBeginAuth(t)
+			assert.NotEqual(t, http.StatusTooManyRequests, code, "リクエスト%d回目で429になってはいけない", i+1)
+		}
+	})
+
+	t.Run("error: 21回目は429になる", func(t *testing.T) {
+		code := getBeginAuth(t)
+		assert.Equal(t, http.StatusTooManyRequests, code)
+	})
+}
+
 // TestNewRouter_TrustedProxyHops は TrustedProxyHops の設定に応じて
 // httpmw.RealIP が X-Forwarded-For を解決し、レートリミッターのバケット分割
 // （httpx.ClientIP 経由のキー生成）に反映されることを検証します。

--- a/internal/transport/httpx/httpx.go
+++ b/internal/transport/httpx/httpx.go
@@ -3,10 +3,15 @@
 package httpx
 
 import (
+	"context"
 	"encoding/json"
 	"net"
 	"net/http"
 )
+
+// clientIPKey は context に解決済みクライアント IP を格納する際のキー型です。
+// 他パッケージのキーと衝突しないよう非公開の型にします。
+type clientIPKey struct{}
 
 // WriteJSON は status コードと共に v を JSON としてレスポンスへ書き込みます。
 // エンコードに失敗した場合はステータス設定後のため
@@ -29,10 +34,23 @@ func DecodeJSON(r *http.Request, dst any) error {
 	return json.NewDecoder(r.Body).Decode(dst)
 }
 
+// WithClientIP は解決済みのクライアント IP を context に格納します。
+// X-Forwarded-For の解決は middleware.RealIP が行い、その結果をここで
+// context に載せることで、以降のハンドラー・ミドルウェアが ClientIP 経由で
+// 参照できるようにします（httpx 自身はプロキシヘッダーを解釈しません）。
+func WithClientIP(ctx context.Context, ip string) context.Context {
+	return context.WithValue(ctx, clientIPKey{}, ip)
+}
+
 // ClientIP はリクエスト元のIPアドレスを返します。
-// X-Forwarded-For 等のプロキシヘッダーは信頼せず、TCP接続元（RemoteAddr）の
-// ホスト部のみを返します。
+// context に middleware.RealIP が解決したIPが格納されていればそれを返し、
+// なければ TCP接続元（RemoteAddr）のホスト部にフォールバックします。
+// X-Forwarded-For 等のプロキシヘッダー自体はここでは解釈しません
+// （信頼するプロキシ段数に基づく解釈は middleware.RealIP の責務です）。
 func ClientIP(r *http.Request) string {
+	if ip, ok := r.Context().Value(clientIPKey{}).(string); ok && ip != "" {
+		return ip
+	}
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {
 		// ポートが付与されていない場合は RemoteAddr をそのまま返す。

--- a/internal/transport/httpx/httpx_test.go
+++ b/internal/transport/httpx/httpx_test.go
@@ -1,0 +1,55 @@
+package httpx
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestClientIP は ClientIP が context 格納済みIPを優先し、
+// 未格納の場合は RemoteAddr にフォールバックすることを検証します。
+func TestClientIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		remoteAddr   string
+		contextIP    string // 空文字なら context に格納しない
+		wantClientIP string
+	}{
+		{
+			name:         "context にIPがあればそれを返す",
+			remoteAddr:   "203.0.113.9:12345",
+			contextIP:    "198.51.100.7",
+			wantClientIP: "198.51.100.7",
+		},
+		{
+			name:         "context が空なら RemoteAddr のホスト部を返す",
+			remoteAddr:   "203.0.113.9:12345",
+			contextIP:    "",
+			wantClientIP: "203.0.113.9",
+		},
+		{
+			name:         "RemoteAddr にポートがなければそのまま返す",
+			remoteAddr:   "203.0.113.9",
+			contextIP:    "",
+			wantClientIP: "203.0.113.9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			if tt.contextIP != "" {
+				req = req.WithContext(WithClientIP(req.Context(), tt.contextIP))
+			}
+
+			assert.Equal(t, tt.wantClientIP, ClientIP(req))
+		})
+	}
+}

--- a/internal/transport/middleware/realip.go
+++ b/internal/transport/middleware/realip.go
@@ -1,0 +1,74 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
+)
+
+// RealIP は X-Forwarded-For ヘッダーから実クライアントIPを解決し、
+// httpx.WithClientIP で context に格納するミドルウェアを返します。
+//
+// trustedHops は「信頼できるリバースプロキシの段数」です。Cloud Run に直接公開する
+// 構成では Google Front End (GFE) が唯一の信頼できるプロキシであり、GFE は受け取った
+// リクエストの X-Forwarded-For 末尾に実クライアントIPを追記するため trustedHops=1 を
+// 設定します。将来、GFE の手前に外部ロードバランサーを追加すればプロキシが1段増えるため
+// trustedHops=2 とします。
+//
+// X-Forwarded-For の値は「クライアント, プロキシ1, プロキシ2, ...」の順（左が古い）で
+// 各ホップが手前の値の右側に自身が観測した送信元を追記していく想定のため、信頼できる
+// プロキシが n 段なら実クライアントIPは右から n 番目のエントリになります。
+// クライアントが偽装した X-Forwarded-For を送っても、信頼するプロキシがその右側に
+// 自身の観測値を追記する限り、偽装エントリは右から n 番目より左に押し出されるため
+// 改ざんできません（信頼できないプロキシの外側にクライアントを直接到達させない前提）。
+//
+// trustedHops <= 0 の場合は X-Forwarded-For を一切信頼せず、何もしないパススルーを返します
+// （httpx.ClientIP は RemoteAddr にフォールバックします）。
+func RealIP(trustedHops int) func(http.Handler) http.Handler {
+	if trustedHops <= 0 {
+		return func(next http.Handler) http.Handler {
+			return next
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ip, ok := resolveClientIP(r, trustedHops); ok {
+				r = r.WithContext(httpx.WithClientIP(r.Context(), ip))
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// resolveClientIP はリクエストの全 X-Forwarded-For ヘッダー値を結合し、
+// 右から trustedHops 番目のエントリを実クライアントIPとして返します。
+// エントリ数が不足する場合や該当エントリが不正なIPの場合は ok=false を返します。
+func resolveClientIP(r *http.Request, trustedHops int) (ip string, ok bool) {
+	xff := r.Header.Values("X-Forwarded-For")
+	if len(xff) == 0 {
+		return "", false
+	}
+
+	var entries []string
+	for _, line := range xff {
+		for _, part := range strings.Split(line, ",") {
+			if trimmed := strings.TrimSpace(part); trimmed != "" {
+				entries = append(entries, trimmed)
+			}
+		}
+	}
+
+	idx := len(entries) - trustedHops
+	if idx < 0 || idx >= len(entries) {
+		return "", false
+	}
+
+	candidate := entries[idx]
+	if net.ParseIP(candidate) == nil {
+		return "", false
+	}
+	return candidate, true
+}

--- a/internal/transport/middleware/realip_test.go
+++ b/internal/transport/middleware/realip_test.go
@@ -1,0 +1,103 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpx"
+)
+
+// TestRealIP は trustedHops の値ごとに X-Forwarded-For の解決結果・フォールバック挙動を検証します。
+func TestRealIP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		trustedHops int
+		remoteAddr  string
+		xff         []string // 複数指定すると複数の X-Forwarded-For ヘッダー行として送る
+		wantIP      string
+	}{
+		{
+			name:        "hops=0はXFFがあってもRemoteAddrを使う",
+			trustedHops: 0,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4, 5.6.7.8, 203.0.113.7"},
+			wantIP:      "10.0.0.1",
+		},
+		{
+			name:        "hops=1はXFF末尾を採用する（偽装エントリは無視）",
+			trustedHops: 1,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4, 5.6.7.8, 203.0.113.7"},
+			wantIP:      "203.0.113.7",
+		},
+		{
+			name:        "hops=2は右から2番目を採用する",
+			trustedHops: 2,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4, 5.6.7.8, 203.0.113.7"},
+			wantIP:      "5.6.7.8",
+		},
+		{
+			name:        "エントリ数が不足する場合はRemoteAddrにフォールバックする",
+			trustedHops: 5,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4, 5.6.7.8, 203.0.113.7"},
+			wantIP:      "10.0.0.1",
+		},
+		{
+			name:        "該当エントリが不正なIPならRemoteAddrにフォールバックする",
+			trustedHops: 1,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4, not-an-ip"},
+			wantIP:      "10.0.0.1",
+		},
+		{
+			name:        "複数のXFFヘッダー行は結合して評価する",
+			trustedHops: 1,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4", "5.6.7.8, 203.0.113.7"},
+			wantIP:      "203.0.113.7",
+		},
+		{
+			name:        "IPv6のXFFエントリも解決できる",
+			trustedHops: 1,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         []string{"1.2.3.4, 2001:db8::1"},
+			wantIP:      "2001:db8::1",
+		},
+		{
+			name:        "XFFヘッダーがない場合はRemoteAddrにフォールバックする",
+			trustedHops: 1,
+			remoteAddr:  "10.0.0.1:1234",
+			xff:         nil,
+			wantIP:      "10.0.0.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotIP string
+			next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				gotIP = httpx.ClientIP(r)
+			})
+
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tt.remoteAddr
+			for _, v := range tt.xff {
+				req.Header.Add("X-Forwarded-For", v)
+			}
+			w := httptest.NewRecorder()
+
+			RealIP(tt.trustedHops)(next).ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantIP, gotIP)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Cloud Run 本番環境でIPベースのレート制限が機能していなかった問題（#309）と、OAuth BeginAuth エンドポイントにレート制限がない問題（#270）を修正します。

Closes #309
Closes #270

## 背景
Cloud Run ではリクエストが Google Front End (GFE) プロキシ経由で届くため、`RemoteAddr` のみを参照する従来の `httpx.ClientIP` では全クライアントがほぼ同一IPと見なされ、`httpratelimit.ByIP` を使うルート（signup 5回/時、login 10回/分、oauth callback 20回/分）が**全ユーザー共有の1バケツ**として動作していました。正規ユーザーが他ユーザーのリクエストにより 429 でブロックされる一方、攻撃者単体への制限としては機能しない状態でした。

## 変更内容

### #309: 信頼プロキシ段数方式の X-Forwarded-For 解決（TRUSTED_PROXY_HOPS）
- **`internal/transport/middleware/realip.go`（新規）**: `RealIP(trustedHops)` ミドルウェアを追加。信頼するリバースプロキシ段数に基づき、X-Forwarded-For の**右から n 番目**のエントリを実クライアントIPとして解決し、context に格納します
  - GFE は実クライアントIPを XFF 末尾に追記するため、クライアントが偽装した XFF エントリは左へ押し出され改ざん不可
  - エントリ数不足・不正IPは `RemoteAddr` にフォールバック
- **`internal/transport/httpx`**: `ClientIP` は context 格納済みIPを優先し、なければ従来どおり `RemoteAddr` にフォールバック。既存の呼び出し箇所（レートリミッター・アクセスログ・各ハンドラーのログ約20箇所）は無変更で実IPを参照できるようになります
- **`internal/app/config`**: 環境変数 `TRUSTED_PROXY_HOPS` を追加（デフォルト 0 = XFF を一切信頼しない secure by default。不正値は警告して 0）
- **`cd-api.yaml`**: Cloud Run デプロイに `TRUSTED_PROXY_HOPS=1` を設定（GFE が唯一の信頼プロキシ。将来外部LBを挟む場合は 2 に変更）
- **`docker/example.env`**: 設定値の説明を追記

### #270: OAuth BeginAuth のレート制限
- `GET /v1/auth/oauth/{provider}` に Callback と同じパターンで IP 単位 **20回/分**（FailClosed、prefix `rl:oauth:begin:ip`）を追加。`SaveState` の Redis 書き込みが無制限に発生し得た問題を解消します

## テスト
- `RealIP`: hops=0/1/2、偽装XFFエントリ、エントリ不足・不正IPフォールバック、複数ヘッダー行結合、IPv6 のテーブル駆動テスト
- `httpx.ClientIP`: context 優先・RemoteAddr フォールバック
- config: `TRUSTED_PROXY_HOPS` の未設定/正常/不正値
- router 統合テスト: BeginAuth の 20回/21回目境界、hops=0（共有バケット）/hops=1（XFF別バケット）の挙動

## 検証結果
- `go build ./...` ✅
- `go test ./... -race -cover` 全パス ✅
- `golangci-lint run` 0 issues ✅
- `go tool go-arch-lint check` OK ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)