### PR TITLE
fix: logoutに条件付きCSRF検証を追加しforced logout CSRFを防止

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -141,11 +141,19 @@ paths:
       security: []
       responses:
         "200":
-          description: ログアウト成功（auth_token・csrf_token Cookieを削除）
+          description: |
+            ログアウト成功（auth_token・csrf_token Cookieを削除）。
+            csrf_token Cookieを保持している場合はX-CSRF-Tokenヘッダーとの一致が必要です。
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/MessageResponse"
+        "403":
+          description: csrf_token Cookieを保持しているにもかかわらずX-CSRF-Tokenヘッダーが欠落・不一致
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
 
   /v1/auth/oauth/{provider}:
     get:

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -131,6 +131,12 @@ sequenceDiagram
     participant Blacklist as jwt.Blacklist<br/>(Redis)
 
     Client->>Handler: DELETE /v1/logout
+    alt csrf_token Cookieを保持
+        Handler->>Handler: X-CSRF-Tokenヘッダーとcsrf_token Cookieを比較
+        alt ヘッダー欠落・不一致
+            Handler-->>Client: 403 Forbidden<br/>{error: "csrf token mismatch"}
+        end
+    end
     Handler->>Handler: リクエストからJWT抽出（Cookie優先→Authorizationヘッダー）
     alt トークンが有効（署名OK・未期限切れ）
         Handler->>Blacklist: Revoke(jti, ttl=exp-now)
@@ -375,6 +381,10 @@ sequenceDiagram
 リクエストが有効なJWTを保持している場合、その`jti`をRedisブラックリストへ登録し、
 有効期限（発行から1時間）を待たずに即時失効させます。
 
+ただし forced logout CSRF 対策として、`csrf_token` Cookie を保持しているリクエストに限り
+`X-CSRF-Token` ヘッダーとの一致（Double Submit Cookie照合）が必須です
+（`csrf_token` Cookieを持たないリクエストはチェックをスキップして通過します）。
+
 **レスポンス**
 
 - **200 OK** - ログアウト成功
@@ -388,7 +398,14 @@ sequenceDiagram
   - `auth_token`: 空文字列、`Max-Age=0`（即時削除）
   - `csrf_token`: 空文字列、`Max-Age=0`（即時削除）
 
-**注意**: 期限切れトークンを持つクライアントでも必ずログアウトできるよう、認証不要のエンドポイントに設定されています。
+- **403 Forbidden** - `csrf_token` Cookieを保持しているにもかかわらず`X-CSRF-Token`ヘッダーが欠落・不一致
+  ```json
+  {
+    "error": "csrf token mismatch"
+  }
+  ```
+
+**注意**: 期限切れトークンを持つクライアントでも必ずログアウトできるよう、認証不要のエンドポイントに設定されています（issue #330）。
 
 ### GET /v1/auth/oauth/:provider
 

--- a/internal/app/router/router.go
+++ b/internal/app/router/router.go
@@ -96,8 +96,12 @@ func NewRouter(h Handlers, cfg Config) http.Handler {
 				Policy: httpratelimit.FailClosed,
 			})).Post("/login", h.Auth.Login)
 
-			// 期限切れトークンでもログアウトできるよう認証不要
-			r.Delete("/logout", h.Auth.Logout)
+			// 期限切れトークンでもログアウトできるよう認証不要（冪等設計）。
+			// ただし forced logout CSRF 対策として、csrf_token Cookie を持つリクエストのみ
+			// Double Submit 照合を行う（Cookie を持たない Bearer クライアント等は通過）。
+			// なお DELETE は CORS プリフライト必須 + SameSite=Lax のため実攻撃は困難であり、
+			// 本ミドルウェアは防御の多層化（defense-in-depth）である（issue #330）。
+			r.With(csrfmw.ProtectIfCookiePresent()).Delete("/logout", h.Auth.Logout)
 
 			// OAuthルート（環境変数が設定されている場合のみ登録）
 			if h.OAuth != nil {

--- a/internal/app/router/router_test.go
+++ b/internal/app/router/router_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/symbollist/symbollisthttp"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/watchlist"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/feature/watchlist/watchlisthttp"
+	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/csrf"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/httpratelimit"
 	"github.com/UCHIDAnobuhiro/stock-backend/internal/transport/jwt"
 )
@@ -233,6 +234,46 @@ func TestNewRouter_PublicRoutes(t *testing.T) {
 			assert.NotEqual(t, http.StatusServiceUnavailable, rec.Code)
 		})
 	}
+}
+
+// TestNewRouter_LogoutCSRF は /v1/logout が forced logout CSRF 対策として、
+// csrf_token Cookie を持つリクエストのみ X-CSRF-Token ヘッダー照合を要求することを検証します（issue #330）。
+func TestNewRouter_LogoutCSRF(t *testing.T) {
+	t.Parallel()
+
+	oauthHandler := authhttp.NewOAuthHandler(stubOAuthUsecase{}, false, "http://localhost:3000")
+
+	t.Run("error: csrf_token cookie present with missing header returns 403", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, oauthHandler)
+		req := httptest.NewRequest(http.MethodDelete, "/v1/logout", nil)
+		req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "csrf-token"})
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("error: csrf_token cookie present with mismatched header returns 403", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, oauthHandler)
+		req := httptest.NewRequest(http.MethodDelete, "/v1/logout", nil)
+		req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "csrf-token"})
+		req.Header.Set(csrf.HeaderName, "other-token")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.Equal(t, http.StatusForbidden, rec.Code)
+	})
+
+	t.Run("success: csrf_token cookie present with matching header does not return 403", func(t *testing.T) {
+		t.Parallel()
+		r := newTestRouter(t, oauthHandler)
+		req := httptest.NewRequest(http.MethodDelete, "/v1/logout", nil)
+		req.AddCookie(&http.Cookie{Name: csrf.CookieName, Value: "csrf-token"})
+		req.Header.Set(csrf.HeaderName, "csrf-token")
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+		assert.NotEqual(t, http.StatusForbidden, rec.Code)
+	})
 }
 
 // TestNewRouter_OAuthRoutesOptional は Handlers.OAuth が nil の場合に

--- a/internal/transport/csrf/middleware.go
+++ b/internal/transport/csrf/middleware.go
@@ -59,13 +59,49 @@ func Protect() func(http.Handler) http.Handler {
 				return
 			}
 
-			headerVal := r.Header.Get(HeaderName)
-			if headerVal == "" || subtle.ConstantTimeCompare([]byte(headerVal), []byte(cookie.Value)) != 1 {
-				httpx.WriteJSON(w, http.StatusForbidden, api.ErrorResponse{Error: "csrf token mismatch"})
+			if !requireHeaderMatch(w, r, cookie.Value) {
 				return
 			}
 
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// ProtectIfCookiePresent は forced logout CSRF対策のミドルウェアです。認証必須にできない
+// logoutエンドポイント向けに、csrf_token Cookieを持つリクエストのみヘッダー照合を要求します（issue #330）。
+func ProtectIfCookiePresent() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions:
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			cookie, err := r.Cookie(CookieName)
+			if err != nil || cookie.Value == "" {
+				// Cookieがない（既にログアウト済み・Bearer認証等）場合はチェックをスキップ
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			if !requireHeaderMatch(w, r, cookie.Value) {
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// requireHeaderMatch はX-CSRF-TokenヘッダーとcsrfCookieValueを定数時間比較します。
+// 一致すればtrueを返し、不一致なら403を書き込んでfalseを返します。
+func requireHeaderMatch(w http.ResponseWriter, r *http.Request, csrfCookieValue string) bool {
+	headerVal := r.Header.Get(HeaderName)
+	if headerVal == "" || subtle.ConstantTimeCompare([]byte(headerVal), []byte(csrfCookieValue)) != 1 {
+		httpx.WriteJSON(w, http.StatusForbidden, api.ErrorResponse{Error: "csrf token mismatch"})
+		return false
+	}
+	return true
 }

--- a/internal/transport/csrf/middleware_test.go
+++ b/internal/transport/csrf/middleware_test.go
@@ -128,6 +128,100 @@ func TestProtect_BearerAuthSkipsCheck(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestProtectIfCookiePresent_SafeMethodsSkipped(t *testing.T) {
+	t.Parallel()
+
+	methods := []string{http.MethodGet, http.MethodHead, http.MethodOptions}
+	for _, method := range methods {
+		t.Run(method, func(t *testing.T) {
+			t.Parallel()
+
+			next, called := newRecordingHandler()
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(method, "/", nil)
+
+			ProtectIfCookiePresent()(next).ServeHTTP(w, req)
+
+			assert.True(t, *called, "next must be called for safe methods")
+			assert.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+}
+
+func TestProtectIfCookiePresent_NoCookieSkipsCheck(t *testing.T) {
+	t.Parallel()
+
+	next, called := newRecordingHandler()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/", nil)
+
+	ProtectIfCookiePresent()(next).ServeHTTP(w, req)
+
+	assert.True(t, *called, "next must be called when csrf_token cookie is absent")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestProtectIfCookiePresent_EmptyCookieSkipsCheck(t *testing.T) {
+	t.Parallel()
+
+	next, called := newRecordingHandler()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: ""})
+
+	ProtectIfCookiePresent()(next).ServeHTTP(w, req)
+
+	assert.True(t, *called, "next must be called when csrf_token cookie is empty")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestProtectIfCookiePresent_RejectsMissingOrMismatchedHeader(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		headerValue string
+	}{
+		{name: "missing header", headerValue: ""},
+		{name: "mismatch", headerValue: "other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			next, called := newRecordingHandler()
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodDelete, "/", nil)
+			req.AddCookie(&http.Cookie{Name: CookieName, Value: "token"})
+			if tt.headerValue != "" {
+				req.Header.Set(HeaderName, tt.headerValue)
+			}
+
+			ProtectIfCookiePresent()(next).ServeHTTP(w, req)
+
+			assert.Equal(t, http.StatusForbidden, w.Code)
+			assert.False(t, *called, "next must not be called when CSRF check fails")
+		})
+	}
+}
+
+func TestProtectIfCookiePresent_AllowsMatchingToken(t *testing.T) {
+	t.Parallel()
+
+	const token = "matching-csrf-token"
+	next, called := newRecordingHandler()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/", nil)
+	req.AddCookie(&http.Cookie{Name: CookieName, Value: token})
+	req.Header.Set(HeaderName, token)
+
+	ProtectIfCookiePresent()(next).ServeHTTP(w, req)
+
+	assert.True(t, *called, "next must be called when tokens match")
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 // TestProtect_CookieAuthWithForgedBearerStillRequiresCSRF is the regression for
 // issue #201: even when a forged Authorization: Bearer header is present, cookie
 // auth takes priority (auth_source == "cookie"), so the CSRF check must still run.


### PR DESCRIPTION
## Summary
- `DELETE /v1/logout` は期限切れトークンでもログアウトできるよう認証不要の公開ルートに置かれており、CSRF保護の対象外だった（forced logout CSRF、issue #330）
- ログアウトを認証必須にはせず（期限切れトークンユーザーがログアウトできなくなるため）、`csrf_token` Cookie を保持するリクエストにのみ `X-CSRF-Token` ヘッダー照合を必須にする `csrf.ProtectIfCookiePresent()` を追加し、`/v1/logout` ルートに適用
- Cookie を持たないリクエスト（Bearer認証クライアント、ログアウト済みクライアント）はチェックをスキップして通過するため、既存の冪等な挙動は維持される
- `api/openapi.yaml` に 403 レスポンスを追記、`docs/features/auth.md` のシーケンス図・説明を更新

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/transport/csrf/... ./internal/app/router/... -v -race`（新規テストケース含めPASS）
- [x] `go test ./... -race -cover`（全パッケージPASS、回帰なし）
- [x] `golangci-lint run --timeout=5m`（0 issues）
- [x] `go tool go-arch-lint check`（OK）

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)