### PR TITLE
refactor: JWT有効期限とCookie Max-Ageを単一定数に集約

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -95,7 +95,7 @@ func run() int {
 	cachedCandleRepo := candles.NewCachingRepository(rdb, candles.DefaultCacheTTL, candleRepo, "candles")
 
 	// JWTジェネレータ・ブラックリスト（ログアウト時の即時失効用）
-	jwtGen := jwt.NewGenerator(cfg.Server.JWTSecret, 1*time.Hour)
+	jwtGen := jwt.NewGenerator(cfg.Server.JWTSecret, jwt.DefaultTokenTTL)
 	jwtBlacklist := jwt.NewBlacklist(rdb)
 
 	// Google Cloudクライアント初期化

--- a/internal/feature/auth/authhttp/handler.go
+++ b/internal/feature/auth/authhttp/handler.go
@@ -32,6 +32,10 @@ const (
 	loginEmailWindow = 15 * time.Minute // メールベースレートリミットのウィンドウ
 )
 
+// authCookieMaxAge は auth_token / csrf_token Cookie の Max-Age（秒）です。
+// JWT の有効期限（jwt.DefaultTokenTTL）から導出し、トークンと Cookie の寿命の乖離を防ぎます。
+const authCookieMaxAge = int(jwt.DefaultTokenTTL / time.Second)
+
 // Handler は認証操作のHTTPリクエストを処理します。
 // Usecaseインターフェースに依存し、JSONリクエスト/レスポンスを処理します。
 type Handler struct {
@@ -140,9 +144,9 @@ func (h *Handler) Login(w http.ResponseWriter, r *http.Request) {
 
 	// 両トークンが揃ってからCookieをセット（原子性保証）
 	// auth_token: httpOnly Cookie（JavaScriptから読み取り不可 → XSS対策）
-	setAuthCookie(w, "auth_token", token, 3600, h.secureCookie, true)
+	setAuthCookie(w, "auth_token", token, authCookieMaxAge, h.secureCookie, true)
 	// csrf_token: 非httpOnly Cookie（JavaScriptが読み取りX-CSRF-Tokenヘッダーにセット → CSRF対策）
-	setAuthCookie(w, "csrf_token", csrfToken, 3600, h.secureCookie, false)
+	setAuthCookie(w, "csrf_token", csrfToken, authCookieMaxAge, h.secureCookie, false)
 
 	slog.Info("user login successful", "email_hash", logging.HashedEmail(req.Email), "remote_addr", httpx.ClientIP(r))
 	httpx.WriteJSON(w, http.StatusOK, api.MessageResponse{Message: "ok"})

--- a/internal/feature/auth/authhttp/oauth.go
+++ b/internal/feature/auth/authhttp/oauth.go
@@ -133,8 +133,8 @@ func (h *OAuthHandler) Callback(w http.ResponseWriter, r *http.Request) {
 	slog.Info("oauth login successful", "provider", provider)
 
 	// handler.go の Login と同一パターンで Cookie をセット
-	setAuthCookie(w, "auth_token", token, 3600, h.secureCookie, true)
-	setAuthCookie(w, "csrf_token", csrfToken, 3600, h.secureCookie, false)
+	setAuthCookie(w, "auth_token", token, authCookieMaxAge, h.secureCookie, true)
+	setAuthCookie(w, "csrf_token", csrfToken, authCookieMaxAge, h.secureCookie, false)
 
 	http.Redirect(w, r, h.frontendURL, http.StatusFound)
 }

--- a/internal/transport/jwt/generator.go
+++ b/internal/transport/jwt/generator.go
@@ -11,6 +11,11 @@ import (
 	gojwt "github.com/golang-jwt/jwt/v5"
 )
 
+// DefaultTokenTTL はアクセストークン（JWT）の有効期限です。
+// トークンの exp クレームと auth_token / csrf_token Cookie の Max-Age は
+// 必ずこの値から導出し、有効期限の定義を一箇所に集約します。
+const DefaultTokenTTL = time.Hour
+
 // Generator はJWTトークンの生成を実装します。
 // 利用者（例: auth/usecase）が定義するJWTGeneratorインターフェースを実装します。
 type Generator struct {


### PR DESCRIPTION
## 概要
JWT の有効期限がトークン生成側（`cmd/api/main.go` の `1*time.Hour`）と Cookie MaxAge 側（`authhttp` の `3600` ×4箇所）に独立してハードコードされており、片方だけ変更すると乖離するリスクがあった。TTL を `transport/jwt` パッケージの単一定数 `DefaultTokenTTL` に集約し、Cookie MaxAge をそこから導出するようにした。

## 変更内容
- `internal/transport/jwt/generator.go`: 公開定数 `DefaultTokenTTL = time.Hour` を追加（TTL の唯一の定義箇所）
- `cmd/api/main.go`: `jwt.NewGenerator` へ渡す TTL を `jwt.DefaultTokenTTL` に変更
- `internal/feature/auth/authhttp/handler.go`: `authCookieMaxAge = int(jwt.DefaultTokenTTL / time.Second)` を定義し、Login の auth_token / csrf_token Cookie の MaxAge に使用
- `internal/feature/auth/authhttp/oauth.go`: OAuth コールバックの Cookie MaxAge も同定数に置換

動作は変更なし（TTL は従来どおり1時間）。issue に記載のリフレッシュトークン導入は本PRのスコープ外とした。

## 関連issue
- closes #333

## テスト
- `go test ./... -race` 全パッケージ通過（testcontainers によるリポジトリ層テスト含む）
- `go build ./...` / `golangci-lint run` / `go tool go-arch-lint check` すべてエラーなし
- 既存テストに Cookie MaxAge=3600 を直接検証するものはないため、テスト変更は不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)