### PR TITLE
perf: /v1/quotesのcache-miss時の読み取り行数を一括クエリで削減

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/lib/pq v1.10.9
 	github.com/oapi-codegen/nethttp-middleware v1.2.0
 	github.com/oapi-codegen/runtime v1.6.0
 	github.com/pressly/goose/v3 v3.27.3

--- a/internal/feature/candles/caching_repository.go
+++ b/internal/feature/candles/caching_repository.go
@@ -128,6 +128,14 @@ func (c *CachingRepository) Find(ctx context.Context, symbol, interval string, o
 	return sliceCandles(all, outputsize), nil
 }
 
+// FindLatestBySymbols は複数銘柄の直近 n 件を inner にそのまま委譲します。
+// Find のキャッシュキーは「全件（MaxOutputSize件）」を保持する契約のため、
+// ここで直近N件の部分データをSETするとcandles経路のキャッシュを汚染してしまいます。
+// そのためキャッシュの読み書きは一切行いません。
+func (c *CachingRepository) FindLatestBySymbols(ctx context.Context, codes []string, interval string, n int) ([]Candle, error) {
+	return c.inner.FindLatestBySymbols(ctx, codes, interval, n)
+}
+
 // sliceCandles は全ローソク足データから先頭 outputsize 件を返します。
 // outputsize は呼び出し元の Find で 1〜MaxOutputSize であることが検証済みのため、
 // ここでは outputsize が件数以上の場合に全件返すことのみを扱います。

--- a/internal/feature/candles/caching_repository_test.go
+++ b/internal/feature/candles/caching_repository_test.go
@@ -4,16 +4,21 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/go-redis/redismock/v9"
+	"github.com/redis/go-redis/v9"
 )
 
 // mockReadWriteRepository はテスト用の readWriteRepository（読み書き）モック実装です。
 type mockReadWriteRepository struct {
-	findFn        func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error)
-	upsertBatchFn func(ctx context.Context, candles []Candle) error
+	findFn                   func(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error)
+	upsertBatchFn            func(ctx context.Context, candles []Candle) error
+	findLatestBySymbolsFn    func(ctx context.Context, codes []string, interval string, n int) ([]Candle, error)
+	findLatestBySymbolsCalls int
 }
 
 // Find はモックのFind関数を呼び出します。
@@ -30,6 +35,15 @@ func (m *mockReadWriteRepository) UpsertBatch(ctx context.Context, candles []Can
 		return m.upsertBatchFn(ctx, candles)
 	}
 	return nil
+}
+
+// FindLatestBySymbols はモックのfindLatestBySymbolsFn関数を呼び出し、呼び出し回数を記録します。
+func (m *mockReadWriteRepository) FindLatestBySymbols(ctx context.Context, codes []string, interval string, n int) ([]Candle, error) {
+	m.findLatestBySymbolsCalls++
+	if m.findLatestBySymbolsFn != nil {
+		return m.findLatestBySymbolsFn(ctx, codes, interval, n)
+	}
+	return nil, nil
 }
 
 // TestNewCachingCandleRepository_Defaults はデフォルト値（TTLとnamespace）が正しく設定されることを検証します。
@@ -513,6 +527,73 @@ func TestCachingCandleRepository_UpsertBatch_DeduplicatesDel(t *testing.T) {
 	}
 	if err := mock.ExpectationsWereMet(); err != nil {
 		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
+// TestCachingCandleRepository_FindLatestBySymbols_PassThrough はFindLatestBySymbolsが
+// innerへ引数どおり委譲され、その結果をそのまま返すことを検証します。
+func TestCachingCandleRepository_FindLatestBySymbols_PassThrough(t *testing.T) {
+	t.Parallel()
+
+	expectedCandles := []Candle{
+		{SymbolCode: "AAPL", Interval: "1day", Open: 150.0, Close: 155.0},
+		{SymbolCode: "GOOGL", Interval: "1day", Open: 250.0, Close: 255.0},
+	}
+	wantCodes := []string{"AAPL", "GOOGL"}
+
+	inner := &mockReadWriteRepository{
+		findLatestBySymbolsFn: func(ctx context.Context, codes []string, interval string, n int) ([]Candle, error) {
+			if !reflect.DeepEqual(codes, wantCodes) {
+				t.Errorf("unexpected codes: got %v, want %v", codes, wantCodes)
+			}
+			if interval != "1day" {
+				t.Errorf("unexpected interval: got %s, want 1day", interval)
+			}
+			if n != 2 {
+				t.Errorf("unexpected n: got %d, want 2", n)
+			}
+			return expectedCandles, nil
+		},
+	}
+
+	repo := NewCachingRepository(nil, 5*time.Minute, inner, "candles")
+	got, err := repo.FindLatestBySymbols(context.Background(), wantCodes, "1day", 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got, expectedCandles) {
+		t.Errorf("expected inner result to be returned as-is: got %v, want %v", got, expectedCandles)
+	}
+	if inner.findLatestBySymbolsCalls != 1 {
+		t.Errorf("expected inner.FindLatestBySymbols to be called once, got %d", inner.findLatestBySymbolsCalls)
+	}
+}
+
+// TestCachingCandleRepository_FindLatestBySymbols_NoCacheAccess はFindLatestBySymbolsが
+// Redisキャッシュへ一切アクセスしないことを検証します。キャッシュキーは「全件
+// （MaxOutputSize件）」を保持する契約のため、直近N件の部分データでキャッシュを
+// 汚染してはならないという不変条件を守っていることを、実際のRedis（miniredis）に
+// 対してキーが作成されないことで確認します。
+func TestCachingCandleRepository_FindLatestBySymbols_NoCacheAccess(t *testing.T) {
+	t.Parallel()
+
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	inner := &mockReadWriteRepository{
+		findLatestBySymbolsFn: func(ctx context.Context, codes []string, interval string, n int) ([]Candle, error) {
+			return []Candle{{SymbolCode: "AAPL", Interval: "1day", Close: 100}}, nil
+		},
+	}
+
+	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
+	if _, err := repo.FindLatestBySymbols(context.Background(), []string{"AAPL"}, "1day", 2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if keys := mr.Keys(); len(keys) != 0 {
+		t.Errorf("expected no keys to be created in Redis, got %v", keys)
 	}
 }
 

--- a/internal/feature/candles/quotes.go
+++ b/internal/feature/candles/quotes.go
@@ -3,8 +3,6 @@ package candles
 import (
 	"context"
 	"time"
-
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -13,10 +11,6 @@ const (
 
 	// MaxQuoteBars はスパークライン用に含められる終値の最大本数です。
 	MaxQuoteBars = 500
-
-	// quoteConcurrency は GetQuotes が銘柄ごとの Repository.Find を並行実行する際の
-	// 最大同時実行数です。DB/Redis への同時アクセス数を抑えるため上限を設けます。
-	quoteConcurrency = 8
 )
 
 // Quote は銘柄ごとの最新終値・前日比・スパークライン用終値配列を表します。
@@ -31,44 +25,34 @@ type Quote struct {
 }
 
 // GetQuotes は指定された複数銘柄について、最新終値・前日比・スパークライン用の
-// 終値配列を取得します。銘柄ごとに既存の Repository.Find（candles.CachingRepository
-// 経由でワイヤリング済み）を呼び出すため、新しいSQL/sqlcクエリは追加しません。
+// 終値配列を取得します。Repository.FindLatestBySymbols を1回呼び出し、全銘柄分の
+// 直近データを unnest + CROSS JOIN LATERAL の一括SQLで取得します（quotes経路は
+// Redisを経由しないため、CachingRepositoryはinnerへの単純委譲になります）。
 //
-// 1銘柄でも Repository.Find がエラーを返した場合は全体をエラーとして返します
+// FindLatestBySymbols がエラーを返した場合は全体をエラーとして返します
 // （部分成功にはしません）。ローソク足が2本未満の銘柄（前日比を計算できない）は
-// 結果から除外します（エラーにはしません）。返却順序は保証しません。
+// 結果から除外します（エラーにはしません）。返却順序は codes の順に安定します。
 func (cu *usecase) GetQuotes(ctx context.Context, codes []string, interval string, bars int) ([]Quote, error) {
 	// 前日比の計算には最低2本のローソク足が必要なため、bars（スパークライン用件数）
 	// が2未満でも常に2本以上を取得する。
 	outputsize := max(bars, 2)
 
-	// 銘柄ごとの結果を index 固定で書き込み、返却順序を安定させる
-	// （順序保証は不要だが、goroutine 間の書き込み競合を避けるため）。
-	results := make([]*Quote, len(codes))
-
-	// DB/Redis への同時アクセス数を抑えるため、並行数を quoteConcurrency に制限する。
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(quoteConcurrency)
-
-	for i, code := range codes {
-		g.Go(func() error {
-			cs, err := cu.candle.Find(gctx, code, interval, outputsize)
-			if err != nil {
-				return err
-			}
-			results[i] = buildQuote(code, cs, bars)
-			return nil
-		})
-	}
-
-	if err := g.Wait(); err != nil {
+	flat, err := cu.candle.FindLatestBySymbols(ctx, codes, interval, outputsize)
+	if err != nil {
 		return nil, err
 	}
 
-	// 2本未満で buildQuote が nil を返した銘柄を除外する。
-	quotes := make([]Quote, 0, len(results))
-	for _, q := range results {
-		if q != nil {
+	// フラットな結果を銘柄ごとにグルーピングする。FindLatestBySymbols は銘柄ごとに
+	// 時刻降順で返すため、append 順のまま grouped[code] も時刻降順が保たれる。
+	grouped := make(map[string][]Candle, len(codes))
+	for _, c := range flat {
+		grouped[c.SymbolCode] = append(grouped[c.SymbolCode], c)
+	}
+
+	// codes の順に buildQuote を呼び、2本未満（nil）の銘柄を除外する。
+	quotes := make([]Quote, 0, len(codes))
+	for _, code := range codes {
+		if q := buildQuote(code, grouped[code], bars); q != nil {
 			quotes = append(quotes, *q)
 		}
 	}
@@ -76,8 +60,8 @@ func (cu *usecase) GetQuotes(ctx context.Context, codes []string, interval strin
 	return quotes, nil
 }
 
-// buildQuote は Repository.Find が返したローソク足（時刻降順、cs[0]が最新）から
-// Quote を組み立てます。cs が2本未満の場合は前日比を計算できないため nil を返します
+// buildQuote は指定銘柄のローソク足（時刻降順、cs[0]が最新）から Quote を組み立てます。
+// cs が2本未満の場合は前日比を計算できないため nil を返します
 // （呼び出し元 GetQuotes が結果から除外します）。
 func buildQuote(code string, cs []Candle, bars int) *Quote {
 	if len(cs) < 2 {

--- a/internal/feature/candles/quotes_test.go
+++ b/internal/feature/candles/quotes_test.go
@@ -11,55 +11,84 @@ import (
 )
 
 // quoteMockRepository はRepositoryインターフェースのモック実装です。
-// GetQuotesは銘柄ごとにFindを呼び出すため、symbolに応じて挙動を切り替えられるようにします。
+// GetQuotesはFindLatestBySymbolsを1回だけ呼び出すため、FindLatestBySymbolsFuncで
+// フラットな結果（銘柄ごとに時刻降順で連結）を返せるようにします。
 type quoteMockRepository struct {
-	FindFunc func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error)
+	FindLatestBySymbolsFunc  func(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error)
+	FindLatestBySymbolsCalls int
 }
 
-// Find はFindFuncに処理を委譲します。
+// Find はRepositoryインターフェースを満たすためだけに存在します。
+// GetQuotesから呼ばれることはないため、呼ばれた場合はテスト失敗として扱います。
 func (m *quoteMockRepository) Find(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-	return m.FindFunc(ctx, symbol, interval, outputsize)
+	return nil, errors.New("Find should not be called by GetQuotes")
 }
 
-// mkCandle は2024年1月dayの日付・終値closeを持つCandleを生成するテストヘルパーです。
-// GetQuotesの計算には Time と Close のみが使われます。
-func mkCandle(day int, close float64) candles.Candle {
+// FindLatestBySymbols はFindLatestBySymbolsFuncに処理を委譲し、呼び出し回数を記録します。
+func (m *quoteMockRepository) FindLatestBySymbols(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+	m.FindLatestBySymbolsCalls++
+	return m.FindLatestBySymbolsFunc(ctx, codes, interval, n)
+}
+
+// flattenByCode は byCode（銘柄→時刻降順のCandleスライス）を codes の順に連結した
+// フラットな []Candle に変換するテストヘルパーです（FindLatestBySymbols の戻り値を模す）。
+func flattenByCode(codes []string, byCode map[string][]candles.Candle) []candles.Candle {
+	var flat []candles.Candle
+	for _, code := range codes {
+		flat = append(flat, byCode[code]...)
+	}
+	return flat
+}
+
+// mkCandle は指定銘柄コード・2024年1月dayの日付・終値closeを持つCandleを生成する
+// テストヘルパーです。GetQuotesはSymbolCodeで銘柄ごとにグルーピングするため、
+// SymbolCodeを必ず設定します。
+func mkCandle(symbol string, day int, close float64) candles.Candle {
 	return candles.Candle{
-		Time:  time.Date(2024, 1, day, 0, 0, 0, 0, time.UTC),
-		Close: close,
+		SymbolCode: symbol,
+		Time:       time.Date(2024, 1, day, 0, 0, 0, 0, time.UTC),
+		Close:      close,
 	}
 }
 
-// TestCandlesUsecase_GetQuotes はGetQuotesメソッドの並行呼び出し・変換ロジックをテストします。
+// TestCandlesUsecase_GetQuotes はGetQuotesメソッドの変換ロジック・FindLatestBySymbolsの
+// 呼び出し方をテストします。
 func TestCandlesUsecase_GetQuotes(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("success: change and change_percent are computed from the two most recent candles", func(t *testing.T) {
 		byCode := map[string][]candles.Candle{
-			// Findは時刻降順（[0]が最新）で返す。
-			"AAPL":  {mkCandle(2, 105), mkCandle(1, 100)},
-			"GOOGL": {mkCandle(2, 210), mkCandle(1, 200)},
+			// FindLatestBySymbolsは銘柄ごとに時刻降順（[0]が最新）で返す。
+			"AAPL":  {mkCandle("AAPL", 2, 105), mkCandle("AAPL", 1, 100)},
+			"GOOGL": {mkCandle("GOOGL", 2, 210), mkCandle("GOOGL", 1, 200)},
 		}
+		codes := []string{"AAPL", "GOOGL"}
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
+			FindLatestBySymbolsFunc: func(ctx context.Context, gotCodes []string, interval string, n int) ([]candles.Candle, error) {
 				if interval != "1day" {
 					t.Errorf("unexpected interval: got %s, want 1day", interval)
 				}
-				// bars=0でも前日比計算に2本必要なため outputsize は max(bars, 2) = 2 になる。
-				if outputsize != 2 {
-					t.Errorf("unexpected outputsize: got %d, want 2", outputsize)
+				// bars=0でも前日比計算に2本必要なため n は max(bars, 2) = 2 になる。
+				if n != 2 {
+					t.Errorf("unexpected n: got %d, want 2", n)
 				}
-				return byCode[symbol], nil
+				if !reflect.DeepEqual(gotCodes, codes) {
+					t.Errorf("unexpected codes: got %v, want %v", gotCodes, codes)
+				}
+				return flattenByCode(codes, byCode), nil
 			},
 		}
 		uc := candles.NewUsecase(repo)
 
-		got, err := uc.GetQuotes(ctx, []string{"AAPL", "GOOGL"}, "1day", 0)
+		got, err := uc.GetQuotes(ctx, codes, "1day", 0)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if len(got) != 2 {
 			t.Fatalf("expected 2 quotes, got %d", len(got))
+		}
+		if repo.FindLatestBySymbolsCalls != 1 {
+			t.Errorf("expected FindLatestBySymbols to be called once, got %d", repo.FindLatestBySymbolsCalls)
 		}
 
 		byResultCode := make(map[string]candles.Quote, len(got))
@@ -95,12 +124,13 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 	})
 
 	t.Run("2本未満のローソク足しかない銘柄は結果から除外される", func(t *testing.T) {
+		byCode := map[string][]candles.Candle{
+			"AAPL": {mkCandle("AAPL", 2, 105), mkCandle("AAPL", 1, 100)},
+			"ONE":  {mkCandle("ONE", 1, 100)},
+		}
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				if symbol == "ONE" {
-					return []candles.Candle{mkCandle(1, 100)}, nil
-				}
-				return []candles.Candle{mkCandle(2, 105), mkCandle(1, 100)}, nil
+			FindLatestBySymbolsFunc: func(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+				return flattenByCode(codes, byCode), nil
 			},
 		}
 		uc := candles.NewUsecase(repo)
@@ -116,13 +146,16 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 
 	t.Run("bars>0のときclosesは古い→新しい順で最大bars件返る", func(t *testing.T) {
 		// 時刻降順（[0]が最新）: day5(50) > day4(40) > day3(30) > day2(20) > day1(10)
-		all := []candles.Candle{mkCandle(5, 50), mkCandle(4, 40), mkCandle(3, 30), mkCandle(2, 20), mkCandle(1, 10)}
+		all := []candles.Candle{
+			mkCandle("AAPL", 5, 50), mkCandle("AAPL", 4, 40), mkCandle("AAPL", 3, 30),
+			mkCandle("AAPL", 2, 20), mkCandle("AAPL", 1, 10),
+		}
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				if outputsize != 3 {
-					t.Errorf("unexpected outputsize: got %d, want 3 (bars=3)", outputsize)
+			FindLatestBySymbolsFunc: func(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+				if n != 3 {
+					t.Errorf("unexpected n: got %d, want 3 (bars=3)", n)
 				}
-				return all[:outputsize], nil
+				return all[:n], nil
 			},
 		}
 		uc := candles.NewUsecase(repo)
@@ -143,8 +176,8 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 
 	t.Run("bars=0のときclosesはnil", func(t *testing.T) {
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				return []candles.Candle{mkCandle(2, 105), mkCandle(1, 100)}, nil
+			FindLatestBySymbolsFunc: func(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+				return []candles.Candle{mkCandle("AAPL", 2, 105), mkCandle("AAPL", 1, 100)}, nil
 			},
 		}
 		uc := candles.NewUsecase(repo)
@@ -160,8 +193,8 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 
 	t.Run("prev_closeが0のときchange_percentは0", func(t *testing.T) {
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				return []candles.Candle{mkCandle(2, 10), mkCandle(1, 0)}, nil
+			FindLatestBySymbolsFunc: func(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+				return []candles.Candle{mkCandle("AAPL", 2, 10), mkCandle("AAPL", 1, 0)}, nil
 			},
 		}
 		uc := candles.NewUsecase(repo)
@@ -178,14 +211,11 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 		}
 	})
 
-	t.Run("error: リポジトリが1銘柄でもエラーを返した場合は全体がエラーになる", func(t *testing.T) {
+	t.Run("error: FindLatestBySymbolsがエラーを返した場合は全体がエラーになる", func(t *testing.T) {
 		errDB := errors.New("database error")
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				if symbol == "BAD" {
-					return nil, errDB
-				}
-				return []candles.Candle{mkCandle(2, 105), mkCandle(1, 100)}, nil
+			FindLatestBySymbolsFunc: func(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+				return nil, errDB
 			},
 		}
 		uc := candles.NewUsecase(repo)
@@ -199,11 +229,15 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 		}
 	})
 
-	t.Run("success: 複数銘柄すべてが返る（順序は保証しない）", func(t *testing.T) {
+	t.Run("success: 複数銘柄すべてがcodesの順で返る", func(t *testing.T) {
 		codes := []string{"A", "B", "C", "D"}
+		byCode := make(map[string][]candles.Candle, len(codes))
+		for _, c := range codes {
+			byCode[c] = []candles.Candle{mkCandle(c, 2, 20), mkCandle(c, 1, 10)}
+		}
 		repo := &quoteMockRepository{
-			FindFunc: func(ctx context.Context, symbol, interval string, outputsize int) ([]candles.Candle, error) {
-				return []candles.Candle{mkCandle(2, 20), mkCandle(1, 10)}, nil
+			FindLatestBySymbolsFunc: func(ctx context.Context, gotCodes []string, interval string, n int) ([]candles.Candle, error) {
+				return flattenByCode(gotCodes, byCode), nil
 			},
 		}
 		uc := candles.NewUsecase(repo)
@@ -216,14 +250,15 @@ func TestCandlesUsecase_GetQuotes(t *testing.T) {
 			t.Fatalf("expected %d quotes, got %d", len(codes), len(got))
 		}
 
-		seen := make(map[string]bool, len(codes))
-		for _, q := range got {
-			seen[q.Code] = true
+		gotCodes := make([]string, len(got))
+		for i, q := range got {
+			gotCodes[i] = q.Code
 		}
-		for _, c := range codes {
-			if !seen[c] {
-				t.Errorf("expected code %s in result, got %+v", c, got)
-			}
+		if !reflect.DeepEqual(gotCodes, codes) {
+			t.Errorf("expected result order %v, got %v", codes, gotCodes)
+		}
+		if repo.FindLatestBySymbolsCalls != 1 {
+			t.Errorf("expected FindLatestBySymbols to be called once, got %d", repo.FindLatestBySymbolsCalls)
 		}
 	})
 }

--- a/internal/feature/candles/repository.go
+++ b/internal/feature/candles/repository.go
@@ -93,3 +93,37 @@ func (r *dbRepository) Find(ctx context.Context, symbol, interval string, output
 	}
 	return out, nil
 }
+
+// FindLatestBySymbols は複数銘柄の直近 n 件を、unnest + CROSS JOIN LATERAL の
+// 1クエリで取得します。銘柄ごとに LIMIT n で打ち切られるため、Find を銘柄数分
+// 繰り返すより読み取り行数を抑えられます。
+func (r *dbRepository) FindLatestBySymbols(ctx context.Context, codes []string, interval string, n int) ([]Candle, error) {
+	if n <= 0 || n > MaxOutputSize {
+		return nil, fmt.Errorf("find latest candles: %w", ErrInvalidOutputSize)
+	}
+	if len(codes) == 0 {
+		return []Candle{}, nil
+	}
+	rows, err := r.q.FindLatestCandlesBySymbols(ctx, candlessqlc.FindLatestCandlesBySymbolsParams{
+		SymbolCodes:    codes,
+		IntervalFilter: interval,
+		MaxRows:        int32(n),
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Candle, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, Candle{
+			SymbolCode: row.SymbolCode,
+			Interval:   row.Interval,
+			Time:       row.Time,
+			Open:       row.Open,
+			High:       row.High,
+			Low:        row.Low,
+			Close:      row.Close,
+			Volume:     row.Volume,
+		})
+	}
+	return out, nil
+}

--- a/internal/feature/candles/repository_test.go
+++ b/internal/feature/candles/repository_test.go
@@ -268,6 +268,106 @@ func TestCandleRepository_Find(t *testing.T) {
 	}
 }
 
+func TestCandleRepository_FindLatestBySymbols(t *testing.T) {
+	t.Parallel()
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		codes        []string
+		interval     string
+		n            int
+		wantErr      error
+		setupFunc    func(t *testing.T, db *sql.DB)
+		validateFunc func(t *testing.T, candles []Candle)
+	}{
+		{
+			name:  "success: 複数銘柄で各銘柄n件・時刻降順に取得できる",
+			codes: []string{"AAPL", "GOOGL"}, interval: "1day", n: 2,
+			setupFunc: func(t *testing.T, db *sql.DB) {
+				for i := 0; i < 3; i++ {
+					seedCandle(t, db, "AAPL", "1day", baseTime.AddDate(0, 0, i))
+					seedCandle(t, db, "GOOGL", "1day", baseTime.AddDate(0, 0, i))
+				}
+			},
+			validateFunc: func(t *testing.T, candles []Candle) {
+				byCode := map[string][]Candle{}
+				for _, c := range candles {
+					byCode[c.SymbolCode] = append(byCode[c.SymbolCode], c)
+				}
+				assert.Len(t, byCode["AAPL"], 2)
+				assert.Len(t, byCode["GOOGL"], 2)
+				// 各銘柄内で時刻降順になっていること
+				assert.True(t, byCode["AAPL"][0].Time.After(byCode["AAPL"][1].Time))
+				assert.True(t, byCode["GOOGL"][0].Time.After(byCode["GOOGL"][1].Time))
+			},
+		},
+		{
+			name:  "success: intervalフィルタが効く",
+			codes: []string{"AAPL"}, interval: "1day", n: 10,
+			setupFunc: func(t *testing.T, db *sql.DB) {
+				seedCandle(t, db, "AAPL", "1day", baseTime)
+				seedCandle(t, db, "AAPL", "1week", baseTime)
+			},
+			validateFunc: func(t *testing.T, candles []Candle) {
+				assert.Len(t, candles, 1)
+				assert.Equal(t, "1day", candles[0].Interval)
+			},
+		},
+		{
+			name:  "success: 存在しない銘柄コードの行は返らない",
+			codes: []string{"AAPL", "NOTFOUND"}, interval: "1day", n: 10,
+			setupFunc: func(t *testing.T, db *sql.DB) {
+				seedCandle(t, db, "AAPL", "1day", baseTime)
+			},
+			validateFunc: func(t *testing.T, candles []Candle) {
+				assert.Len(t, candles, 1)
+				assert.Equal(t, "AAPL", candles[0].SymbolCode)
+			},
+		},
+		{
+			name:  "success: codesが空スライスなら空結果でクエリ発行なし",
+			codes: []string{}, interval: "1day", n: 10,
+			setupFunc: func(t *testing.T, db *sql.DB) {
+				seedCandle(t, db, "AAPL", "1day", baseTime)
+			},
+			validateFunc: func(t *testing.T, candles []Candle) {
+				assert.Empty(t, candles)
+			},
+		},
+		{
+			name:  "error: n=0はErrInvalidOutputSize",
+			codes: []string{"AAPL"}, interval: "1day", n: 0,
+			wantErr: ErrInvalidOutputSize,
+		},
+		{
+			name:  "error: n=MaxOutputSize+1はErrInvalidOutputSize",
+			codes: []string{"AAPL"}, interval: "1day", n: MaxOutputSize + 1,
+			wantErr: ErrInvalidOutputSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			db := setupTestDB(t)
+			repo := NewRepository(db)
+			if tt.setupFunc != nil {
+				tt.setupFunc(t, db)
+			}
+			candles, err := repo.FindLatestBySymbols(context.Background(), tt.codes, tt.interval, tt.n)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.validateFunc != nil {
+				tt.validateFunc(t, candles)
+			}
+		})
+	}
+}
+
 func TestCandleRepository_Find_EntityMapping(t *testing.T) {
 	t.Parallel()
 	db := setupTestDB(t)

--- a/internal/feature/candles/sqlc/querier.go
+++ b/internal/feature/candles/sqlc/querier.go
@@ -10,6 +10,7 @@ import (
 
 type Querier interface {
 	FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]Candle, error)
+	FindLatestCandlesBySymbols(ctx context.Context, arg FindLatestCandlesBySymbolsParams) ([]Candle, error)
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/feature/candles/sqlc/queries.sql
+++ b/internal/feature/candles/sqlc/queries.sql
@@ -4,3 +4,14 @@ FROM candles
 WHERE symbol_code = $1 AND "interval" = $2
 ORDER BY "time" DESC
 LIMIT $3;
+
+-- name: FindLatestCandlesBySymbols :many
+SELECT c.symbol_code, c."interval", c."time", c.open, c.high, c.low, c.close, c.volume
+FROM unnest(sqlc.arg(symbol_codes)::text[]) AS s(code)
+CROSS JOIN LATERAL (
+  SELECT symbol_code, "interval", "time", open, high, low, close, volume
+  FROM candles
+  WHERE symbol_code = s.code AND "interval" = sqlc.arg(interval_filter)
+  ORDER BY "time" DESC
+  LIMIT sqlc.arg(max_rows)
+) c;

--- a/internal/feature/candles/sqlc/queries.sql.go
+++ b/internal/feature/candles/sqlc/queries.sql.go
@@ -7,6 +7,8 @@ package candlessqlc
 
 import (
 	"context"
+
+	"github.com/lib/pq"
 )
 
 const findCandlesLimit = `-- name: FindCandlesLimit :many
@@ -25,6 +27,56 @@ type FindCandlesLimitParams struct {
 
 func (q *Queries) FindCandlesLimit(ctx context.Context, arg FindCandlesLimitParams) ([]Candle, error) {
 	rows, err := q.db.QueryContext(ctx, findCandlesLimit, arg.SymbolCode, arg.Interval, arg.Limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Candle{}
+	for rows.Next() {
+		var i Candle
+		if err := rows.Scan(
+			&i.SymbolCode,
+			&i.Interval,
+			&i.Time,
+			&i.Open,
+			&i.High,
+			&i.Low,
+			&i.Close,
+			&i.Volume,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const findLatestCandlesBySymbols = `-- name: FindLatestCandlesBySymbols :many
+SELECT c.symbol_code, c."interval", c."time", c.open, c.high, c.low, c.close, c.volume
+FROM unnest($1::text[]) AS s(code)
+CROSS JOIN LATERAL (
+  SELECT symbol_code, "interval", "time", open, high, low, close, volume
+  FROM candles
+  WHERE symbol_code = s.code AND "interval" = $2
+  ORDER BY "time" DESC
+  LIMIT $3
+) c
+`
+
+type FindLatestCandlesBySymbolsParams struct {
+	SymbolCodes    []string
+	IntervalFilter string
+	MaxRows        int32
+}
+
+func (q *Queries) FindLatestCandlesBySymbols(ctx context.Context, arg FindLatestCandlesBySymbolsParams) ([]Candle, error) {
+	rows, err := q.db.QueryContext(ctx, findLatestCandlesBySymbols, pq.Array(arg.SymbolCodes), arg.IntervalFilter, arg.MaxRows)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/feature/candles/usecase.go
+++ b/internal/feature/candles/usecase.go
@@ -27,6 +27,10 @@ func IsValidInterval(interval string) bool {
 type Repository interface {
 	// Find はデータベースからローソク足データを検索します。
 	Find(ctx context.Context, symbol, interval string, outputsize int) ([]Candle, error)
+
+	// FindLatestBySymbols は複数銘柄の直近 n 件を1クエリで取得します。
+	// 戻り値はフラットな []Candle（銘柄ごとに時刻降順）。
+	FindLatestBySymbols(ctx context.Context, codes []string, interval string, n int) ([]Candle, error)
 }
 
 // usecase はローソク足データ操作のユースケースを定義します。

--- a/internal/feature/candles/usecase_test.go
+++ b/internal/feature/candles/usecase_test.go
@@ -28,6 +28,12 @@ func (m *mockRepository) Find(ctx context.Context, symbol, interval string, outp
 	return nil, errors.New("FindFunc is not implemented")
 }
 
+// FindLatestBySymbols はRepositoryインターフェースを満たすためだけに存在します
+// （GetCandlesのテストでは使用しません）。
+func (m *mockRepository) FindLatestBySymbols(ctx context.Context, codes []string, interval string, n int) ([]candles.Candle, error) {
+	return nil, errors.New("FindLatestBySymbols is not implemented")
+}
+
 // TestCandlesUsecase_GetCandles はGetCandlesメソッドのパラメータ処理とリポジトリ呼び出しをテストします。
 func TestCandlesUsecase_GetCandles(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
## 概要
`/v1/quotes` は cache-miss 時、銘柄ごとに `CachingRepository.Find` が全件（`MaxOutputSize=5000`）を取得してキャッシュを再構築していた。最大50銘柄を並行8で fan-out するため、`bars=0`（2件で足りる）でも Redis コールドスタート時に最大25万行/リクエストの DB 読み取りが発生し得た。quotes 専用の一括クエリを導入し、必要件数のみを1クエリで取得するよう改善する。

## 変更内容
- `GetQuotes` を銘柄ごとの `Find` fan-out（errgroup・並行8）から、`FindLatestBySymbols` の一括SQL1回に置き換え
- `unnest($1::text[]) + CROSS JOIN LATERAL` で各銘柄の直近N件のみ取得（銘柄ごとに `LIMIT N` で打ち切られる）
- quotes 経路は Redis を経由せず、`CachingRepository.FindLatestBySymbols` は inner への単純委譲（全件保持のキャッシュ契約を部分データで汚染しないため、キャッシュの読み書きはしない）
- `Repository` インターフェースに `FindLatestBySymbols` を追加、sqlc クエリ `FindLatestCandlesBySymbols` を生成
- 返却順が `codes` の順に安定するよう変更（従来は順序保証なし）

### 読み取り行数の比較（cache-miss / 50銘柄）
| | クエリ数 | DB読み取り行数 |
|---|---|---|
| 変更前 | 最大50 | 最大 250,000行（5000×50） |
| 変更後 | 1 | 約100行（bars=0）／最大25,000行（bars=500） |

## 影響範囲
- `/v1/candles` 経路・取り込みバッチ（cmd/batch）・DBスキーマ・DI・OpenAPI 仕様は変更なし
- `Repository` はメソッド追加のみ（既存 `Find` のシグネチャは不変）。HTTP APIコントラクトに破壊的変更なし
- `go.mod`: sqlc 生成コードが配列パラメータを `pq.Array` でエンコードするため `github.com/lib/pq` を直接依存に昇格（go.sum に間接依存として既存）

## 関連issue
- closes #327

## テスト
- usecase（quotes）: モックを `FindLatestBySymbols` ベースに更新、1回だけ呼ばれること・codes順の安定性を検証
- caching: inner へのパススルー、および Redis にキーが一切作成されないこと（miniredis）を検証
- repository: testcontainers の実DBで各銘柄N件・時刻降順・intervalフィルタ・存在しない銘柄の除外・空codes・範囲外Nのエラーを検証
- `go build ./...` / `go test ./... -race` / `golangci-lint run` / `go tool go-arch-lint check` すべてパス

## レビューポイント
- LATERAL クエリが既存の `(symbol_code, interval, time)` インデックスで銘柄ごとに `LIMIT` 打ち切りできている点（issue記載の `ROW_NUMBER` 案よりスキャン量を抑えられるため採用）
- CachingRepository をパススルーにした判断（キャッシュ汚染回避）