### PR TITLE
docs: JWTブラックリストのfail-open説明を実装に合わせて修正

### DIFF
--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -144,7 +144,7 @@ sequenceDiagram
 
 **注意**: ログアウトは期限切れトークンでも動作するよう、認証不要のルートに配置されています（失効させるべき有効なトークンがない場合、ブラックリスト登録はスキップされます）。
 
-**即時失効の仕組み（issue #263）**: JWTには生成時に`jti`（JWT ID）クレームを付与しており（`internal/transport/jwt/generator.go`）、ログアウト時に`jti`をRedisブラックリストへ登録します（`internal/transport/jwt/blacklist.go`）。認証ミドルウェア（`AuthRequired`）はリクエストごとにブラックリストを確認し、登録済みの`jti`を持つトークンを401で拒否します。ブラックリストのRedisエントリはトークンの残り有効期限と同じTTLで自動失効するため、際限なく肥大化しません。Redis未接続時は他のRedis依存コンポーネント（レートリミッター・キャッシュ）と同様にフェイルオープン（失効チェックをスキップ）します。
+**即時失効の仕組み（issue #263）**: JWTには生成時に`jti`（JWT ID）クレームを付与しており（`internal/transport/jwt/generator.go`）、ログアウト時に`jti`をRedisブラックリストへ登録します（`internal/transport/jwt/blacklist.go`）。認証ミドルウェア（`AuthRequired`）はリクエストごとにブラックリストを確認し、登録済みの`jti`を持つトークンを401で拒否します。ブラックリストのRedisエントリはトークンの残り有効期限と同じTTLで自動失効するため、際限なく肥大化しません。Redis未接続時はフェイルオープン（失効チェックをスキップ）します。JWTは元々短命（`DefaultTokenTTL` = 1時間）で`exp`により失効するため、ブラックリストは失効を前倒しする補助機構と位置づけ、可用性を優先する方針です。認証系レートリミットは同じRedis障害に対してfail-closed（503）である点に注意してください（[ADR-0008](../adr/0008-レートリミット障害時のfail-open-fail-closed方針.md)）。
 
 ### OAuth2 認可開始フロー
 

--- a/internal/transport/jwt/blacklist.go
+++ b/internal/transport/jwt/blacklist.go
@@ -40,8 +40,10 @@ func (b *Blacklist) Revoke(ctx context.Context, jti string, ttl time.Duration) e
 }
 
 // IsRevoked はjtiがブラックリストに登録されているかを確認します。
-// Redis未接続・エラー時は「失効していない」として扱います（フェイルオープン。
-// 他のRedis依存コンポーネント（レートリミッター・キャッシュ）と同じグレースフルデグレード方針）。
+// Redis未接続・エラー時は「失効していない」として扱います（フェイルオープン）。
+// JWTは元々短命（DefaultTokenTTL = 1時間）でexpにより失効するため、ブラックリストは
+// 失効を前倒しする補助機構と位置づけ、Redis障害時は可用性を優先します。
+// 認証系レートリミットは同じRedis障害に対してfail-closedです（ADR-0008）。
 func (b *Blacklist) IsRevoked(ctx context.Context, jti string) bool {
 	if b == nil || b.rdb == nil || jti == "" {
 		return false


### PR DESCRIPTION
## 概要

`jwt.Blacklist.IsRevoked` の doc コメントが、fail-open の根拠を
**「他のRedis依存コンポーネント（レートリミッター・キャッシュ）と同じグレースフルデグレード方針」**
と説明していましたが、ADR-0008（issue #266）でレートリミッターは **fail-closed** に変更されており、
記述が実装と逆になっていました。

実際に `router.go` の 6 箇所と `authhttp/handler.go:108` はすべて `httpratelimit.FailClosed` を
指定しており、`FailOpen` を使う呼び出し元は現在ゼロです。この状態のコメントは
「このリポジトリは Redis 依存を一律 fail-open にしている」という誤った理解を招きます。

fail-open という方針自体は ADR-0008 で意図的に維持されているため、**挙動は一切変更せず説明文のみ**を修正しました。

## 変更内容

| ファイル | 内容 |
| --- | --- |
| `internal/transport/jwt/blacklist.go` | `IsRevoked` の doc コメントを修正。根拠を ADR-0008 の実際の判断（JWTが短命で `exp` により失効するため、ブラックリストは失効を前倒しする補助機構）に差し替え、レートリミッターが fail-closed である点を明示 |
| `docs/features/auth.md` | 同じ誤った一文がコピーされていたため併せて修正し、ADR-0008 へのリンクを追加 |

## スコープ外（確認済み・修正不要）

- `docs/adr/0008-*.md` — 決定内容は実装と一致しており正しい
- `internal/transport/jwt/blacklist_test.go` — 「フェイルオープン」とだけ書かれており誤った相互参照はない
- `internal/transport/httpratelimit/limiter.go` の `FailOpen` 定数 — 現在利用箇所はないが、ADR-0008 が将来の非クリティカル用途向けに残す判断をしているためそのまま
- `docs/features/auth.md` の「Redis障害時の挙動（fail-closed）」節 — ADR-0008 反映済みで正しい

## 検証

コメント・ドキュメントのみの変更で挙動は変わらないため、既存テストがそのまま通ることを確認しました。

- `go build ./...` → BUILD OK
- `go test ./internal/transport/jwt/... -race` → ok (1.508s)
- `golangci-lint run --timeout=5m` → 0 issues
- `grep -rn "レートリミッター・キャッシュ" .` → 0 件（誤った相互参照は解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
