### PR TITLE
feat: キャッシュTTLの設定と削除失敗ログを追加

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -92,7 +92,7 @@ func run() int {
 
 	// Redisキャッシュでラップ（ingestのUpsertBatchは対象キーをDELするのみで、再構築は
 	// 次回Findのcache-miss時に行われる。TTLはDEL失敗時や競合による汚染時のセーフティネット）
-	cachedCandleRepo := candles.NewCachingRepository(rdb, candles.DefaultCacheTTL, candleRepo, "candles")
+	cachedCandleRepo := candles.NewCachingRepository(rdb, cfg.Cache.CandlesTTL, candleRepo, "candles")
 
 	// JWTジェネレータ・ブラックリスト（ログアウト時の即時失効用）
 	jwtGen := jwt.NewGenerator(cfg.Server.JWTSecret, jwt.DefaultTokenTTL)

--- a/docker/example.env
+++ b/docker/example.env
@@ -67,6 +67,9 @@ REDIS_HOST=redis
 REDIS_PORT=6379
 REDIS_PASSWORD=
 
+# ローソク足キャッシュTTL（任意。time.ParseDuration形式。未設定・不正時は24h）
+# CANDLES_CACHE_TTL=24h
+
 # Google Cloud (ロゴ検出・企業分析機能)
 GOOGLE_GENAI_USE_VERTEXAI=true
 GOOGLE_CLOUD_PROJECT=your_gcp_project_id

--- a/docs/features/candles.md
+++ b/docs/features/candles.md
@@ -563,7 +563,7 @@ go test ./internal/feature/candles/... -v -race -cover
 | 設定 | 値 | 説明 |
 |------|-----|------|
 | キー形式 | `candles:{symbol}:{interval}` | symbol+interval単位でキャッシュ（全データ最大5000件を保存） |
-| 本番TTL | 24時間 | `candles.DefaultCacheTTL`。DEL失敗時や競合による汚染時に古いキャッシュが残り続けないためのセーフティネット |
+| TTL | 24時間（既定値） | `CANDLES_CACHE_TTL`（`time.ParseDuration`形式）で変更可能。DEL失敗時や競合による汚染時に古いキャッシュが残り続けないためのセーフティネット |
 | デフォルトTTL | 5分 | コンストラクタにttl=0を渡した場合のフォールバック |
 | 名前空間 | `candles` | 分離のためのキープレフィックス |
 
@@ -572,12 +572,13 @@ go test ./internal/feature/candles/... -v -race -cover
 1. **読み取りパス（Find）**
    - Redisのキャッシュデータを確認
    - ヒット時: デシリアライズしたデータを返却
-   - ミス時: PostgreSQLにクエリし、`SET NX`（キーが存在しない場合のみ書き込み、TTL 24h）でキャッシュしてから返却
+   - ミス時: PostgreSQLにクエリし、`SET NX`（キーが存在しない場合のみ書き込み、TTLは`CANDLES_CACHE_TTL`、既定値24h）でキャッシュしてから返却
    - Redisエラー時: キャッシュをバイパスし、PostgreSQLに直接クエリ
 
 2. **書き込みパス（UpsertBatch）**
    - まずPostgreSQLに書き込み
    - 影響を受ける symbol+interval のキャッシュキーを削除するのみ（`DEL candles:{symbol}:{interval}`、ウォームアップなし）
+   - キャッシュ削除に失敗した場合は、対象のsymbol・intervalとエラーを警告ログに記録し、DB更新は成功として扱う
    - 再構築は行わず、次回Findのcache-miss経路に委ねる（ingestバッチとAPIサーバーは別インスタンスで動作するため、
      UpsertBatch直後にウォームアップすると、他インスタンスのFindが読んだ古いDBデータで上書きされる競合が
      起こり得る。「書くのは読み手だけ、消すのは書き手だけ」の原則により、この競合を回避している）

--- a/internal/app/batch/candles.go
+++ b/internal/app/batch/candles.go
@@ -49,7 +49,7 @@ func runCandleIngest(cfg *config.Config) int {
 
 	// UpsertBatchは対象キーのキャッシュをDELするのみで、再構築は次回Findのcache-miss時に行われる。
 	// TTLはDEL失敗時や競合による汚染時に古いキャッシュが残り続けないためのセーフティネット。
-	cachedCandleRepo := candles.NewCachingRepository(rdb, candles.DefaultCacheTTL, candleRepo, "candles")
+	cachedCandleRepo := candles.NewCachingRepository(rdb, cfg.Cache.CandlesTTL, candleRepo, "candles")
 
 	uc := candles.NewIngestUsecase(marketRepo, cachedCandleRepo, ingestSymbolRepo, rateLimiter)
 

--- a/internal/app/config/config.go
+++ b/internal/app/config/config.go
@@ -33,6 +33,8 @@ const (
 	defaultIngestTimeoutHours = 3
 	// defaultMaxFailureRate は *_MAX_FAILURE_RATE のデフォルト値。
 	defaultMaxFailureRate = 0.2
+	// defaultCandlesCacheTTL は CANDLES_CACHE_TTL 未設定・不正時のフォールバック。
+	defaultCandlesCacheTTL = 24 * time.Hour
 	// minSecretLength は JWT_SECRET / PASSWORD_PEPPER に要求する最低バイト数。
 	// HS256 署名鍵の総当たり偽造を防ぐため 32 バイト以上を必須とする。
 	minSecretLength = 32
@@ -44,6 +46,7 @@ type Config struct {
 	Log        LogConfig         // 全エントリポイント共通
 	DB         db.Config         // API / batch / migrate
 	Redis      RedisConfig       // API / batch
+	Cache      CacheConfig       // API / batch
 	Server     ServerConfig      // API のみ
 	OAuth      *di.OAuthConfig   // API のみ（OAuth 無効なら nil）
 	TwelveData twelvedata.Config // batch のみ
@@ -62,6 +65,11 @@ type RedisConfig struct {
 	Host     string
 	Port     string
 	Password string
+}
+
+// CacheConfig はキャッシュの有効期限設定です。
+type CacheConfig struct {
+	CandlesTTL time.Duration
 }
 
 // ServerConfig は API サーバー固有の検証済み設定です。
@@ -92,6 +100,7 @@ func LoadAPI() (*Config, error) {
 	cfg.Log = readLog(&cfg.Warnings)
 	cfg.DB = readDB(&cfg.Warnings)
 	cfg.Redis = readRedis()
+	cfg.Cache = readCache(&cfg.Warnings)
 
 	server, err := readServer(&cfg.Warnings)
 	if err != nil {
@@ -115,6 +124,7 @@ func LoadBatch() (*Config, error) {
 	cfg.Log = readLog(&cfg.Warnings)
 	cfg.DB = readDB(&cfg.Warnings)
 	cfg.Redis = readRedis()
+	cfg.Cache = readCache(&cfg.Warnings)
 	cfg.TwelveData = readTwelveData()
 	cfg.Batch = readBatch(&cfg.Warnings)
 	return cfg, nil
@@ -168,6 +178,15 @@ func readRedis() RedisConfig {
 		Port:     os.Getenv("REDIS_PORT"),
 		Password: os.Getenv("REDIS_PASSWORD"),
 	}
+}
+
+// readCache はキャッシュ関連の環境変数を読み込みます。
+func readCache(warn *[]string) CacheConfig {
+	ttl := readDuration("CANDLES_CACHE_TTL", warn)
+	if ttl == 0 {
+		ttl = defaultCandlesCacheTTL
+	}
+	return CacheConfig{CandlesTTL: ttl}
 }
 
 // readTwelveData は TWELVE_DATA_* 環境変数から TwelveData クライアント設定を組み立てます。

--- a/internal/app/config/config_test.go
+++ b/internal/app/config/config_test.go
@@ -117,6 +117,36 @@ func TestReadDuration(t *testing.T) {
 	}
 }
 
+func TestReadCache(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		want     time.Duration
+		wantWarn bool
+	}{
+		{name: "未設定は既定値", value: "", want: defaultCandlesCacheTTL},
+		{name: "正常値", value: "2h30m", want: 2*time.Hour + 30*time.Minute},
+		{name: "不正値は警告して既定値", value: "invalid", want: defaultCandlesCacheTTL, wantWarn: true},
+		{name: "0以下は警告して既定値", value: "0s", want: defaultCandlesCacheTTL, wantWarn: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CANDLES_CACHE_TTL", tt.value)
+			var warn []string
+
+			got := readCache(&warn)
+
+			if got.CandlesTTL != tt.want {
+				t.Errorf("CandlesTTL = %v, want %v", got.CandlesTTL, tt.want)
+			}
+			if (len(warn) > 0) != tt.wantWarn {
+				t.Errorf("warn = %v, wantWarn %v", warn, tt.wantWarn)
+			}
+		})
+	}
+}
+
 // TestParseCORSOrigins は CORS_ALLOWED_ORIGINS env の生文字列パースが
 // trim・空要素除去・複数要素対応を正しく行うことを検証します。
 func TestParseCORSOrigins(t *testing.T) {

--- a/internal/feature/candles/caching_repository.go
+++ b/internal/feature/candles/caching_repository.go
@@ -4,17 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 )
-
-// DefaultCacheTTL はキャッシュが汚染された場合やDEL失敗時に、古いデータが
-// 残り続けないためのセーフティネットTTL。通常運用ではingestのUpsertBatchが
-// 対象キーをDELし、次回Find時のcache-miss経路でキャッシュが再構築されるため、
-// このTTLはあくまでフォールバックとしてのみ機能する。
-const DefaultCacheTTL = 24 * time.Hour
 
 // readWriteRepository はCachingRepositoryが内部で必要とする読み書きインターフェースです。
 type readWriteRepository interface {
@@ -79,7 +74,13 @@ func (c *CachingRepository) UpsertBatch(ctx context.Context, candles []Candle) e
 	// 各 symbol+interval のキャッシュを削除するのみ（再構築は次回Findに委ねる）
 	for si := range seen {
 		key := c.cacheKey(si.symbol, si.interval)
-		_ = c.rdb.Del(ctx, key).Err() // ベストエフォート
+		if err := c.rdb.Del(ctx, key).Err(); err != nil {
+			slog.Warn("failed to invalidate candle cache",
+				"symbol", si.symbol,
+				"interval", si.interval,
+				"error", err,
+			)
+		}
 	}
 	return nil
 }

--- a/internal/feature/candles/caching_repository_concurrent_test.go
+++ b/internal/feature/candles/caching_repository_concurrent_test.go
@@ -89,7 +89,7 @@ func TestCachingRepository_ConcurrentFindAndUpsert(t *testing.T) {
 	)
 
 	inner := newVersionedInnerRepository(symbol, interval, candleCount)
-	repo := NewCachingRepository(rdb, DefaultCacheTTL, inner, "candles-concurrent-test")
+	repo := NewCachingRepository(rdb, 24*time.Hour, inner, "candles-concurrent-test")
 
 	ctx := context.Background()
 

--- a/internal/feature/candles/caching_repository_test.go
+++ b/internal/feature/candles/caching_repository_test.go
@@ -485,6 +485,34 @@ func TestCachingCandleRepository_UpsertBatch_InvalidatesCache(t *testing.T) {
 	}
 }
 
+// TestCachingCandleRepository_UpsertBatch_CacheInvalidationError はキャッシュ削除に
+// 失敗しても、DBへの書き込みが成功していればUpsertBatchを成功として扱うことを検証します。
+func TestCachingCandleRepository_UpsertBatch_CacheInvalidationError(t *testing.T) {
+	t.Parallel()
+
+	rdb, mock := redismock.NewClientMock()
+	defer func() { _ = rdb.Close() }()
+
+	inner := &mockReadWriteRepository{
+		upsertBatchFn: func(ctx context.Context, candles []Candle) error {
+			return nil
+		},
+	}
+
+	mock.ExpectDel("candles:AAPL:1day").SetErr(errors.New("redis unavailable"))
+
+	repo := NewCachingRepository(rdb, 5*time.Minute, inner, "candles")
+	err := repo.UpsertBatch(context.Background(), []Candle{
+		{SymbolCode: "AAPL", Interval: "1day"},
+	})
+	if err != nil {
+		t.Fatalf("cache invalidation error should not fail the DB write: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled mock expectations: %v", err)
+	}
+}
+
 // TestCachingCandleRepository_UpsertBatch_DeduplicatesDel は同一symbol+intervalの
 // キャッシュキーに対するDELが重複せず1回のみ実行されることを検証します。
 func TestCachingCandleRepository_UpsertBatch_DeduplicatesDel(t *testing.T) {


### PR DESCRIPTION
## 概要
ローソク足キャッシュのTTLを環境変数で調整できるようにし、Redis障害によるキャッシュ削除失敗をログから検知可能にします。DB更新は従来どおり成功扱いとし、キャッシュ障害に対するfail-open方針を維持します。

## 変更内容
- `CANDLES_CACHE_TTL`を追加し、API・candlesバッチ双方からキャッシュTTLへ反映
- 未設定・不正値では既定値の24時間へフォールバックし、不正値を起動時警告へ記録
- キャッシュ削除失敗時にsymbol・interval・エラーを構造化ログへ出力
- 設定値の正常系・異常系と、削除失敗時のベストエフォート動作をテスト
- サンプル環境変数とcandles機能ドキュメントを更新

## 破壊的変更
- 任意環境変数`CANDLES_CACHE_TTL`を追加。未設定時は従来と同じ24時間を使用するため、既存環境の移行作業は不要

## テスト
- `go test ./... -count=1`
- `go build ./...`
- `go tool go-arch-lint check`
- `git diff --check`

## レビューポイント
- キャッシュ削除失敗をDB更新失敗として扱わず、警告ログのみとするfail-open方針が適切か
- TTLの未設定・不正時に従来値24時間へフォールバックする設定経路が適切か
