### PR TITLE
chore: ドキュメントと運用設定を現行実装に同期

### DIFF
--- a/.github/workflows/cd-api.yaml
+++ b/.github/workflows/cd-api.yaml
@@ -61,12 +61,12 @@ jobs:
                     --region "${{ env.REGION }}" \
                     --platform managed \
                     --allow-unauthenticated \
-                    --set-env-vars=GIN_MODE=release,TRUSTED_PROXY_HOPS=1 \
+                    --set-env-vars=APP_ENV=production,COOKIE_SECURE=true,TRUSTED_PROXY_HOPS=1,GOOGLE_GENAI_USE_VERTEXAI=true,GOOGLE_CLOUD_PROJECT=${{ secrets.GCP_PROJECT_ID }},GOOGLE_CLOUD_LOCATION=${{ env.REGION }} \
                     --service-account "${{ env.RUNTIME_SERVICE_ACCOUNT }}" \
                     --add-cloudsql-instances "${{ secrets.INSTANCE_CONNECTION_NAME_FOR_DEPLOY }}" \
                     --vpc-connector run-connector \
                     --vpc-egress private-ranges-only \
-                    --set-secrets JWT_SECRET=JWT_SECRET:latest,TWELVE_DATA_API_KEY=TWELVE_DATA_API_KEY:latest,TWELVE_DATA_BASE_URL=TWELVE_DATA_BASE_URL:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,DB_NAME=DB_NAME:latest,INSTANCE_CONNECTION_NAME=INSTANCE_CONNECTION_NAME:latest,RUN_MIGRATIONS=RUN_MIGRATIONS:latest,REDIS_HOST=REDIS_HOST:latest,REDIS_PORT=REDIS_PORT:latest,REDIS_PASSWORD=REDIS_PASSWORD:latest \
+                    --set-secrets JWT_SECRET=JWT_SECRET:latest,PASSWORD_PEPPER=PASSWORD_PEPPER:latest,CORS_ALLOWED_ORIGINS=CORS_ALLOWED_ORIGINS:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,DB_NAME=DB_NAME:latest,INSTANCE_CONNECTION_NAME=INSTANCE_CONNECTION_NAME:latest,REDIS_HOST=REDIS_HOST:latest,REDIS_PORT=REDIS_PORT:latest,REDIS_PASSWORD=REDIS_PASSWORD:latest \
                     $EXTRA \
                     --quiet
 

--- a/.github/workflows/cd-batch.yaml
+++ b/.github/workflows/cd-batch.yaml
@@ -28,6 +28,8 @@ jobs:
                       batch_arg: candles
                     - job_name: logo
                       batch_arg: logo
+                    - job_name: auth-session-cleanup
+                      batch_arg: auth-session-cleanup
 
         steps:
             - name: Checkout
@@ -76,12 +78,12 @@ jobs:
                     "--task-timeout=900s"
                     "--cpu=1"
                     "--memory=512Mi"
-                    --set-env-vars=GIN_MODE=release
+                    --set-env-vars=APP_ENV=production
                     "--service-account=${{ env.RUNTIME_SERVICE_ACCOUNT }}"
                     "--add-cloudsql-instances=${{ secrets.INSTANCE_CONNECTION_NAME_FOR_DEPLOY }}"
                     "--vpc-connector=run-connector"
                     "--vpc-egress=private-ranges-only"
-                    "--set-secrets=JWT_SECRET=JWT_SECRET:latest,TWELVE_DATA_API_KEY=TWELVE_DATA_API_KEY:latest,TWELVE_DATA_BASE_URL=TWELVE_DATA_BASE_URL:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,DB_NAME=DB_NAME:latest,INSTANCE_CONNECTION_NAME=INSTANCE_CONNECTION_NAME:latest,RUN_MIGRATIONS=RUN_MIGRATIONS:latest,REDIS_HOST=REDIS_HOST:latest,REDIS_PORT=REDIS_PORT:latest,REDIS_PASSWORD=REDIS_PASSWORD:latest"
+                    "--set-secrets=TWELVE_DATA_API_KEY=TWELVE_DATA_API_KEY:latest,TWELVE_DATA_BASE_URL=TWELVE_DATA_BASE_URL:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,DB_NAME=DB_NAME:latest,INSTANCE_CONNECTION_NAME=INSTANCE_CONNECTION_NAME:latest,REDIS_HOST=REDIS_HOST:latest,REDIS_PORT=REDIS_PORT:latest,REDIS_PASSWORD=REDIS_PASSWORD:latest"
                   )
 
                   if [ "$CMD" = "create" ]; then

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,6 +49,18 @@ jobs:
             echo "code_changed=false" >> "$GITHUB_OUTPUT"
           fi
 
+  # Markdown内のローカルリンク切れを、ドキュメントのみのPRでも検出する。
+  docs-link-check:
+    name: Docs Link Check
+    needs: docs-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Check local Markdown links
+        run: bash scripts/check-doc-links.sh
+
   # 静的解析（golangci-lint）
   lint:
     name: Lint
@@ -212,19 +224,21 @@ jobs:
   # GitHub Branch Protectionではこのジョブだけをrequiredに設定する
   ci-gate:
     name: CI Gate
-    needs: [lint, arch-lint, vuln-scan, build-test, schema-doc-check]
+    needs: [docs-link-check, lint, arch-lint, vuln-scan, build-test, schema-doc-check]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check CI results
         run: |
           LINT="${{ needs.lint.result }}"
+          DOCS_LINK="${{ needs.docs-link-check.result }}"
           ARCH_LINT="${{ needs.arch-lint.result }}"
           VULN_SCAN="${{ needs.vuln-scan.result }}"
           BUILD_TEST="${{ needs.build-test.result }}"
           SCHEMA_DOC="${{ needs.schema-doc-check.result }}"
-          echo "lint=${LINT} arch-lint=${ARCH_LINT} vuln-scan=${VULN_SCAN} build-test=${BUILD_TEST} schema-doc=${SCHEMA_DOC}"
-          if [[ "${LINT}" == "success" || "${LINT}" == "skipped" ]] && \
+          echo "docs-link=${DOCS_LINK} lint=${LINT} arch-lint=${ARCH_LINT} vuln-scan=${VULN_SCAN} build-test=${BUILD_TEST} schema-doc=${SCHEMA_DOC}"
+          if [[ "${DOCS_LINK}" == "success" ]] && \
+             [[ "${LINT}" == "success" || "${LINT}" == "skipped" ]] && \
              [[ "${ARCH_LINT}" == "success" || "${ARCH_LINT}" == "skipped" ]] && \
              [[ "${VULN_SCAN}" == "success" || "${VULN_SCAN}" == "skipped" ]] && \
              [[ "${BUILD_TEST}" == "success" || "${BUILD_TEST}" == "skipped" ]] && \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,7 +104,7 @@ api/
 internal/
 ├── api/              # OpenAPIから自動生成された型定義（types.gen.go）
 ├── app/
-│   ├── batch/        # バッチ実行ロジック（job_id ディスパッチ: candles / logo）
+│   ├── batch/        # バッチ実行ロジック（job_id: auth-session-cleanup / candles / logo）
 │   ├── config/       # 環境変数パースの純粋関数ヘルパー
 │   ├── di/           # 依存性注入ファクトリ
 │   ├── migrate/      # マイグレーション実行ロジック（goose サブコマンドディスパッチ）
@@ -119,8 +119,10 @@ internal/
 │   ├── csrf/         # CSRF保護（Double Submit Cookieパターン）
 │   ├── handler/      # プラットフォームレベルのHTTPハンドラー（ヘルスチェック等）
 │   ├── httpratelimit/ # Redisベースのスライディングウィンドウレートリミッター（HTTPミドルウェア）
+│   ├── httpx/        # JSON・クライアントIP等のHTTP共通処理
 │   ├── jwt/          # JWT生成・認証ミドルウェア（package jwt）
-│   └── middleware/   # 共通HTTPミドルウェア（セキュリティヘッダー等）
+│   ├── middleware/   # 共通HTTPミドルウェア（セキュリティヘッダー等）
+│   └── openapivalidate/ # OpenAPIリクエスト検証ミドルウェア
 ├── infra/            # 技術基盤層（外部リソース接続・横断ユーティリティ）
 │   ├── db/           # データベース初期化
 │   ├── httpclient/   # 外部API呼び出し用HTTPクライアント設定（outbound）
@@ -200,7 +202,7 @@ vertical slice として、各フィーチャーは**HTTP 読み取り**と**バ
 5. **3つのエントリーポイント**:
    - `cmd/api/main.go`: REST APIサーバー（ポート8080）の起動・DIワイヤリング
      - 環境変数パースの純粋関数ヘルパーは `internal/app/config/`（`CORS_ALLOWED_ORIGINS` / `COOKIE_SECURE` 等）
-   - `cmd/batch/main.go`: バッチジョブ統合エントリーポイント。コマンド引数 `job_id` で実行内容を切替（`candles`: TwelveData APIから株価データ取得 / `logo`: ロゴURL取得）
+   - `cmd/batch/main.go`: バッチジョブ統合エントリーポイント。コマンド引数 `job_id` で実行内容を切替（`auth-session-cleanup`: 期限切れ認証セッション削除 / `candles`: TwelveData APIから株価データ取得 / `logo`: ロゴURL取得）
    - `cmd/migrate/main.go`: goose 埋め込みマイグレーションを適用する専用バイナリ（Cloud Run Job 等で起動）
 
 ### 外部依存

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 - **ユーザー認証**
 
   - メールアドレス/パスワードによるログイン
-  - OAuth2 ソーシャルログイン（Google / GitHub、PKCE 対応。同メールの既存アカウントへの自動リンクは行わない）
+  - OAuth2 ソーシャルログイン（Google / GitHub。Google は PKCE 対応、GitHub は state による CSRF 保護。同メールの既存アカウントへの自動リンクは行わない）
   - JWTの発行（10分の短期アクセストークン + PostgreSQL管理のリフレッシュトークン）
   - トークン検証ミドルウェアによる認可
 
@@ -23,9 +23,9 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 
 - **キャッシュ最適化**
 
-  - ローソク足データ・シンボルデータのRedisキャッシュ
-  - TTL設定と自動リフレッシュ
-  - キャッシュミス時: API呼び出し + DB保存
+  - ローソク足データのRedisキャッシュ
+  - TTL設定とバッチ書き込み後のキャッシュ無効化
+  - キャッシュミス時: PostgreSQLから取得してRedisへ保存
 
 - **ロゴ検出・企業分析**
 
@@ -57,7 +57,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 | DB              | PostgreSQL / Cloud SQL                                              |
 | キャッシュ      | Redis                                                               |
 | AI / ML         | Cloud Vision API / Gemini API（Vertex AI）                          |
-| 認証・セキュリティ | JWT / bcrypt / OAuth2（Google・GitHub, PKCE）/ CSRF（Double Submit Cookie）/ レートリミット |
+| 認証・セキュリティ | JWT / bcrypt / OAuth2（GoogleのみPKCE、Google・GitHubともstate検証）/ CSRF（Double Submit Cookie）/ レートリミット |
 | API仕様         | OpenAPI 3.0.4 / oapi-codegen（型生成）                              |
 | 設定管理        | **docker/.env（ローカル）/ Secret Manager（本番）+ os.Getenv()**|
 | コンテナ        | Docker / Docker Compose                                             |
@@ -73,8 +73,8 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 │   └── oapi-codegen.cfg.yaml   # oapi-codegen設定（型のみ生成）
 │
 ├── cmd/
-│   ├── batch/                  # データ取得・取り込み（バッチジョブ: candles / logo）
-│   ├── migrate/                # スキーマのマイグレーション専用バイナリ（CI / Cloud Run pre-deploy 用）
+│   ├── batch/                  # バッチジョブ（auth-session-cleanup / candles / logo）
+│   ├── migrate/                # スキーマのマイグレーション専用バイナリ（CI / Cloud Run Job等で利用）
 │   └── api/                    # APIサーバーのエントリーポイント（main.go）
 │
 ├── internal/
@@ -83,7 +83,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 │   │   └── types.gen.go        # 生成コード（手動編集不可）
 │   │
 │   ├── app/                    # アプリケーション基盤
-│   │   ├── batch/              # バッチ実行ロジック（job_id ディスパッチ: candles / logo）
+│   │   ├── batch/              # バッチ実行ロジック（job_id ディスパッチ: auth-session-cleanup / candles / logo）
 │   │   ├── config/             # 環境変数パースの純粋関数ヘルパー
 │   │   ├── di/                 # 依存性注入
 │   │   ├── migrate/            # マイグレーション実行ロジック（goose サブコマンドディスパッチ）
@@ -116,8 +116,10 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 │   │   ├── csrf/               # CSRF保護（Double Submit Cookieパターン）
 │   │   ├── handler/            # ヘルスチェックハンドラー
 │   │   ├── httpratelimit/      # Redisベースのスライディングウィンドウレートリミッター（HTTPミドルウェア）
+│   │   ├── httpx/              # JSON・クライアントIP等のHTTP共通処理
 │   │   ├── jwt/                # JWT生成/検証/ミドルウェア（package jwt）
-│   │   └── middleware/         # セキュリティヘッダーミドルウェア
+│   │   ├── middleware/         # セキュリティヘッダー・アクセスログ等のミドルウェア
+│   │   └── openapivalidate/    # OpenAPIリクエスト検証ミドルウェア
 │   │
 │   ├── infra/                  # 技術基盤層（外部リソース接続・横断ユーティリティ）
 │   │   ├── db/                 # データベース接続初期化
@@ -129,7 +131,7 @@ REST APIとして、ユーザー認証・株式データ配信・キャッシュ
 │       └── clientratelimit/    # 外部API呼び出し用 in-memory レートリミッター
 │
 ├── docker/                     # Docker関連ファイル
-│   ├── Dockerfile.batch        # バッチ統合用Dockerfile（本番・job_idでcandles/logo切替）
+│   ├── Dockerfile.batch        # バッチ統合用Dockerfile（本番・job_idで3ジョブを切替）
 │   ├── Dockerfile.api          # APIサーバー用Dockerfile（本番）
 │   ├── Dockerfile.api.dev      # APIサーバー用Dockerfile（ローカル開発）
 │   ├── Dockerfile.migrate      # マイグレーション用Dockerfile（Cloud Run Job で実行）
@@ -180,9 +182,9 @@ go generate ./internal/api/...
 
 - 10分のJWTアクセストークンによる認証（Cookieまたは`Authorization: Bearer <token>`ヘッダー）
 - **リフレッシュトークン**: 30日有効の不透明トークンをPostgreSQLでハッシュ管理し、使用ごとにローテーション
-- **OAuth2 ソーシャルログイン**: Google / GitHub（PKCE 対応、state は Redis 管理。同メールの既存アカウントへの自動リンクは行わず 409 を返す）。OAuth 環境変数が設定されている場合のみ有効
+- **OAuth2 ソーシャルログイン**: Google / GitHub（GoogleのみPKCE対応、state は両プロバイダーともRedis管理。同メールの既存アカウントへの自動リンクは行わず、フロントエンドへ `error=account_conflict` 付きでリダイレクト）。OAuth 環境変数が設定されている場合のみ有効
 - **CSRF保護**: Double Submit Cookieパターン（`csrf_token` Cookie + `X-CSRF-Token` ヘッダーの一致を検証）
-- **レートリミット**: Redisスライディングウィンドウ方式（signup: 5回/時、login: 10回/分、oauth callback: 20回/分）
+- **レートリミット**: Redisスライディングウィンドウ方式（signup: 5回/時、login: 10回/分、OAuth認可開始・callback: 各20回/分、logo API: ユーザー単位で各10回/日）
 - **セキュリティヘッダー**: `X-Content-Type-Options`、`X-Frame-Options` 等を全レスポンスに付与
 - **SameSite Cookie**: `Lax` 設定でクロスサイトリクエストを制御
 
@@ -222,8 +224,8 @@ go generate ./internal/api/...
 
 | メソッド | パス                                   | 認証   | 説明                                                    |
 | -------- | -------------------------------------- | ------ | ------------------------------------------------------- |
-| GET      | `/v1/auth/oauth/:provider`             | 不要   | OAuth認可フローを開始（`provider`: `google` / `github`）|
-| GET      | `/v1/auth/oauth/:provider/callback`    | 不要   | OAuth認可コールバック（IPレートリミット: 20回/分）       |
+| GET      | `/v1/auth/oauth/{provider}`             | 不要   | OAuth認可フローを開始（IPレートリミット: 20回/分）       |
+| GET      | `/v1/auth/oauth/{provider}/callback`    | 不要   | OAuth認可コールバック（IPレートリミット: 20回/分）       |
 
 ---
 
@@ -241,8 +243,8 @@ go generate ./internal/api/...
 
 | メソッド | パス                | 認証   | 説明                                              |
 | -------- | ------------------- | ------ | ------------------------------------------------- |
-| POST     | `/v1/logo/detect`   | 必要   | 画像からロゴを検出（multipart/form-data）          |
-| POST     | `/v1/logo/analyze`  | 必要   | 企業分析サマリーを生成（JSON）                     |
+| POST     | `/v1/logo/detect`   | 必要   | 画像からロゴを検出（multipart/form-data、ユーザー単位10回/日） |
+| POST     | `/v1/logo/analyze`  | 必要   | 企業分析サマリーを生成（JSON、ユーザー単位10回/日）            |
 
 ---
 
@@ -252,13 +254,13 @@ go generate ./internal/api/...
 | -------- | ------------------------- | ---- | ----------------------------- |
 | GET      | `/v1/watchlist`           | 必要 | ウォッチリスト一覧取得         |
 | POST     | `/v1/watchlist`           | 必要 | ウォッチリストに銘柄を追加     |
-| DELETE   | `/v1/watchlist/:code`     | 必要 | ウォッチリストから銘柄を削除   |
+| DELETE   | `/v1/watchlist/{code}`     | 必要 | ウォッチリストから銘柄を削除   |
 | PUT      | `/v1/watchlist/order`     | 必要 | ウォッチリストの並び順を更新   |
 
 ### 補足
 
-- `/v1/candles`、`/v1/symbols`、`/v1/watchlist`、`/v1/logo/*` は **JWT認証（`Authorization: Bearer <token>`）** が必要です。
-- 認証済みエンドポイントはすべて **CSRFトークン（`X-CSRF-Token` ヘッダー）** も必須です。
+- `/v1/candles/*`、`/v1/quotes`、`/v1/symbols`、`/v1/watchlist*`、`/v1/logo/*` は **JWT認証** が必要です。`auth_token` Cookieを優先し、Cookieがなければ`Authorization: Bearer <token>`を使用します。
+- CSRFトークンは、Cookie認証でPOST・PUT・PATCH・DELETEを呼ぶ場合に必要です。GET・HEAD・OPTIONSおよびBearer認証では検証をスキップします。
 - `/v1/signup` と `/v1/login` には **IPベースのレートリミット** が適用されています。
 - `/v1/auth/refresh` は `refresh_token` CookieとCSRFトークンを検証し、トークン一式をローテーションします。
 - `/v1/auth/oauth/*` は OAuth 環境変数（`GOOGLE_CLIENT_ID` または `GITHUB_CLIENT_ID` 等）が設定されている場合のみ登録されます。詳細は [auth フィーチャーのドキュメント](docs/features/auth.md) を参照してください。
@@ -268,23 +270,25 @@ go generate ./internal/api/...
 - **Cloud Run**: Dockerイメージをデプロイ
 - **Cloud SQL（PostgreSQL）**: アプリケーションデータの永続化
 - **Redis（Cloud Memorystore）**: キャッシュ管理
-- **Secret Manager**: APIキー・DBパスワード・JWTシークレットキーを安全に管理
-- 起動時に `os.Getenv()` + Secret Manager APIで読み込み
+- **Secret Manager**: APIキー・DBパスワード・JWTシークレット等を安全に管理し、Cloud Runの環境変数として注入
+- アプリケーションは注入された値を起動時に `os.Getenv()` で読み込み
 - **ローカル開発では `docker/.env` から読み込み**
 
 ## CI/CD
 
 - **GitHub Actions** がプルリクエスト作成時に自動テストを実行
-- マージ後、**Cloud Build** がDockerイメージをビルドし、**Artifact Registry** に保存
+- ドキュメントのみの変更でもMarkdown内のローカルリンク切れを検証
+- 手動起動したCDワークフローがGitHub Actions上でDockerイメージをビルドし、**Artifact Registry** に保存
 - **Workload Identity Federation** を使用してGitHubからGCPへ安全にデプロイ
-- **Cloud Run** に自動デプロイし、Secret Manager経由で環境変数を注入
+- **Cloud Run** へのデプロイは現在 `workflow_dispatch` による手動実行で、Secret Manager経由で環境変数を注入
+- API用CDでは、DB・Redis・JWTの各シークレットに加えて `PASSWORD_PEPPER` と `CORS_ALLOWED_ORIGINS` をSecret Managerへ登録しておく必要があります
 
 ## セットアップ
 
 ### 前提条件
 
 - Docker / Docker Compose がインストール済みであること
-- Go のインストールは不要（すべてDocker内で実行）
+- 通常のAPI・バッチ起動だけならGoのインストールは不要。スキーマ文書再生成やホスト上でのテストにはGoが必要
 - `docker/.env` にローカル環境変数を設定
 
 ---
@@ -316,7 +320,7 @@ cp docker/example.env docker/.env
 
 この制限に対応するため、本アプリケーションでは以下を実施しています：
 
-- **スケジュールバッチ（candles）プロセスによるデータの事前取得**
+- **candles バッチによるデータの事前取得**
 - **Redisキャッシュによるリクエスト数の最小化**
 
 ### GCP認証の設定（ロゴ検出・企業分析機能を使用する場合）
@@ -370,6 +374,12 @@ docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps candles
 docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps logo
 ```
 
+### バッチプロセスの起動（期限切れ認証セッション削除）
+
+```bash
+docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps auth-session-cleanup
+```
+
 ### ER 図・テーブル定義書の生成（tbls）
 
 スキーマは [tbls](https://github.com/k1LoW/tbls) で稼働中の PostgreSQL から自動生成されます。
@@ -404,4 +414,4 @@ docker compose -f docker/docker-compose.yml -p stock run --rm --no-deps logo
 - **PostgreSQL**: `localhost:5432`
 - **Redis**: `localhost:6379`
 - **ログ確認**: `docker logs -f stock-backend`
-- **バッチプロセス**: candles コンテナが外部APIから株価を取得し、PostgreSQLに保存
+- **バッチプロセス**: `candles`（株価取り込み）、`logo`（ロゴURL取り込み）、`auth-session-cleanup`（期限切れ認証セッション削除）

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -236,7 +236,8 @@ paths:
       summary: OAuthログイン開始
       description: |
         指定プロバイダー（google/github）のOAuth2認可画面へリダイレクトします。
-        state + PKCEコードチャレンジを生成しRedisに保存します（TTL: 10分）。
+        state とコード検証用のランダム値を生成しRedisに保存します（TTL: 10分）。
+        GoogleではPKCE（S256）を使用し、PKCE非対応のGitHubではstateによるCSRF保護のみを使用します。
       operationId: beginOAuth
       tags:
         - auth
@@ -254,6 +255,23 @@ paths:
           description: プロバイダー認可画面へリダイレクト
         "400":
           description: 未サポートのプロバイダー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: リクエスト過多（IPレートリミット超過）
+          headers:
+            Retry-After:
+              description: 再試行までの秒数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "503":
+          description: サービス一時利用不可（レートリミット基盤障害時）
           content:
             application/json:
               schema:
@@ -297,6 +315,17 @@ paths:
               - `account_conflict`: 同メールアドレスの既存アカウントが存在（自動リンクは行わない）
               - `oauth_failed`: 上記以外のすべてのエラー（state不正・期限切れ、プロバイダーAPIエラー、
                 未サポートのプロバイダー、内部エラー等）
+        "429":
+          description: リクエスト過多（IPレートリミット超過）
+          headers:
+            Retry-After:
+              description: 再試行までの秒数
+              schema:
+                type: integer
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "503":
           description: サービス一時利用不可（レートリミット基盤障害時）
           content:

--- a/db/README.md
+++ b/db/README.md
@@ -19,7 +19,7 @@ db/
 
 ## マイグレーションの実行方法
 
-### 1. cmd/migrate バイナリ（推奨・本番ジョブと同じ経路）
+### 1. cmd/migrate バイナリ（推奨・本番ジョブでも利用可能な経路）
 
 埋め込み済み migrations を使うので、SQL ファイルを別途配布する必要がありません。
 
@@ -31,7 +31,7 @@ go run ./cmd/migrate status
 go run ./cmd/migrate down
 go run ./cmd/migrate up-to 1
 
-# Docker（本番 Cloud Run Job と同等のイメージ）
+# Docker（Cloud Run Jobへデプロイ可能なものと同じイメージ）
 docker compose -f docker/docker-compose.yml -p stock run --rm migrate         # up
 docker compose -f docker/docker-compose.yml -p stock run --rm migrate status
 ```
@@ -72,8 +72,9 @@ go tool goose down
 
 ## 本番・ステージング環境での適用
 
-`docker/Dockerfile.migrate` でビルドした `migrate` バイナリを Cloud Run Job などで起動し、
-デプロイの前段で `migrate up` を実行してから `cmd/api` のデプロイへ進みます。
+`docker/Dockerfile.migrate` でビルドした `migrate` バイナリは Cloud Run Job などで実行できます。
+現在のGitHub Actions CDはマイグレーションジョブを自動作成・実行しないため、本番・ステージングでは
+APIデプロイ前に運用側で `migrate up` を明示的に実行してください。
 
 接続情報はサーバーと同じ環境変数（`DB_USER` / `DB_PASSWORD` / `DB_NAME` / `DB_HOST` / `DB_PORT` /
 `INSTANCE_CONNECTION_NAME`）から読み取ります。

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -100,6 +100,22 @@ services:
       db:
         condition: service_healthy
 
+  auth-session-cleanup:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.api.dev
+    env_file:
+      - ./.env
+    volumes:
+      - ..:/app
+      - go-mod-cache:/go/pkg/mod
+      - go-build-cache:/root/.cache/go-build
+    command: ["go", "run", "./cmd/batch", "auth-session-cleanup"]
+    restart: "no"
+    depends_on:
+      db:
+        condition: service_healthy
+
   # マイグレーション専用バイナリ。本番では同 Dockerfile を Cloud Run Job 等にデプロイ。
   # backend 起動時に依存として自動実行される。
   # 個別実行: docker compose -f docker/docker-compose.yml -p stock run --rm migrate [up|status|down|...]

--- a/docker/example.env
+++ b/docker/example.env
@@ -14,16 +14,12 @@ DB_PORT=5432
 DB_USER=appuser
 DB_PASSWORD=apppass
 DB_NAME=app
-RUN_MIGRATIONS=true
 
 # DB 接続オプション（任意。未設定時は db パッケージのデフォルトを使用）
 # DB_SSLMODE=disable               # TCP 接続時の sslmode（本番 TCP 外部接続では require 等を推奨）
 # DB_MAX_OPEN_CONNS=25             # 最大接続数（デフォルト 25）
 # DB_MAX_IDLE_CONNS=25             # アイドル接続数（デフォルト 25）
 # DB_CONN_MAX_LIFETIME=5m          # 接続の最大生存時間（time.ParseDuration 形式。デフォルト 5m）
-
-# GORM ログレベル（任意。info / warn / error のいずれか。未設定・不明値は Silent）
-# DB_LOG_LEVEL=warn
 
 # CORS（許可するオリジン、カンマ区切りで複数指定可。未設定時は http://localhost:3000）
 CORS_ALLOWED_ORIGINS=http://localhost:3000
@@ -61,6 +57,12 @@ TWELVE_DATA_BASE_URL=https://api.twelvedata.com
 # Ingest バッチの許容失敗率（任意。0.0〜1.0 の浮動小数。未設定時は 0.2）
 # 銘柄単位の失敗率がこの値を超えた場合、ingest プロセスは exit 1 で終了する。
 # INGEST_MAX_FAILURE_RATE=0.2
+
+# Logo ingest バッチのタイムアウト時間（任意。正の整数。未設定時は 3 時間）
+# LOGO_INGEST_TIMEOUT_HOURS=3
+
+# Logo ingest バッチの許容失敗率（任意。0.0〜1.0。未設定時は 0.2）
+# LOGO_INGEST_MAX_FAILURE_RATE=0.2
 
 # Redis
 REDIS_HOST=redis

--- a/docs/features/auth.md
+++ b/docs/features/auth.md
@@ -8,10 +8,11 @@ Auth フィーチャーは、短期JWTとサーバー管理リフレッシュト
 
 - **ユーザー登録（Signup）**: メールアドレスとパスワードで新規ユーザーを登録
 - **ログイン**: 認証情報を検証し、JWTとリフレッシュトークンを発行
-- **OAuth2 ログイン**: Google / GitHub プロバイダーによるソーシャルログイン（PKCE 対応。同メールの既存アカウントへの自動リンクは行わず、フロントエンドのログイン画面へ `error=account_conflict` 付きでリダイレクトする）
+- **OAuth2 ログイン**: Google / GitHub プロバイダーによるソーシャルログイン（GoogleはPKCE対応、GitHubはstateによるCSRF保護。同メールの既存アカウントへの自動リンクは行わず、フロントエンドのログイン画面へ `error=account_conflict` 付きでリダイレクトする）
 - **パスワード暗号化**: HMAC-SHA256ペッパー + bcryptによる安全なパスワードハッシュ化
 - **JWT認証**: 保護エンドポイントへのアクセス制御用に有効期限10分のJWTトークンを発行
 - **セッション更新**: 30日有効のリフレッシュトークンを使用ごとにローテーションし、再利用を検知した系列を失効
+- **セッション整理**: `auth-session-cleanup` バッチで期限切れ・失効済みリフレッシュセッションを削除（Cloud Scheduler などから定期起動可能）
 - **レートリミット**: Redis Sorted Setによるスライディングウィンドウ方式でブルートフォース攻撃を防止
 
 ## シーケンス図
@@ -113,11 +114,11 @@ sequenceDiagram
         Handler-->>Client: 401 Unauthorized<br/>{error: "invalid email or password"}
     end
 
+    Handler->>Handler: GenerateCSRFToken()
     Usecase->>Session: Issue(userID, email)
     Session->>DB: INSERT refresh_sessions (token hash only)
     Session-->>Usecase: TokenPair
     Usecase-->>Handler: TokenPair
-    Handler->>Handler: GenerateCSRFToken()
     Handler->>Handler: SetCookie auth_token / refresh_token / csrf_token
     Handler-->>Client: 200 OK<br/>{"message":"ok"}
     Note over Handler,Client: auth_token / refresh_token are HttpOnly
@@ -159,12 +160,12 @@ sequenceDiagram
     participant Sessions as RefreshSessionRepository<br/>(PostgreSQL)
 
     Client->>Handler: DELETE /v1/logout
-    Handler->>Sessions: refresh token familyを失効
     Handler->>Handler: リクエストからJWT抽出（Cookie優先→Authorizationヘッダー）
     alt トークンが有効（署名OK・未期限切れ）
         Handler->>Blacklist: Revoke(jti, ttl=exp-now)
         Note over Blacklist: jwt:blacklist:<jti> をttl付きでSET<br/>Redis未接続時は警告ログのみ（グレースフルデグレード）
     end
+    Handler->>Sessions: refresh token familyを失効
     Handler->>Handler: Clear auth_token / refresh_token / csrf_token
     Handler-->>Client: 200 OK {"message":"ok"}
     Note over Handler,Client: 認証CookieはすべてMax-Age 0
@@ -184,7 +185,7 @@ sequenceDiagram
     participant StateStore as OAuthStateStore<br/>(Redis)
     participant Provider as OAuthProvider<br/>(Google/GitHub)
 
-    Client->>Handler: GET /v1/auth/oauth/:provider
+    Client->>Handler: GET /v1/auth/oauth/{provider}
     Handler->>Usecase: BeginAuth(provider)
 
     alt Unknown Provider
@@ -193,7 +194,7 @@ sequenceDiagram
     end
 
     Usecase->>Usecase: Generate state (32B random)
-    Usecase->>Usecase: Generate PKCE codeVerifier (32B random)<br/>codeChallenge = BASE64URL(SHA256(codeVerifier))
+    Usecase->>Usecase: Generate codeVerifier (32B random)<br/>GoogleのみcodeChallenge = BASE64URL(SHA256(codeVerifier))を使用
     Usecase->>StateStore: SaveState(state, codeVerifier, TTL=10min)
     Usecase->>Provider: AuthorizationURL(state, codeChallenge)
     Provider-->>Usecase: Authorization URL
@@ -217,7 +218,7 @@ sequenceDiagram
     participant Hooks as UserCreatedHook(s)
     participant JWT as JWTGenerator
 
-    Provider->>RateLimit: GET /v1/auth/oauth/:provider/callback?code=...&state=...
+    Provider->>RateLimit: GET /v1/auth/oauth/{provider}/callback?code=...&state=...
     RateLimit->>RateLimit: Check IP rate limit (20 req/min)
     RateLimit->>Handler: Request forwarded
     Handler->>Handler: Validate code/state present
@@ -287,7 +288,7 @@ sequenceDiagram
 ```json
 {
   "email": "user@example.com",
-  "password": "password123"
+  "password": "password1234"
 }
 ```
 
@@ -341,7 +342,7 @@ sequenceDiagram
 ```json
 {
   "email": "user@example.com",
-  "password": "password123"
+  "password": "password1234"
 }
 ```
 
@@ -366,6 +367,7 @@ sequenceDiagram
   **JWTクレーム（auth_token内）:**
   - `sub`: ユーザーID（int64を文字列として格納）
   - `email`: ユーザーのメールアドレス
+  - `jti`: JWTの一意ID（ログアウト時の即時失効に使用）
   - `iat`: 発行日時（Unixタイムスタンプ）
   - `exp`: 有効期限（発行日時 + 10分）
 
@@ -447,7 +449,7 @@ Redis障害時はレートリミットを例外的にfail-openとし、PostgreSQ
 
 **注意**: 期限切れトークンを持つクライアントでも必ずログアウトできるよう、認証不要のエンドポイントに設定されています。
 
-### GET /v1/auth/oauth/:provider
+### GET /v1/auth/oauth/{provider}
 
 OAuth2 認可フローを開始し、プロバイダーの認可画面へリダイレクトします。OAuth 環境変数（`GOOGLE_CLIENT_ID` または `GITHUB_CLIENT_ID`）が設定されている場合のみルートが登録されます。
 
@@ -461,8 +463,10 @@ OAuth2 認可フローを開始し、プロバイダーの認可画面へリダ�
   ```json
   { "error": "unsupported provider" }
   ```
+- **429 Too Many Requests** - レートリミット超過（IPベース: 20回/分）
+- **503 Service Unavailable** - レートリミット基盤（Redis）が利用不可
 
-### GET /v1/auth/oauth/:provider/callback
+### GET /v1/auth/oauth/{provider}/callback
 
 プロバイダーから認可コードを受け取り、ユーザー認証・認証セッション発行・フロントエンドへのリダイレクトを行います。
 
@@ -502,7 +506,8 @@ OAuth2 認可フローを開始し、プロバイダーの認可画面へリダ�
 | `POST /v1/login` | IPアドレス | 10回 | 1分 | HTTPミドルウェア |
 | `POST /v1/login` | メールアドレス | 5回 | 15分 | Handler内 |
 | `POST /v1/signup` | IPアドレス | 5回 | 1時間 | HTTPミドルウェア |
-| `GET /v1/auth/oauth/:provider/callback` | IPアドレス | 20回 | 1分 | HTTPミドルウェア |
+| `GET /v1/auth/oauth/{provider}` | IPアドレス | 20回 | 1分 | HTTPミドルウェア |
+| `GET /v1/auth/oauth/{provider}/callback` | IPアドレス | 20回 | 1分 | HTTPミドルウェア |
 | `POST /v1/auth/refresh` | IPアドレス | 30回 | 1分 | HTTPミドルウェア |
 
 ### アルゴリズム
@@ -516,7 +521,7 @@ Redis Sorted Setを使用したSliding Window Logアルゴリズム:
 
 ### Redis障害時の挙動
 
-認証系エンドポイント（signup / login IP・メール / OAuth コールバック）のレートリミットは
+認証系エンドポイント（signup / login IP・メール / OAuth 認可開始・コールバック）のレートリミットは
 **fail-closed** です。Redisが利用できない場合（未接続・Luaスクリプト実行エラー）、
 判定不能としてリクエストを拒否し、**503 Service Unavailable**
 （`{"error": "service temporarily unavailable"}`、`Retry-After`ヘッダーなし）を返します。
@@ -554,8 +559,8 @@ graph TB
     end
 
     subgraph "Usecase Interfaces"
-        RepoInterface[UserRepository Interface<br/>usecase.go]
-        JWTInterface[JWTGenerator Interface<br/>usecase.go]
+        RepoInterface[UserRepository Interface<br/>credentials.go]
+        JWTInterface[JWTGenerator Interface<br/>session.go]
         Errors[Domain Errors<br/>errors.go]
     end
 
@@ -612,11 +617,12 @@ graph TB
   - `api.LoginRequest`: ログインリクエスト
 
 #### Usecase層
-- **Usecase**（[usecase.go](../../internal/feature/auth/usecase.go)）: 認証ビジネスロジックを実装
+- **Usecase**（[credentials.go](../../internal/feature/auth/credentials.go)）: メール・パスワード認証ビジネスロジックを実装
   - パスワードバリデーション（最低12文字）
   - パスワードハッシュ化（bcrypt + HMAC-SHA256 ペッパー）
   - タイミング攻撃を防止するパスワード検証（ユーザー未検出時もbcrypt比較を実行）
-  - UserRepository / JWTGenerator / UserCreatedHook インターフェースを定義
+  - UserRepository / UserCreatedHook インターフェースを定義し、SessionManagerを利用
+- **SessionService**（[session.go](../../internal/feature/auth/session.go)）: JWTとリフレッシュセッションの発行・更新・失効を実装し、JWTGenerator / RefreshSessionRepositoryインターフェースを定義
 - **OAuthUsecase**（[oauth.go](../../internal/feature/auth/oauth.go)）: OAuth2 認証フローを実装
   - PKCE（S256）の state / codeVerifier 生成（`BeginAuth` は state を呼び出し側に返却し、ブラウザ Cookie への紐付けを可能にする）
   - 同メールの既存ユーザーが存在する場合は自動リンクせず `ErrOAuthEmailConflict` を返却（アカウント乗っ取り防止）
@@ -635,8 +641,8 @@ graph TB
   - `ErrUnknownProvider`: 未対応の OAuth プロバイダー指定
 
 #### Domain層
-- **User Entity**（[user.go](../../internal/feature/auth/user.go)）: ユーザードメインモデル（OAuth 専用ユーザーは `Password = nil`）
-- **OAuthAccount Entity**（[oauth_account.go](../../internal/feature/auth/oauth_account.go)）: OAuth プロバイダーとユーザーの紐付け
+- **User Entity**（[credentials.go](../../internal/feature/auth/credentials.go)）: ユーザードメインモデル（OAuth 専用ユーザーは `PasswordHash = nil`）
+- **OAuthAccount Entity**（[oauth.go](../../internal/feature/auth/oauth.go)）: OAuth プロバイダーとユーザーの紐付け
   - `(provider, provider_uid)` の複合ユニーク制約
   - `oauth_accounts` テーブルにマッピング
 
@@ -654,10 +660,10 @@ graph TB
 #### Adapters層
 - **userRepository**（[user_repository.go](../../internal/feature/auth/user_repository.go)）: UserRepository / OAuthUserCreator の sqlc + database/sql 実装
 - **oauthAccountRepository**（[oauth_account_repository.go](../../internal/feature/auth/oauth_account_repository.go)）: OAuthAccountRepository の sqlc + database/sql 実装
-- **refreshSessionRepository**（[refresh_session_repository.go](../../internal/feature/auth/refresh_session_repository.go)）: refreshセッションのPostgreSQL実装
+- **refreshSessionRepository**（[session_repository.go](../../internal/feature/auth/session_repository.go)）: refreshセッションのPostgreSQL実装
 - **redisOAuthStateStore**（[oauth_state_store.go](../../internal/feature/auth/oauth_state_store.go)）: OAuthStateStore の Redis 実装（`GETDEL` で atomic に消費）
-- **GoogleProvider**（[google_provider.go](../../internal/feature/auth/google_provider.go)）: Google OAuth2 実装（PKCE S256 対応、`/oauth2/v3/userinfo` でメール取得）
-- **GitHubProvider**（[github_provider.go](../../internal/feature/auth/github_provider.go)）: GitHub OAuth2 実装（GitHub は PKCE 非対応、state による CSRF 保護のみ）
+- **GoogleProvider**（[oauth_provider_google.go](../../internal/feature/auth/oauth_provider_google.go)）: Google OAuth2 実装（PKCE S256 対応、`/oauth2/v3/userinfo` でメール取得）
+- **GitHubProvider**（[oauth_provider_github.go](../../internal/feature/auth/oauth_provider_github.go)）: GitHub OAuth2 実装（GitHub は PKCE 非対応、state による CSRF 保護のみ）
 
 ### アーキテクチャ上の特徴
 
@@ -681,45 +687,48 @@ graph TB
 
 ```
 auth/                                  # package auth（フィーチャー直下にコアを集約）
-├── README.md                          # このファイル
-├── user.go                            # Userエンティティ定義
-├── oauth_account.go                   # OAuthAccountエンティティ定義
-├── refresh_session.go                 # RefreshSession / TokenPair
-├── session.go                         # セッション発行・更新・失効
-├── refresh_session_repository.go      # PostgreSQLセッションリポジトリ
-├── usecase.go                         # 認証ビジネスロジック + UserRepository等インターフェース
-├── usecase_test.go                    # Usecaseテスト
+├── credentials.go                     # User、メール/パスワード認証、UserRepository
+├── credentials_email_test.go          # メール正規化テスト
+├── credentials_test.go                # 認証ユースケーステスト
+├── session.go                         # RefreshSession / TokenPair、セッション発行・更新・失効
+├── session_test.go                    # セッションサービステスト
+├── session_repository.go              # PostgreSQLセッションリポジトリ
+├── session_repository_test.go         # セッションリポジトリテスト
+├── session_cleanup.go                 # 期限切れセッション削除ユースケース
+├── session_cleanup_test.go
 ├── oauth.go                           # OAuth2ビジネスロジック + OAuth関連インターフェース
+├── oauth_test.go
 ├── errors.go                          # ドメインエラー定義
 ├── user_repository.go                 # UserRepository/OAuthUserCreator 実装
 ├── user_repository_test.go            # リポジトリテスト
 ├── oauth_account_repository.go        # OAuthAccountRepository 実装
 ├── oauth_state_store.go               # OAuthStateStoreのRedis実装
-├── google_provider.go                 # Google OAuth2プロバイダー実装
-├── github_provider.go                 # GitHub OAuth2プロバイダー実装
+├── oauth_provider_google.go           # Google OAuth2プロバイダー実装
+├── oauth_provider_github.go           # GitHub OAuth2プロバイダー実装
 ├── sqlc/                              # package authsqlc（sqlc 生成コード・編集禁止）
 │   ├── queries.sql                    # クエリ定義
 │   └── *.go                           # 型安全な生成コード
 └── authhttp/                         # package authhttp
     ├── handler.go                     # 認証HTTPハンドラー（signup/login/refresh/logout）
     ├── handler_test.go                # ハンドラーテスト
-    └── oauth.go                       # OAuth2 HTTPハンドラー（begin/callback）
+    ├── oauth.go                       # OAuth2 HTTPハンドラー（begin/callback）
+    └── oauth_test.go
 ```
 
 ## テスト
 
-auth フィーチャーのすべてのテストは、一貫性と保守性のために**テーブル駆動テストパターン**に従っています。
+auth フィーチャーでは、複数の入力・エラー条件を扱うテストを中心に**テーブル駆動テストパターン**を使用しています。
 
 ### テスト構造とパターン
 
 #### 全テスト共通のパターン
 
-1. **テーブル駆動テスト**: すべてのテスト関数は `tests` スライスと構造体フィールドを使用:
+1. **テーブル駆動テスト**: 複数ケースを扱うテストは `tests` スライスと構造体フィールドを使用:
    - `name`: テストケースの説明（例: `"success: user creation"`, `"failure: duplicate email"`）
    - `wantErr`: エラーが期待されるかどうかを示すブールフラグ
    - テストタイプ固有の追加フィールド（後述）
 
-2. **並列実行**: すべてのテストは `t.Parallel()` を使用して並行実行を有効化:
+2. **並列実行**: 状態共有のないテストでは `t.Parallel()` を使用して並行実行を有効化:
    ```go
    func TestSomething(t *testing.T) {
        t.Parallel()  // 並列実行を有効化
@@ -740,7 +749,7 @@ auth フィーチャーのすべてのテストは、一貫性と保守性のた
    - Handler: `makeRequest()`, `assertJSONResponse()`
    - Repository: `setupTestDB()`, `seedUser()`
 
-#### Usecaseテスト（[usecase_test.go](../../internal/feature/auth/usecase_test.go)）
+#### Usecaseテスト（[credentials_test.go](../../internal/feature/auth/credentials_test.go)）
 
 **モックリポジトリ**を使用してビジネスロジックを単独でテストします。
 
@@ -803,9 +812,9 @@ tests := []struct {
     name         string
     email        string          // （テストによってはuser, userIDなど）
     wantErr      bool
-    expectedErr  error           // 特定のエラー型（例: usecase.ErrUserNotFound）
-    setupFunc    func(t *testing.T, db *sql.DB) *entity.User  // テストデータの準備
-    validateFunc func(t *testing.T, expected, found *entity.User)  // 結果の検証
+    expectedErr  error           // 特定のエラー型（例: auth.ErrUserNotFound）
+    setupFunc    func(t *testing.T, db *sql.DB) *User  // テストデータの準備
+    validateFunc func(t *testing.T, expected, found *User)  // 結果の検証
 }{/* ... */}
 ```
 

--- a/docs/features/candles.md
+++ b/docs/features/candles.md
@@ -2,7 +2,7 @@
 
 ## 概要
 
-Candlesフィーチャーは、株式市場のローソク足（OHLCV）データ管理を提供します。REST APIによるリアルタイムデータ取得と、外部マーケットデータプロバイダーからのバッチデータ取り込みの両方を処理します。
+Candlesフィーチャーは、株式市場のローソク足（OHLCV）データ管理を提供します。REST APIによるPostgreSQL保存済みデータの取得と、外部マーケットデータプロバイダーからのバッチデータ取り込みを処理します。
 
 ### 主な機能
 
@@ -27,10 +27,9 @@ sequenceDiagram
     participant Redis
     participant DB as PostgreSQL
 
-    Client->>Handler: GET /candles/:code?interval=1day&outputsize=200
+    Client->>Handler: GET /v1/candles/{code}?interval=1day&outputsize=200
     Handler->>Handler: Parse params (defaults: interval=1day, outputsize=200)
     Handler->>Usecase: GetCandles(symbol, interval, outputsize)
-    Usecase->>Usecase: Apply defaults if needed
     Usecase->>Cache: Find(symbol, interval, outputsize)
 
     alt Redis Available
@@ -129,13 +128,13 @@ sequenceDiagram
 
 ## API仕様
 
-### GET /candles/:code
+### GET /v1/candles/{code}
 
 指定された銘柄のローソク足データを取得します。JWT認証が必要です。
 
 **認証方式**（優先順位順）:
-1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
-2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）— この場合CSRFチェックをスキップ
+1. `auth_token` Cookie（ブラウザクライアント。GETのためCSRFトークンは不要）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
 
 **パスパラメータ**
 | パラメータ | 説明 | 例 |
@@ -152,7 +151,6 @@ sequenceDiagram
 ```http
 GET /v1/candles/7203.T?interval=1day&outputsize=100
 Cookie: auth_token=eyJhbGc...
-X-CSRF-Token: <csrf_token Cookieの値>
 ```
 
 **リクエスト例（Bearerヘッダー）**
@@ -193,24 +191,17 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
   }
   ```
 
-- **403 Forbidden** - CSRFトークンが不正（Cookieベース認証時）
+- **500 Internal Server Error** - リポジトリまたはキャッシュ層のエラー
   ```json
   {
-    "error": "invalid csrf token"
+    "error": "internal server error"
   }
   ```
 
-- **502 Bad Gateway** - データベースまたは上流サービスのエラー
-  ```json
-  {
-    "error": "database connection failed"
-  }
-  ```
-
-### GET /quotes
+### GET /v1/quotes
 
 複数銘柄の最新終値・前日比・スパークライン用終値配列を1リクエストで取得します（ウォッチリストが
-銘柄ごとに `GET /candles/:code` を呼ぶ N+1 を回避するためのバッチAPI）。JWT認証が必要です。
+銘柄ごとに `GET /v1/candles/{code}` を呼ぶN+1を回避するためのバッチAPIです）。JWT認証が必要です。
 新しいSQL/sqlcクエリは追加せず、既存の `Repository.Find`（`CachingRepository` 経由でワイヤリング
 済み）を銘柄ごとに並行呼び出しして実現しています（並行数は `quoteConcurrency`（8）で上限管理）。
 
@@ -225,7 +216,6 @@ Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
 ```http
 GET /v1/quotes?codes=AAPL,GOOGL,7203.T&interval=1day&bars=60
 Cookie: auth_token=eyJhbGc...
-X-CSRF-Token: <csrf_token Cookieの値>
 ```
 
 **レスポンス**
@@ -388,8 +378,8 @@ graph TB
 
 ```
 candles/                               # package candles（コア: domain/usecase/adapters を統合）
-├── README.md                          # 本ファイル
 ├── candle.go                          # Candleエンティティ（OHLCVデータ）
+├── errors.go                          # 入力不変条件のエラー
 ├── usecase.go                         # クエリロジック + Repositoryインターフェース
 ├── usecase_test.go                    # ユースケーステスト
 ├── quotes.go                          # Quoteエンティティ + GetQuotes（複数銘柄の一括取得。既存Repositoryを並行呼び出し）
@@ -402,6 +392,7 @@ candles/                               # package candles（コア: domain/usecas
 ├── repository_test.go                 # リポジトリテスト
 ├── caching_repository.go              # Redisキャッシュデコレータ
 ├── caching_repository_test.go
+├── caching_repository_concurrent_test.go
 ├── sqlc/                              # package candlessqlc（sqlc 生成コード、手動編集禁止）
 │   ├── db.go
 │   ├── models.go
@@ -422,13 +413,13 @@ candles/                               # package candles（コア: domain/usecas
 
 ## テスト
 
-Candlesフィーチャーの全テストは、一貫性と保守性のために**テーブル駆動テストパターン**に従います。
+Candlesフィーチャーでは、複数の入力・エラー条件を扱うテストを中心に**テーブル駆動テストパターン**を使用します。
 
 ### テスト構造とパターン
 
 #### 全テスト共通のパターン
 
-1. **テーブル駆動テスト**: 全テスト関数は構造体フィールドを持つ`tests`スライスを使用:
+1. **テーブル駆動テスト**: 複数ケースを扱うテストは構造体フィールドを持つ`tests`スライスを使用:
    - `name`: テストケースの説明（例: `"success: all parameters specified"`, `"error: repository returns error"`）
    - `wantErr`: エラーが期待されるかどうかを示すブール値フラグ
    - テストタイプ固有の追加フィールド
@@ -462,8 +453,8 @@ tests := []struct {
     inputSymbol        string
     inputInterval      string
     inputOutputsize    int
-    mockFindFunc       func(...) ([]entity.Candle, error)
-    expectedCandles    []entity.Candle
+    mockFindFunc       func(...) ([]candles.Candle, error)
+    expectedCandles    []candles.Candle
     expectedErr        error
     expectedInterval   string  // モックに渡されるべき値
     expectedOutputsize int     // モックに渡されるべき値
@@ -489,7 +480,7 @@ HTTPリクエスト/レスポンス処理をテストするために**モック�
 tests := []struct {
     name           string
     url            string
-    mockGetCandles func(...) ([]entity.Candle, error)
+    mockGetCandles func(...) ([]candles.Candle, error)
     expectedStatus int
     expectedBody   string  // JSON文字列比較
 }{/* ... */}
@@ -519,7 +510,7 @@ tests := []struct {
     outputsize   int
     wantErr      bool
     setupFunc    func(t *testing.T, db *sql.DB)
-    validateFunc func(t *testing.T, candles []entity.Candle)
+    validateFunc func(t *testing.T, candles []Candle)
 }{/* ... */}
 ```
 
@@ -539,21 +530,6 @@ go test ./internal/feature/candles/... -v
 
 ```bash
 go test ./internal/feature/candles/... -v -race -cover
-```
-
-### テスト出力例
-
-```
-=== RUN   TestCandlesUsecase_GetCandles
-=== RUN   TestCandlesUsecase_GetCandles/success:_all_parameters_specified
-=== RUN   TestCandlesUsecase_GetCandles/success:_default_value_used_when_interval_is_empty
-=== RUN   TestCandlesUsecase_GetCandles/success:_default_value_used_when_outputsize_is_0
-=== RUN   TestCandlesUsecase_GetCandles/success:_default_value_used_when_outputsize_exceeds_max
-=== RUN   TestCandlesUsecase_GetCandles/error:_repository_returns_error
---- PASS: TestCandlesUsecase_GetCandles (0.00s)
-    --- PASS: TestCandlesUsecase_GetCandles/success:_all_parameters_specified (0.00s)
-    --- PASS: TestCandlesUsecase_GetCandles/success:_default_value_used_when_interval_is_empty (0.00s)
-    ...
 ```
 
 ## キャッシュ戦略
@@ -595,6 +571,10 @@ go test ./internal/feature/candles/... -v -race -cover
 | 変数 | 説明 | 必須 |
 |------|------|------|
 | `TWELVE_DATA_API_KEY` | TwelveDataマーケットデータのAPIキー | はい（取り込み用） |
+| `TWELVE_DATA_BASE_URL` | TwelveData APIのベースURL | いいえ |
+| `INGEST_TIMEOUT_HOURS` | candlesバッチ全体のタイムアウト時間（既定3時間） | いいえ |
+| `INGEST_MAX_FAILURE_RATE` | candlesバッチを失敗扱いにする銘柄単位失敗率（既定0.2） | いいえ |
+| `CANDLES_CACHE_TTL` | RedisキャッシュTTL（既定24時間） | いいえ |
 
 **注:** RedisとPostgreSQLの接続設定は、このフィーチャー固有ではなくアプリケーションレベルで設定されます。
 

--- a/docs/features/logodetection.md
+++ b/docs/features/logodetection.md
@@ -65,7 +65,7 @@ sequenceDiagram
     participant API as Google Gemini API
 
     Client->>Handler: POST /v1/logo/analyze<br/>{"company_name":"任天堂"}
-    Handler->>Handler: ShouldBindJSON(&req)
+    Handler->>Handler: httpx.DecodeJSON(&req)
 
     alt バリデーションエラー
         Handler-->>Client: 400 Bad Request<br/>{"error":"invalid request"}
@@ -97,7 +97,9 @@ sequenceDiagram
 
 **認証方式**（優先順位順）:
 1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
-2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等。CSRFトークンは不要）
+
+ユーザー単位で10回/日のレートリミットが適用されます。
 
 **Content-Type**: `multipart/form-data`
 
@@ -152,6 +154,12 @@ Content-Type: image/jpeg
   }
   ```
 
+- **401 Unauthorized** - JWTが未指定または無効
+- **403 Forbidden** - Cookie認証時のCSRFトークンが不正
+- **429 Too Many Requests** - ユーザー単位のレートリミット超過
+- **500 Internal Server Error** - 画像読み取り等の内部エラー
+- **503 Service Unavailable** - レートリミット基盤が利用不可
+
 - **502 Bad Gateway** - Vision APIエラー
   ```json
   {
@@ -165,7 +173,9 @@ Content-Type: image/jpeg
 
 **認証方式**（優先順位順）:
 1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
-2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
+2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等。CSRFトークンは不要）
+
+ユーザー単位で10回/日のレートリミットが適用されます。
 
 **Content-Type**: `application/json`
 
@@ -211,6 +221,11 @@ Content-Type: application/json
     "error": "invalid request"
   }
   ```
+
+- **401 Unauthorized** - JWTが未指定または無効
+- **403 Forbidden** - Cookie認証時のCSRFトークンが不正
+- **429 Too Many Requests** - ユーザー単位のレートリミット超過
+- **503 Service Unavailable** - レートリミット基盤が利用不可
 
 - **502 Bad Gateway** - Gemini APIエラー
   ```json
@@ -299,14 +314,14 @@ graph TB
 - Google Cloud Vision API v2（`cloud.google.com/go/vision/v2/apiv1`）を使用
 - ADC（Application Default Credentials）認証
 - `LOGO_DETECTION`フィーチャーによる`BatchAnnotateImagesRequest`
-- コンパイル時インターフェース検証: `var _ usecase.LogoDetector = (*VisionLogoDetector)(nil)`
+- コンパイル時インターフェース検証: `var _ logodetection.LogoDetector = (*VisionLogoDetector)(nil)`
 
 #### アダプター層 - Gemini（[gemini/client.go](../../internal/feature/logodetection/gemini/client.go)）
 - **GeminiAnalyzer**: `CompanyAnalyzer`インターフェースを実装
 - Google GenAIクライアント（`google.golang.org/genai`）を使用
 - デフォルトモデル: `gemini-2.5-flash`
 - Vertex AI経由の利用をサポート（環境変数で設定）
-- コンパイル時インターフェース検証: `var _ usecase.CompanyAnalyzer = (*GeminiAnalyzer)(nil)`
+- コンパイル時インターフェース検証: `var _ logodetection.CompanyAnalyzer = (*GeminiAnalyzer)(nil)`
 
 ### アーキテクチャの特徴
 
@@ -321,18 +336,20 @@ graph TB
 
 ```text
 logodetection/
-├── README.md            # 本ファイル
 ├── logo.go              # DetectedLogoエンティティ（ロゴ名、信頼度）
 ├── analysis.go          # CompanyAnalysisエンティティ（企業名、サマリー）
+├── errors.go            # バリデーションエラー
 ├── usecase.go           # ビジネスロジック + LogoDetector / CompanyAnalyzerインターフェース
 ├── usecase_test.go      # ユースケーステスト
 ├── prompts/
 │   ├── analysis.md      # 企業分析プロンプト（go:embedで埋め込み）
 │   └── format.md        # 出力フォーマットテンプレート（go:embedで埋め込み）
 ├── vision/
-│   └── client.go        # Google Cloud Vision APIクライアント（LogoDetector実装）
+│   ├── client.go        # Google Cloud Vision APIクライアント（LogoDetector実装）
+│   └── client_test.go
 ├── gemini/
-│   └── client.go        # Google Gemini APIクライアント（CompanyAnalyzer実装）
+│   ├── client.go        # Google Gemini APIクライアント（CompanyAnalyzer実装）
+│   └── client_test.go
 └── logodetectionhttp/
     ├── handler.go       # HTTPハンドラー + Usecaseインターフェース
     └── handler_test.go  # ハンドラーテスト
@@ -340,20 +357,20 @@ logodetection/
 
 ## テスト
 
-Logodetectionフィーチャーのすべてのテストは、一貫性と保守性のために**テーブル駆動テストパターン**に従います。
+Logodetectionフィーチャーでは、複数の入力・エラー条件を扱うテストを中心に**テーブル駆動テストパターン**を使用します。
 
 ### テスト構造とパターン
 
 #### 全テスト共通のパターン
 
-1. **テーブル駆動テスト**: 全テスト関数は構造体フィールドを持つ`testCases`/`tests`スライスを使用:
+1. **テーブル駆動テスト**: 複数ケースを扱うテストは構造体フィールドを持つ`testCases`/`tests`スライスを使用:
    - `name`: テストケースの説明（例: `"success: logos detected"`, `"error: empty image data"`）
    - テストタイプ固有の追加フィールド（モック関数、期待値など）
 
 2. **モック実装**: 関数フィールドを持つモック構造体:
    ```go
    type mockLogoDetector struct {
-       DetectLogosFunc  func(ctx context.Context, imageData []byte) ([]entity.DetectedLogo, error)
+       DetectLogosFunc  func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error)
        DetectLogosCalls int
    }
    ```
@@ -371,8 +388,8 @@ Logodetectionフィーチャーのすべてのテストは、一貫性と保守�
 testCases := []struct {
     name          string
     imageData     []byte
-    mockFunc      func(ctx context.Context, imageData []byte) ([]entity.DetectedLogo, error)
-    expectedLogos []entity.DetectedLogo
+    mockFunc      func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error)
+    expectedLogos []logodetection.DetectedLogo
     expectedErr   string
 }{/* ... */}
 ```
@@ -397,7 +414,7 @@ HTTPリクエスト/レスポンス処理をテストするために**モック�
 tests := []struct {
     name           string
     setupRequest   func(t *testing.T) *http.Request
-    mockFunc       func(ctx context.Context, imageData []byte) ([]entity.DetectedLogo, error)
+    mockFunc       func(ctx context.Context, imageData []byte) ([]logodetection.DetectedLogo, error)
     expectedStatus int
     expectedBody   string
 }{/* ... */}

--- a/docs/features/symbollist.md
+++ b/docs/features/symbollist.md
@@ -48,7 +48,7 @@ sequenceDiagram
 アクティブな株式銘柄の一覧を取得します。
 
 **認証方式**（優先順位順）:
-1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+1. `auth_token` Cookie（ブラウザクライアント。GETのためCSRFトークンは不要）
 2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
 
 **レスポンス**
@@ -75,10 +75,12 @@ sequenceDiagram
   ```
   注: `logo_url` は未取得時 `null` を返します。
 
+- **401 Unauthorized** - JWTが未指定または無効
+
 - **500 Internal Server Error** - データベースエラー
   ```json
   {
-    "error": "database connection failed"
+    "error": "internal server error"
   }
   ```
 
@@ -138,7 +140,7 @@ graph TB
 
 #### Usecase層
 - **Usecase**（[usecase.go](../../internal/feature/symbollist/usecase.go)）: 銘柄一覧取得のビジネスロジックを実装
-  - `Repository` インターフェースを定義（`ListActive(ctx) ([]entity.Symbol, error)`）
+  - `Repository` インターフェースを定義（`ListActive(ctx) ([]Symbol, error)`）
 - **LogoIngestUsecase**（[ingest.go](../../internal/feature/symbollist/ingest.go)）: ロゴ URL バッチ取り込みのビジネスロジック
   - active 銘柄に対し外部 API でロゴ URL を取得し、`symbols.logo_url` / `logo_updated_at` を更新
   - 銘柄単位の失敗では処理を止めず、既存 `logo_url` も保持
@@ -180,7 +182,6 @@ graph TB
 
 ```
 symbollist/                                # package symbollist（コア）
-├── README.md                              # このファイル
 ├── symbol.go                              # Symbolエンティティ定義
 ├── usecase.go                             # 一覧取得ロジック + Repositoryインターフェース
 ├── usecase_test.go                        # Usecaseテスト
@@ -201,18 +202,18 @@ symbollist/                                # package symbollist（コア）
 
 ## テスト
 
-symbollistフィーチャーのすべてのテストは、一貫性と保守性のために**テーブル駆動テストパターン**に従います。
+symbollistフィーチャーでは、複数の入力・エラー条件を扱うテストを中心に**テーブル駆動テストパターン**を使用します。
 
 ### テスト構造とパターン
 
 #### 全テスト共通のパターン
 
-1. **テーブル駆動テスト**: すべてのテスト関数は構造体フィールドを持つ `tests` スライスを使用:
+1. **テーブル駆動テスト**: 複数ケースを扱うテストは構造体フィールドを持つ `tests` スライスを使用:
    - `name`: テストケースの説明（例: `"success: returns active symbols"`）
    - `wantErr`: エラーが期待されるかどうかのboolフラグ
    - 各テストタイプ固有の追加フィールド
 
-2. **並列実行**: すべてのテストは `t.Parallel()` を使用して並行実行を有効化
+2. **並列実行**: 状態共有のないテストでは `t.Parallel()` を使用して並行実行を有効化
 
 3. **ヘルパー関数**: 各テストファイルにはコードの重複を削減するヘルパー関数を含む
 
@@ -259,16 +260,18 @@ candles フィーチャーの `IngestUsecase` が定義する `SymbolRepository`
 
 ```go
 // candles/ingest.go で定義
-type Repository interface {
+type SymbolRepository interface {
     ListActiveSymbols(ctx context.Context) ([]ActiveSymbol, error)
 }
 ```
 
-これに対し symbollist の `repository` は `ListActive(ctx) ([]entity.Symbol, error)` を提供しています。両者は `internal/app/di/ingest_symbol.go` のアダプターで橋渡しされ、フィーチャー間の直接依存を避けています。
+これに対し symbollist の `repository` は `ListActive(ctx) ([]Symbol, error)` を提供しています。両者は `internal/app/di/ingest_symbol.go` のアダプターで橋渡しされ、フィーチャー間の直接依存を避けています。
 
 ### logo バッチ
 
 [cmd/batch](../../cmd/batch) を `logo` job_id（`batch logo`）で起動すると `LogoIngestUsecase` が動き、active 銘柄の `logo_url` を外部 API（TwelveData）から取得して `symbols` テーブルに保存します。レートリミッターで外部 API 呼び出しを制御し、銘柄単位の失敗では中断せず処理を継続します。
+
+バッチ全体のタイムアウトは`LOGO_INGEST_TIMEOUT_HOURS`（既定3時間）、失敗扱いにする銘柄単位失敗率は`LOGO_INGEST_MAX_FAILURE_RATE`（既定0.2）で変更できます。
 
 管理者はデータベースの `is_active` を設定することで、アクティブにトラッキングする銘柄を制御できます。
 

--- a/docs/features/watchlist.md
+++ b/docs/features/watchlist.md
@@ -33,7 +33,7 @@ sequenceDiagram
     Repository-->>Usecase: []UserSymbol
     Usecase-->>Handler: []UserSymbol
     Handler->>Handler: Convert to []api.WatchlistItem
-    Handler-->>Client: 200 OK [{id, symbolCode, sortKey}, ...]
+    Handler-->>Client: 200 OK [{id, symbol_code, sort_key}, ...]
 ```
 
 ### 銘柄追加フロー
@@ -47,7 +47,7 @@ sequenceDiagram
     participant Repository as Repository
     participant DB as PostgreSQL
 
-    Client->>Handler: POST /v1/watchlist {symbolCode: "AAPL"}
+    Client->>Handler: POST /v1/watchlist {symbol_code: "AAPL"}
     Handler->>Handler: Extract userID from JWT context
     Handler->>Usecase: AddSymbol(ctx, userID, symbolCode)
     Usecase->>SymbolChecker: Exists(ctx, symbolCode)
@@ -62,7 +62,7 @@ sequenceDiagram
         SymbolChecker-->>Usecase: true
         Usecase->>Repository: AddWithNextSortKey(ctx, userID, symbolCode)
         Repository->>DB: BEGIN TRANSACTION
-        DB-->>Repository: SELECT MAX(sort_key) FOR UPDATE
+        DB-->>Repository: SELECT MAX(sort_key)
         Repository->>DB: INSERT INTO watchlists ...
         alt 重複エントリ (23505)
             DB-->>Repository: unique_violation
@@ -91,9 +91,12 @@ sequenceDiagram
     Client->>Handler: PUT /v1/watchlist/order {codes: ["AAPL", "MSFT", "GOOGL"]}
     Handler->>Handler: Extract userID from JWT context
     Handler->>Usecase: ReorderSymbols(ctx, userID, codes)
+    Usecase->>Repository: ListByUser(ctx, userID)
+    Usecase->>Usecase: 全件との過不足・重複を検証
     Usecase->>Usecase: Build []UserSymbol with SortKey = index
     Usecase->>Repository: UpdateSortKeys(ctx, userID, entries)
     Repository->>DB: BEGIN TRANSACTION
+    Repository->>DB: SELECT id ... ORDER BY id FOR UPDATE
     Note over Repository,DB: Phase 1: 既存のsort_keyを負値にシフト<br/>（ユニーク制約の一時的衝突を回避）
     loop 各エントリ
         Repository->>DB: UPDATE watchlists SET sort_key=-(i+1) WHERE user_id=? AND symbol_code=?
@@ -115,7 +118,7 @@ sequenceDiagram
 ログインユーザーのウォッチリストを `sort_key` 昇順で取得します。JWT認証が必要です。
 
 **認証方式**（優先順位順）:
-1. `auth_token` Cookie（ブラウザクライアント）+ `X-CSRF-Token` ヘッダー（必須）
+1. `auth_token` Cookie（ブラウザクライアント。GETのためCSRFトークンは不要）
 2. `Authorization: Bearer <token>` ヘッダー（APIクライアント・curl等）
 
 **レスポンス**
@@ -123,9 +126,9 @@ sequenceDiagram
 - **200 OK** - 成功
   ```json
   [
-    {"id": 1, "symbolCode": "AAPL", "sortKey": 0},
-    {"id": 2, "symbolCode": "MSFT", "sortKey": 1},
-    {"id": 3, "symbolCode": "GOOGL", "sortKey": 2}
+    {"id": 1, "symbol_code": "AAPL", "sort_key": 0},
+    {"id": 2, "symbol_code": "MSFT", "sort_key": 1},
+    {"id": 3, "symbol_code": "GOOGL", "sort_key": 2}
   ]
   ```
 
@@ -133,11 +136,11 @@ sequenceDiagram
 
 ### POST /v1/watchlist
 
-ウォッチリストに銘柄を追加します。JWT認証（+ CSRFトークン）が必要です。
+ウォッチリストに銘柄を追加します。JWT認証が必要です。Cookie認証ではCSRFトークンも必要ですが、Bearer認証では不要です。
 
 **リクエストボディ**
 ```json
-{"symbolCode": "AAPL"}
+{"symbol_code": "AAPL"}
 ```
 
 **レスポンス**
@@ -146,15 +149,17 @@ sequenceDiagram
 |-----------|------|
 | 201 Created | 追加成功 `{"message": "added to watchlist"}` |
 | 400 Bad Request | リクエストボディが不正 |
+| 401 Unauthorized | JWTが未指定または無効 |
+| 403 Forbidden | Cookie認証時のCSRFトークンが不正 |
 | 404 Not Found | `symbols` テーブルに存在しない銘柄コード |
 | 409 Conflict | 既にウォッチリストに登録済みの銘柄 |
 | 500 Internal Server Error | サーバー内部エラー |
 
 ---
 
-### DELETE /v1/watchlist/:code
+### DELETE /v1/watchlist/{code}
 
-ウォッチリストから銘柄を削除します。JWT認証（+ CSRFトークン）が必要です。
+ウォッチリストから銘柄を削除します。JWT認証が必要です。Cookie認証ではCSRFトークンも必要ですが、Bearer認証では不要です。
 
 **パスパラメータ**
 | パラメータ | 説明 | 例 |
@@ -166,7 +171,9 @@ sequenceDiagram
 | ステータス | 説明 |
 |-----------|------|
 | 204 No Content | 削除成功 |
-| 400 Bad Request | 銘柄コードが未指定 |
+| 400 Bad Request | 銘柄コードの形式が不正 |
+| 401 Unauthorized | JWTが未指定または無効 |
+| 403 Forbidden | Cookie認証時のCSRFトークンが不正 |
 | 404 Not Found | ウォッチリストに存在しない銘柄 |
 | 500 Internal Server Error | サーバー内部エラー |
 
@@ -174,7 +181,7 @@ sequenceDiagram
 
 ### PUT /v1/watchlist/order
 
-ウォッチリストの並び順を一括更新します。JWT認証（+ CSRFトークン）が必要です。
+ウォッチリストの並び順を一括更新します。JWT認証が必要です。Cookie認証ではCSRFトークンも必要ですが、Bearer認証では不要です。
 
 **リクエストボディ**
 ```json
@@ -187,7 +194,9 @@ sequenceDiagram
 | ステータス | 説明 |
 |-----------|------|
 | 204 No Content | 更新成功 |
-| 400 Bad Request | リクエストボディが不正 |
+| 400 Bad Request | リクエストボディが不正、または`codes`が現在のウォッチリスト全件と一致しない |
+| 401 Unauthorized | JWTが未指定または無効 |
+| 403 Forbidden | Cookie認証時のCSRFトークンが不正 |
 | 500 Internal Server Error | サーバー内部エラー |
 
 ## 依存関係図
@@ -274,7 +283,7 @@ graph TB
 - **repository**: RepositoryインターフェースのPostgreSQL実装
   - `ListByUser`: `sort_key ASC` 順でリスト返却
   - `Add`: エントリ追加（PostgreSQLエラーコードで `ErrAlreadyInWatchlist` / `ErrSymbolNotFound` に変換）
-  - `AddWithNextSortKey`: `SELECT MAX(sort_key) FOR UPDATE` + INSERT をトランザクション内で実行（並行追加時の重複順位防止）
+  - `AddWithNextSortKey`: `SELECT MAX(sort_key)` + INSERT をトランザクション内で実行し、`(user_id, sort_key)`ユニーク制約で重複順位を防止
   - `Remove`: 削除（`RowsAffected == 0` の場合 `ErrNotInWatchlist` を返す）
   - `UpdateSortKeys`: 2フェーズ更新でユニーク制約衝突を回避（負値シフト→最終値）
 
@@ -283,19 +292,20 @@ graph TB
 1. **クリーンアーキテクチャ**: ドメイン層がインフラストラクチャから独立
 2. **インターフェース所有権**: `Repository` は usecase 層で定義、`Usecase` は watchlisthttp 層で定義
 3. **フィーチャー分離**: `SymbolExistsChecker` 最小インターフェースにより symbollist への直接依存を回避
-4. **並行安全**: `AddWithNextSortKey` でトランザクション + `FOR UPDATE` により重複 sort_key を防止
+4. **並行安全**: `AddWithNextSortKey` はトランザクションと`(user_id, sort_key)`ユニーク制約により重複 sort_key の永続化を防止（競合した追加は409になり得る）
 5. **2フェーズ sort_key 更新**: ユニーク制約を一時的に違反しないよう、負値シフト後に最終値を設定
 
 ## ディレクトリ構成
 
 ```
 watchlist/                            # package watchlist（コア）
-├── README.md                         # 本ファイル
 ├── user_symbol.go                    # UserSymbol エンティティ
 ├── usecase.go                        # ビジネスロジック + Repository / SymbolExistsChecker インターフェース
+├── usecase_test.go                   # ユースケーステスト
 ├── errors.go                         # ErrSymbolNotFound / ErrAlreadyInWatchlist / ErrNotInWatchlist
 ├── repository.go                     # Repository の PostgreSQL 実装
 ├── repository_test.go                # リポジトリの統合テスト
+├── repository_concurrent_test.go     # 並び順更新・削除の並行テスト
 ├── sqlc/                             # package watchlistsqlc（sqlc 生成コード）
 │   ├── db.go
 │   ├── models.go
@@ -303,35 +313,18 @@ watchlist/                            # package watchlist（コア）
 │   ├── queries.sql
 │   └── queries.sql.go
 └── watchlisthttp/
-    └── handler.go                    # package watchlisthttp（HTTPハンドラー + Usecase インターフェース）
+    ├── handler.go                    # package watchlisthttp（HTTPハンドラー + Usecase インターフェース）
+    └── handler_test.go               # HTTPハンドラーテスト
 ```
 
 ## テスト
 
-### 現在のテスト構造
+現在は以下を実装しています。
 
-#### リポジトリテスト（`repository_test.go`）
-リポジトリの統合テスト。
-
-- `AddWithNextSortKey` の並行安全性テスト
-- `UpdateSortKeys` の 2フェーズ更新テスト
-- 重複追加・存在しない銘柄削除のエラー変換テスト
-
-### 推奨テスト構造（未作成）
-
-#### ユースケーステスト（`usecase_test.go`）
-モックリポジトリとモック SymbolExistsChecker を使用してビジネスロジックをテスト。
-
-- `TestWatchlistUsecase_ListUserSymbols`: リスト取得の正常系・エラー系
-- `TestWatchlistUsecase_AddSymbol`: 銘柄存在確認・追加成功・ErrSymbolNotFound・ErrAlreadyInWatchlist
-- `TestWatchlistUsecase_RemoveSymbol`: 削除成功・ErrNotInWatchlist
-- `TestWatchlistUsecase_ReorderSymbols`: 並び順更新の正常系・エラー系
-
-#### ハンドラーテスト（`watchlisthttp/handler_test.go`）
-モックユースケースを使用して HTTP リクエスト/レスポンスをテスト。
-
-- 各エンドポイントの HTTP ステータスコード検証
-- エラーケース（404/409/500）のレスポンスボディ検証
+- `usecase_test.go`: 一覧、追加、削除、全件一致を要求する並び替え、デフォルト銘柄初期化
+- `repository_test.go`: PostgreSQLを使った追加・削除・2フェーズ並び順更新と制約エラー変換
+- `repository_concurrent_test.go`: 並び順更新同士、および並び順更新と削除の競合
+- `watchlisthttp/handler_test.go`: 各HTTPステータス、snake_caseリクエスト、入力検証、ドメインエラー変換
 
 ### テスト実行コマンド
 

--- a/scripts/check-doc-links.sh
+++ b/scripts/check-doc-links.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Markdown内のリポジトリ相対リンクが実在するファイル・ディレクトリを指すか検証する。
+# 外部URL、メールアドレス、同一ページ内アンカーは対象外とする。
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+markdown_files=()
+while IFS= read -r file; do
+  markdown_files+=("$file")
+done < <(git -c core.quotePath=false ls-files '*.md')
+
+perl -MFile::Basename=dirname -MFile::Spec -e '
+  my $failed = 0;
+  while (<>) {
+    while (/\[[^\]]*\]\(([^)#]+)(?:#[^)]*)?\)/g) {
+      my $target = $1;
+      $target =~ s/^<|>$//g;
+      next if $target =~ m{^(?:https?://|mailto:|#)};
+      next if $target eq "XXXX-title.md";
+
+      my $path = File::Spec->rel2abs($target, dirname($ARGV));
+      next if -e $path;
+
+      print STDERR "$ARGV:$.: broken local link: $target\n";
+      $failed = 1;
+    }
+  } continue {
+    close ARGV if eof;
+  }
+  exit $failed;
+' "${markdown_files[@]}"


### PR DESCRIPTION
## 概要
コードとドキュメントの乖離を解消し、API仕様・機能説明・運用設定を現行実装へ同期します。
あわせてMarkdownのローカルリンク切れをCIで検出し、同種の乖離を早期に発見できるようにします。

## 変更内容
- OAuth、CSRF、キャッシュ、APIパス、JSON例、エラー応答の説明を現行コードへ同期
- OpenAPIへOAuth認可開始・コールバックの429/503応答を反映
- `auth-session-cleanup`をDocker ComposeとCloud Run Jobのデプロイ対象へ追加
- API・バッチCDの環境変数とSecret Manager参照を実装上の必須設定へ更新
- 未使用の`RUN_MIGRATIONS`と`DB_LOG_LEVEL`をサンプル環境変数から削除
- Markdownローカルリンク検証スクリプトを追加し、CI Gateへ統合
- 本番マイグレーションが現在は自動実行されないことを運用文書へ明記

## 破壊的変更
- API用CDの実行前に、Secret Managerへ`PASSWORD_PEPPER`と`CORS_ALLOWED_ORIGINS`を登録する必要があります。未登録の場合はCloud Runデプロイが失敗します。
- `auth-session-cleanup`はCloud Run Jobとしてデプロイされますが、定期実行にはCloud Schedulerなどのトリガー設定が別途必要です。

## テスト
- `go generate ./internal/api/...`
- `go build ./...`
- 関連8パッケージの`go test`
- `go tool go-arch-lint check`（`.claude/worktrees`を除外した一時コピーで実行）
- `bash scripts/check-doc-links.sh`
- `docker compose -f docker/docker-compose.yml --env-file docker/example.env config -q`
- GitHub Actions、OpenAPI、Docker ComposeのYAML構文検証
- `git diff --check`

## レビューポイント
- APIの認証・CSRF・エラー応答の説明が実装と一致しているか
- Cloud Runの環境変数・シークレット構成が本番運用に適しているか
- Markdownリンク検証をドキュメントのみのPRでも必須にする構成が妥当か
