### PR TITLE
refactor: CSRFヘッダーをセキュリティ要件として定義

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -228,6 +228,7 @@ paths:
         - candles
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: code
           in: path
@@ -289,6 +290,7 @@ paths:
         - quotes
       security:
         - cookieAuth: []
+        - bearerAuth: []
       parameters:
         - name: codes
           in: query
@@ -349,6 +351,7 @@ paths:
         - symbols
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: 銘柄一覧
@@ -375,6 +378,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+        - bearerAuth: []
       responses:
         "200":
           description: ウォッチリスト一覧
@@ -400,6 +404,7 @@ paths:
       security:
         - cookieAuth: []
           csrfToken: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -455,6 +460,7 @@ paths:
       security:
         - cookieAuth: []
           csrfToken: []
+        - bearerAuth: []
       parameters:
         - name: code
           in: path
@@ -503,6 +509,7 @@ paths:
       security:
         - cookieAuth: []
           csrfToken: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -542,6 +549,7 @@ paths:
       security:
         - cookieAuth: []
           csrfToken: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -623,6 +631,7 @@ paths:
       security:
         - cookieAuth: []
           csrfToken: []
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -681,6 +690,11 @@ components:
       in: cookie
       name: auth_token
 
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
     csrfToken:
       type: apiKey
       name: X-CSRF-Token
@@ -691,7 +705,7 @@ components:
 
   responses:
     UnauthorizedError:
-      description: 認証失敗（auth_token Cookieが無い・無効・期限切れ）
+      description: 認証失敗（auth_token CookieまたはBearerトークンが無い・無効・期限切れ）
       content:
         application/json:
           schema:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -399,8 +399,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
-      parameters:
-        - $ref: "#/components/parameters/CsrfToken"
+          csrfToken: []
       requestBody:
         required: true
         content:
@@ -455,6 +454,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
+          csrfToken: []
       parameters:
         - name: code
           in: path
@@ -464,7 +464,6 @@ paths:
             type: string
             maxLength: 20
             pattern: "^[A-Za-z0-9._-]{1,20}$"
-        - $ref: "#/components/parameters/CsrfToken"
       responses:
         "204":
           description: 削除成功
@@ -503,8 +502,7 @@ paths:
         - watchlist
       security:
         - cookieAuth: []
-      parameters:
-        - $ref: "#/components/parameters/CsrfToken"
+          csrfToken: []
       requestBody:
         required: true
         content:
@@ -543,8 +541,7 @@ paths:
         - logo
       security:
         - cookieAuth: []
-      parameters:
-        - $ref: "#/components/parameters/CsrfToken"
+          csrfToken: []
       requestBody:
         required: true
         content:
@@ -625,8 +622,7 @@ paths:
         - logo
       security:
         - cookieAuth: []
-      parameters:
-        - $ref: "#/components/parameters/CsrfToken"
+          csrfToken: []
       requestBody:
         required: true
         content:
@@ -685,16 +681,13 @@ components:
       in: cookie
       name: auth_token
 
-  parameters:
-    CsrfToken:
+    csrfToken:
+      type: apiKey
       name: X-CSRF-Token
       in: header
-      required: true
       description: |
         CSRFトークン（Double Submit Cookieパターン）。
         ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
-      schema:
-        type: string
 
   responses:
     UnauthorizedError:

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -2,43 +2,99 @@ package apispec
 
 import (
 	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 )
 
-func TestMutationOperationsRequireCookieAndCSRF(t *testing.T) {
+var publicMutations = map[string]struct{}{
+	"POST /v1/signup":   {},
+	"POST /v1/login":    {},
+	"DELETE /v1/logout": {},
+}
+
+func TestAllMutationOperationsRequireCSRF(t *testing.T) {
 	t.Parallel()
 
 	doc, err := Load()
 	require.NoError(t, err)
 
+	for path, pathItem := range doc.Paths.Map() {
+		for method, operation := range pathItem.Operations() {
+			method = strings.ToUpper(method)
+			switch method {
+			case http.MethodGet, http.MethodHead, http.MethodOptions:
+				continue
+			}
+
+			operationKey := method + " " + path
+			if _, ok := publicMutations[operationKey]; ok {
+				continue
+			}
+
+			t.Run(operationKey, func(t *testing.T) {
+				require.NotNil(t, operation.Security)
+				require.Len(t, *operation.Security, 2)
+				require.True(t, hasExactSecurityRequirement(*operation.Security, "cookieAuth", "csrfToken"))
+				require.True(t, hasExactSecurityRequirement(*operation.Security, "bearerAuth"))
+			})
+		}
+	}
+}
+
+func TestSecuritySchemes(t *testing.T) {
+	t.Parallel()
+
+	doc, err := Load()
+	require.NoError(t, err)
+	require.NotNil(t, doc.Components)
+
 	tests := []struct {
-		method string
-		path   string
+		name         string
+		schemeType   string
+		in           string
+		headerName   string
+		scheme       string
+		bearerFormat string
 	}{
-		{method: http.MethodPost, path: "/v1/watchlist"},
-		{method: http.MethodDelete, path: "/v1/watchlist/{code}"},
-		{method: http.MethodPut, path: "/v1/watchlist/order"},
-		{method: http.MethodPost, path: "/v1/logo/detect"},
-		{method: http.MethodPost, path: "/v1/logo/analyze"},
+		{name: "cookieAuth", schemeType: "apiKey", in: "cookie", headerName: "auth_token"},
+		{name: "csrfToken", schemeType: "apiKey", in: "header", headerName: "X-CSRF-Token"},
+		{name: "bearerAuth", schemeType: "http", scheme: "bearer", bearerFormat: "JWT"},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
-			t.Parallel()
-
-			pathItem := doc.Paths.Find(tt.path)
-			require.NotNil(t, pathItem)
-
-			operation := pathItem.GetOperation(tt.method)
-			require.NotNil(t, operation)
-			require.NotNil(t, operation.Security)
-			require.Len(t, *operation.Security, 2)
-
-			require.Contains(t, (*operation.Security)[0], "cookieAuth")
-			require.Contains(t, (*operation.Security)[0], "csrfToken")
-			require.Contains(t, (*operation.Security)[1], "bearerAuth")
+		t.Run(tt.name, func(t *testing.T) {
+			schemeRef, ok := doc.Components.SecuritySchemes[tt.name]
+			require.True(t, ok)
+			require.NotNil(t, schemeRef)
+			require.NotNil(t, schemeRef.Value)
+			require.Equal(t, tt.schemeType, schemeRef.Value.Type)
+			require.Equal(t, tt.in, schemeRef.Value.In)
+			require.Equal(t, tt.headerName, schemeRef.Value.Name)
+			require.Equal(t, tt.scheme, schemeRef.Value.Scheme)
+			require.Equal(t, tt.bearerFormat, schemeRef.Value.BearerFormat)
 		})
 	}
+}
+
+func hasExactSecurityRequirement(requirements openapi3.SecurityRequirements, names ...string) bool {
+	for _, requirement := range requirements {
+		if len(requirement) != len(names) {
+			continue
+		}
+
+		matches := true
+		for _, name := range names {
+			if _, ok := requirement[name]; !ok {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
 }

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -1,0 +1,43 @@
+package apispec
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMutationOperationsRequireCookieAndCSRF(t *testing.T) {
+	t.Parallel()
+
+	doc, err := Load()
+	require.NoError(t, err)
+
+	tests := []struct {
+		method string
+		path   string
+	}{
+		{method: http.MethodPost, path: "/v1/watchlist"},
+		{method: http.MethodDelete, path: "/v1/watchlist/{code}"},
+		{method: http.MethodPut, path: "/v1/watchlist/order"},
+		{method: http.MethodPost, path: "/v1/logo/detect"},
+		{method: http.MethodPost, path: "/v1/logo/analyze"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method+" "+tt.path, func(t *testing.T) {
+			t.Parallel()
+
+			pathItem := doc.Paths.Find(tt.path)
+			require.NotNil(t, pathItem)
+
+			operation := pathItem.GetOperation(tt.method)
+			require.NotNil(t, operation)
+			require.NotNil(t, operation.Security)
+			require.Len(t, *operation.Security, 1)
+
+			require.Contains(t, (*operation.Security)[0], "cookieAuth")
+			require.Contains(t, (*operation.Security)[0], "csrfToken")
+		})
+	}
+}

--- a/api/spec_test.go
+++ b/api/spec_test.go
@@ -34,10 +34,11 @@ func TestMutationOperationsRequireCookieAndCSRF(t *testing.T) {
 			operation := pathItem.GetOperation(tt.method)
 			require.NotNil(t, operation)
 			require.NotNil(t, operation.Security)
-			require.Len(t, *operation.Security, 1)
+			require.Len(t, *operation.Security, 2)
 
 			require.Contains(t, (*operation.Security)[0], "cookieAuth")
 			require.Contains(t, (*operation.Security)[0], "csrfToken")
+			require.Contains(t, (*operation.Security)[1], "bearerAuth")
 		})
 	}
 }

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -8,6 +8,7 @@ import (
 )
 
 const (
+	BearerAuthScopes bearerAuthContextKey = "bearerAuth.Scopes"
 	CookieAuthScopes cookieAuthContextKey = "cookieAuth.Scopes"
 	CsrfTokenScopes  csrfTokenContextKey  = "csrfToken.Scopes"
 )
@@ -232,6 +233,9 @@ type WatchlistItem struct {
 
 // UnauthorizedError defines model for UnauthorizedError.
 type UnauthorizedError = ErrorResponse
+
+// bearerAuthContextKey is the context key for bearerAuth security scheme
+type bearerAuthContextKey string
 
 // cookieAuthContextKey is the context key for cookieAuth security scheme
 type cookieAuthContextKey string

--- a/internal/api/types.gen.go
+++ b/internal/api/types.gen.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	CookieAuthScopes cookieAuthContextKey = "cookieAuth.Scopes"
+	CsrfTokenScopes  csrfTokenContextKey  = "csrfToken.Scopes"
 )
 
 // Defines values for BeginOAuthParamsProvider.
@@ -229,14 +230,14 @@ type WatchlistItem struct {
 	SymbolCode string `json:"symbol_code"`
 }
 
-// CsrfToken defines model for CsrfToken.
-type CsrfToken = string
-
 // UnauthorizedError defines model for UnauthorizedError.
 type UnauthorizedError = ErrorResponse
 
 // cookieAuthContextKey is the context key for cookieAuth security scheme
 type cookieAuthContextKey string
+
+// csrfTokenContextKey is the context key for csrfToken security scheme
+type csrfTokenContextKey string
 
 // BeginOAuthParamsProvider defines parameters for BeginOAuth.
 type BeginOAuthParamsProvider string
@@ -262,24 +263,10 @@ type GetCandlesParams struct {
 // GetCandlesParamsInterval defines parameters for GetCandles.
 type GetCandlesParamsInterval string
 
-// AnalyzeCompanyParams defines parameters for AnalyzeCompany.
-type AnalyzeCompanyParams struct {
-	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
-	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
-	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
-}
-
 // DetectLogoMultipartBody defines parameters for DetectLogo.
 type DetectLogoMultipartBody struct {
 	// Image ロゴ検出対象の画像ファイル（最大10MB）
 	Image openapi_types.File `json:"image"`
-}
-
-// DetectLogoParams defines parameters for DetectLogo.
-type DetectLogoParams struct {
-	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
-	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
-	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
 }
 
 // GetQuotesParams defines parameters for GetQuotes.
@@ -296,27 +283,6 @@ type GetQuotesParams struct {
 
 // GetQuotesParamsInterval defines parameters for GetQuotes.
 type GetQuotesParamsInterval string
-
-// AddToWatchlistParams defines parameters for AddToWatchlist.
-type AddToWatchlistParams struct {
-	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
-	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
-	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
-}
-
-// ReorderWatchlistParams defines parameters for ReorderWatchlist.
-type ReorderWatchlistParams struct {
-	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
-	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
-	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
-}
-
-// RemoveFromWatchlistParams defines parameters for RemoveFromWatchlist.
-type RemoveFromWatchlistParams struct {
-	// XCSRFToken CSRFトークン（Double Submit Cookieパターン）。
-	// ログイン時にSet-Cookieで発行された csrf_token Cookie の値を、変更系リクエストでこのヘッダーに設定します。
-	XCSRFToken CsrfToken `json:"X-CSRF-Token"`
-}
 
 // LoginJSONRequestBody defines body for Login for application/json ContentType.
 type LoginJSONRequestBody = LoginRequest

--- a/internal/transport/openapivalidate/middleware.go
+++ b/internal/transport/openapivalidate/middleware.go
@@ -34,9 +34,9 @@ func New() (func(http.Handler) http.Handler, error) {
 
 	opts := &nethttpmiddleware.Options{
 		Options: openapi3filter.Options{
-			// 認証は jwt / csrf ミドルウェアが担うため、検証層では認証を no-op にする。
-			// spec の protected route は security: [cookieAuth] を宣言しており、
-			// これを設定しないと openapi3filter が認証器不在でエラーになる。
+			// 認証とCSRFの実検証は前段の jwt / csrf ミドルウェアが担う。
+			// OpenAPI の Security Requirement は契約記述に使用し、この検証層では no-op にする。
+			// これを設定しないと openapi3filter が各 Security Scheme の認証器不在でエラーになる。
 			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
 		},
 		// バリデーション失敗時は詳細をログに残しつつ、クライアントへは汎用文言を返す

--- a/internal/transport/openapivalidate/middleware_test.go
+++ b/internal/transport/openapivalidate/middleware_test.go
@@ -98,9 +98,6 @@ func TestMiddleware_RequestValidation(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
 			req.Header.Set("Content-Type", "application/json")
-			// 保護ルートは spec で X-CSRF-Token ヘッダーを必須宣言しているため常に付与する
-			// （実運用では csrf ミドルウェアが先に検証し、ここには到達済みの値が渡る）。
-			req.Header.Set("X-CSRF-Token", "dummy-csrf-token")
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, tt.expectedStatus, w.Code)


### PR DESCRIPTION
## 概要
OpenAPI上の `X-CSRF-Token` を通常の必須ヘッダーパラメーターではなく、Cookie認証と組み合わせるセキュリティ要件として定義します。あわせて実装済みのBearer認証を契約へ追加し、保護APIを `(cookieAuth AND csrfToken) OR bearerAuth` として実際のHTTP契約に一致させます。

## 変更内容
- `csrfToken` をヘッダー型、`bearerAuth` をHTTP Bearer型のセキュリティスキームとして追加
- 保護された参照系APIを `cookieAuth OR bearerAuth` として定義
- 変更系5エンドポイントを `(cookieAuth AND csrfToken) OR bearerAuth` として定義
- OpenAPIからGo型を再生成し、各操作の `XCSRFToken` パラメーター型を削除
- 全変更系エンドポイントを走査し、認証・CSRF要件の追加漏れを検出する契約テストを追加
- Cookie・CSRF・BearerのSecurity Scheme定義を契約テストで検証
- OpenAPI検証テストから不要になったダミーCSRFヘッダーを削除

## 実行時検証の責務
OpenAPIのSecurity RequirementはAPI契約の記述に使用します。`openapi3filter` の `AuthenticationFunc` はno-opのままとし、実際の認証とCSRF検証はルーター上で先に実行される `jwt.AuthRequired` と `csrf.Protect` が担当します。したがって、ヘッダー欠落時の403など既存の実挙動は変わりません。

## テスト
- `go generate ./internal/api/...`（再実行後の差分ゼロ）
- `go test ./...`
- `go build ./...`
- `golangci-lint run --timeout=5m ./api/... ./cmd/... ./db/... ./internal/...`（0 issues）
- `git diff --check`

## レビューポイント
- Cookie認証とCSRFトークンが同一Security Requirement内のAND条件になっているか
- Cookie認証経路とBearer認証経路が別Security RequirementのOR条件になっているか
- 実際の認証・CSRF検証を既存ミドルウェアに維持したまま、生成型から呼び出し側のヘッダー指定だけが除去されているか
- 新しい変更系APIでCSRF要件を書き忘れた場合に契約テストが失敗するか